### PR TITLE
#4262 - don't restore rowIndex in UIData#invokeOnComponent, if it …

### DIFF
--- a/impl/src/main/java/javax/faces/component/UIData.java
+++ b/impl/src/main/java/javax/faces/component/UIData.java
@@ -962,22 +962,22 @@ public class UIData extends UIComponentBase
         }
 
         int lastSep, newRow, savedRowIndex = this.getRowIndex();
-        try {
-            char sepChar = UINamingContainer.getSeparatorChar(context);
-            // If we need to strip out the rowIndex from our id
-            // PENDING(edburns): is this safe with respect to I18N?
-            if (myId.endsWith(sepChar + Integer.toString(savedRowIndex, 10))) {
-                lastSep = myId.lastIndexOf(sepChar);
-                assert (-1 != lastSep);
-                myId = myId.substring(0, lastSep);
-            }
+        char sepChar = UINamingContainer.getSeparatorChar(context);
+        // If we need to strip out the rowIndex from our id
+        // PENDING(edburns): is this safe with respect to I18N?
+        if (myId.endsWith(sepChar + Integer.toString(savedRowIndex, 10))) {
+            lastSep = myId.lastIndexOf(sepChar);
+            assert (-1 != lastSep);
+            myId = myId.substring(0, lastSep);
+        }
 
-            // myId will be something like form:outerData for a non-nested table,
-            // and form:outerData:3:data for a nested table.
-            // clientId will be something like form:outerData:3:outerColumn
-            // for a non-nested table.  clientId will be something like
-            // outerData:3:data:3:input for a nested table.
-            if (clientId.startsWith(myId)) {
+        // myId will be something like form:outerData for a non-nested table,
+        // and form:outerData:3:data for a nested table.
+        // clientId will be something like form:outerData:3:outerColumn
+        // for a non-nested table.  clientId will be something like
+        // outerData:3:data:3:input for a nested table.
+        if (clientId.startsWith(myId)) {
+            try {
                 int preRowIndexSep, postRowIndexSep;
 
                 if (-1 != (preRowIndexSep =
@@ -1012,15 +1012,15 @@ public class UIData extends UIComponentBase
                     }
                 }
             }
-        }
-        catch (FacesException fe) {
-            throw fe;
-        }
-        catch (NumberFormatException e) {
-            throw new FacesException(e);
-        }
-        finally {
-            this.setRowIndex(savedRowIndex);
+            catch (FacesException fe) {
+                throw fe;
+            }
+            catch (NumberFormatException e) {
+                throw new FacesException(e);
+            }
+            finally {
+                this.setRowIndex(savedRowIndex);
+            }
         }
         return found;
     }


### PR DESCRIPTION
Don't restore rowIndex in UIData#invokeOnComponent, if it was not modified

`setRowIndex` is called in finally, even if the rowIndex was not modified
by invokeOnComponent. This leads to unexpected method calls. This commit
reduces the scope of the try catch finally.

Fixes #4262