### PR TITLE
Upgrade EE4J Branch Javadoc Plugin and Transaction API

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -361,7 +361,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-api-javadocs</id>
@@ -398,6 +398,13 @@
     </build>
     
     <dependencies>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+            <version>1.3.2</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -566,7 +566,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -795,7 +795,14 @@
     
     <dependencies>
         <!-- Java EE Dependencies -->
-        
+         
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+            <version>1.3.2</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>


### PR DESCRIPTION
Build currently fails with NPE in Javadoc plugin and artifact not found for `jakarta.transaction:jakarta.transaction-api:1.3.1`. Both were fixed by upgrading them by one patch version.