### PR TITLE
Don't log expected NoSuchMethodException after it's caught.

### DIFF
--- a/impl/src/main/java/com/sun/faces/spi/ConfigurationResourceProviderFactory.java
+++ b/impl/src/main/java/com/sun/faces/spi/ConfigurationResourceProviderFactory.java
@@ -25,6 +25,12 @@ import static com.sun.faces.spi.ServiceFactoryUtils.getServiceEntries;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.ServiceLoader;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.faces.FacesException;
+
+import com.sun.faces.util.FacesLogger;
 
 /**
  * Factory class for creating <code>ConfigurationResourceProvider</code> instances
@@ -32,6 +38,7 @@ import java.util.ServiceLoader;
  */
 public class ConfigurationResourceProviderFactory {
 
+    private static final Logger LOGGER = FacesLogger.APPLICATION.getLogger();
 
     public enum ProviderType {
 
@@ -87,6 +94,10 @@ public class ConfigurationResourceProviderFactory {
                     }
                 } catch (ClassCastException cce) {
                     // we are going to ignore these for now.
+                } catch (FacesException e) {
+                    if (LOGGER.isLoggable(Level.FINE)) {
+                        LOGGER.log(Level.FINE, e.toString(), e);
+                    }
                 }
             }
         } else {

--- a/impl/src/main/java/com/sun/faces/spi/ServiceFactoryUtils.java
+++ b/impl/src/main/java/com/sun/faces/spi/ServiceFactoryUtils.java
@@ -49,7 +49,7 @@ final class ServiceFactoryUtils {
     // ---------------------------------------------------------- Public Methods
 
 
-    static Object getProviderFromEntry(String entry, Class<?>[] argumentTypes, Object[] arguments) {
+    static Object getProviderFromEntry(String entry, Class<?>[] argumentTypes, Object[] arguments) throws FacesException {
 
         if (entry == null) {
             return null;
@@ -62,11 +62,8 @@ final class ServiceFactoryUtils {
                 throw new FacesException("Unable to find constructor accepting arguments: " + Arrays.toString(arguments));
             }
             return c.newInstance(arguments);
-        } catch (ClassNotFoundException | NoSuchMethodException | SecurityException | FacesException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-            if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.log(Level.FINE, e.toString(), e);
-            }
-            return null;
+        } catch (ClassNotFoundException | NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            throw new FacesException(e);
         }
 
     }


### PR DESCRIPTION
WildFly and Red Hat JBoss Enterprise Application users reports issue in https://developer.jboss.org/message/960985 and https://issues.jboss.org/browse/WFLY-6918

When a AnnotationProvider implementation doesn't have a two parameters(javax.servlet.ServletContext, com.sun.faces.spi.AnnotationProvider) which is optional,

ServiceFactoryUtils will log  a confusing NoSuchMethodException when WildFly and Red Hat JBoss Enterprise Application with a TRACE logger level enabled.

This change stop logging for expected NoSuchMethodException after it's caught.

Downstream 2.3 branch PR: https://github.com/eclipse-ee4j/mojarra/pull/4590