### PR TITLE
move decrypt into the try catch so we handle if bytes are not valid

### DIFF
--- a/impl/src/main/java/com/sun/faces/context/flash/ELFlash.java
+++ b/impl/src/main/java/com/sun/faces/context/flash/ELFlash.java
@@ -1379,7 +1379,7 @@ public class ELFlash extends Flash {
             String temp;
             String value;
             
-            String urlDecodedValue = null;
+            String urlDecodedValue;
             
             try {
                 urlDecodedValue = URLDecoder.decode(cookie.getValue(), "UTF-8");
@@ -1387,9 +1387,9 @@ public class ELFlash extends Flash {
                 urlDecodedValue = cookie.getValue();
             }
             
-            value = guard.decrypt(urlDecodedValue);
-            
             try {
+                value = guard.decrypt(urlDecodedValue);
+
                 int i = value.indexOf("_");
 
                 // IMPORTANT: what was "next" when the cookie was
@@ -1442,15 +1442,16 @@ public class ELFlash extends Flash {
                     }
                     nextRequestFlashInfo.setFlashMap(flashMap);
                 }
+            } catch(InvalidKeyException e) {
+                throw e;
             } catch (Throwable t) {
                 context.getAttributes().put(CONSTANTS.ForceSetMaxAgeZero, Boolean.TRUE);
                 if (LOGGER.isLoggable(Level.SEVERE)) {
                     LOGGER.log(Level.SEVERE,
                             "jsf.externalcontext.flash.bad.cookie",
-                            new Object [] { value });
+                            new Object [] { urlDecodedValue });
                 }
             }
-
         }
 
 	/**

--- a/impl/src/main/java/com/sun/faces/util/ByteArrayGuardAESCTR.java
+++ b/impl/src/main/java/com/sun/faces/util/ByteArrayGuardAESCTR.java
@@ -126,7 +126,7 @@ public final class ByteArrayGuardAESCTR {
 
     public String decrypt(String value) throws InvalidKeyException {
         
-        byte[] bytes = DatatypeConverter.parseBase64Binary(value);;
+        byte[] bytes = DatatypeConverter.parseBase64Binary(value);
         
         try {
             byte[] iv = new byte[16];


### PR DESCRIPTION
This place the ByteArrayGuardAESCTR.decrypt inside the existing try catch so that general errors such as the follow are properly caught and the cookie is reported as bad. This still allows the  InvalidKeyException  to propagate up to it's specific catch handling.

See: #4547 and https://github.com/javaserverfaces/mojarra/issues/4386



```
java.lang.ArrayIndexOutOfBoundsException
	at java.lang.System.arraycopy(Native Method)
	at com.sun.faces.util.ByteArrayGuardAESCTR.decrypt(ByteArrayGuardAESCTR.java:133)
	at com.sun.faces.context.flash.ELFlash$PreviousNextFlashInfoManager.decode(ELFlash.java:1391)
	at com.sun.faces.context.flash.ELFlash.getCurrentFlashManager(ELFlash.java:1214)
	at com.sun.faces.context.flash.ELFlash.doPrePhaseActions(ELFlash.java:618)
	at com.sun.faces.lifecycle.Phase.handleBeforePhase(Phase.java:190)
	at com.sun.faces.lifecycle.Phase.doPhase(Phase.java:74)
	at com.sun.faces.lifecycle.RestoreViewPhase.doPhase(RestoreViewPhase.java:109)
	at com.sun.faces.lifecycle.LifecycleImpl.execute(LifecycleImpl.java:177)
	at javax.faces.webapp.FacesServlet.executeLifecyle(FacesServlet.java:707)
	at javax.faces.webapp.FacesServlet.service(FacesServlet.java:451)
```
