### PR TITLE
[issue-4577] Protected view JSF page can not be accessed with port 80

### DIFF
--- a/impl/src/main/java/com/sun/faces/lifecycle/RestoreViewPhase.java
+++ b/impl/src/main/java/com/sun/faces/lifecycle/RestoreViewPhase.java
@@ -69,6 +69,7 @@ import com.sun.faces.renderkit.RenderKitUtils;
 import com.sun.faces.util.FacesLogger;
 import com.sun.faces.util.MessageUtils;
 import com.sun.faces.util.Util;
+import static com.sun.faces.util.Util.isOneOf;
 
 /**
  * <B>Lifetime And Scope</B> <P> Same lifetime and scope as
@@ -380,7 +381,9 @@ public class RestoreViewPhase extends Phase {
             hostsMatch = uri.getHost().equals(extContext.getRequestServerName());    
         }
         if (-1 == uri.getPort()) {
-            portsMatch = false;
+            //When running on default http/https ports the uri will not contain the port number
+            // to verify run test-javaee7-protectedView.war on port 80
+        	portsMatch = isOneOf(extContext.getRequestServerPort(), 80, 443);
         } else {
             portsMatch = uri.getPort() == extContext.getRequestServerPort();
         }


### PR DESCRIPTION
Fix for #4577 
2.3 PR: #4579
RestoreViewPhase is ignoring default ports 443 and 80
To validate run test Bug22995287IT on port 80 by setting integration.url=http://host/test-javaee7-protectedView 

