### PR TITLE
Avoid NPE in ELUtils.addEL3_0_Resolvers when streamELResolver is null

### DIFF
--- a/impl/src/main/java/com/sun/faces/el/ELUtils.java
+++ b/impl/src/main/java/com/sun/faces/el/ELUtils.java
@@ -212,12 +212,13 @@ public class ELUtils {
         if (getStreamELResolverMethod != null) {
             try {
                 ELResolver streamELResolver = (ELResolver) getStreamELResolverMethod.invoke(expressionFactory, (Object[]) null);
-                composite.addRootELResolver(streamELResolver);
+                if (streamELResolver != null) {
+                    composite.addRootELResolver(streamELResolver);
 
-                // Assume that if we have getStreamELResolver, then we must have
-                // javax.el.staticFieldELResolver
-                composite.addRootELResolver((ELResolver) newInstance("javax.el.StaticFieldELResolver"));
-
+                    // Assume that if we have getStreamELResolver, then we must have
+                    // javax.el.staticFieldELResolver
+                    composite.addRootELResolver((ELResolver) newInstance("javax.el.StaticFieldELResolver"));
+                }
             } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | InstantiationException t) {
                 // This is normal on containers that do not have these ELResolvers
             }

--- a/impl/src/test/java/com/sun/faces/el/ELUtilsTest.java
+++ b/impl/src/test/java/com/sun/faces/el/ELUtilsTest.java
@@ -1,0 +1,66 @@
+package com.sun.faces.el;
+
+import com.sun.el.ExpressionFactoryImpl;
+import com.sun.faces.RIConstants;
+import com.sun.faces.application.ApplicationAssociate;
+import com.sun.faces.application.ApplicationImpl;
+import com.sun.faces.context.ExternalContextImpl;
+import com.sun.faces.context.FacesContextImpl;
+import com.sun.faces.lifecycle.LifecycleImpl;
+import com.sun.faces.mock.MockHttpServletRequest;
+import com.sun.faces.mock.MockHttpServletResponse;
+import com.sun.faces.mock.MockServletContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.el.ELResolver;
+import javax.faces.FactoryFinder;
+import java.net.URL;
+
+public class ELUtilsTest {
+
+    private ApplicationAssociate applicationAssociate;
+
+    @Before
+    public void setUp() {
+        MockServletContext mockServletContext = new MockServletContext() {
+            @Override
+            public URL getResource(String path) {
+                return null;
+            }
+        };
+        mockServletContext.addInitParameter("appParamName", "appParamValue");
+        mockServletContext.setAttribute("appScopeName", "appScopeValue");
+
+        ExternalContextImpl externalContext = new ExternalContextImpl(
+                mockServletContext,
+                new MockHttpServletRequest(),
+                new MockHttpServletResponse()
+        );
+
+        FactoryFinder.setFactory(FactoryFinder.RENDER_KIT_FACTORY,
+                "com.sun.faces.mock.MockRenderKitFactory");
+
+        new FacesContextImpl(externalContext, new LifecycleImpl());
+        new ApplicationImpl();
+
+        applicationAssociate = (ApplicationAssociate) externalContext.getApplicationMap()
+                .get(RIConstants.FACES_PREFIX + "ApplicationAssociate");
+    }
+
+    @Test
+    public void testNPEWhenStreamELResolverIsNull() {
+        // set expr factory with null streamELResolver
+        applicationAssociate.setExpressionFactory(new ExpressionFactoryImpl() {
+            @Override
+            public ELResolver getStreamELResolver() {
+                return null;
+            }
+        });
+
+        DemuxCompositeELResolver elResolver = new DemuxCompositeELResolver(FacesCompositeELResolver.ELResolverChainType.Faces);
+
+        ELUtils.buildFacesResolver(elResolver, applicationAssociate); // should not throw NPE
+    }
+
+}


### PR DESCRIPTION
This is upstream PR for https://github.com/eclipse-ee4j/mojarra/pull/4594

During previous refactoring [1] of method `ELUtils#addEL3_0_Resolvers`, a block catching `Throwable` was replaced with block catching multiple specific exceptions:

```
        if (getStreamELResolverMethod != null) {
            try {
                ELResolver streamELResolver = (ELResolver) getStreamELResolverMethod.invoke(expressionFactory, (Object[]) null);
                composite.addRootELResolver(streamELResolver);  <-- can throw NPE

                // Assume that if we have getStreamELResolver, then we must have
                // javax.el.staticFieldELResolver
                composite.addRootELResolver((ELResolver) newInstance("javax.el.StaticFieldELResolver"));

-           } catch (Throwable t) {
+           } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | InstantiationException t) {
                // This is normal on containers that do not have these ELResolvers
            }
        }
```

The code in the try block can however also throw a NPE, which would've been caught before the refactoring and is not caught now. NPE is thrown inside the `composite.addRootELResolver(streamELResolver)` call (specifically at `DemuxCompositeELResolver:80`), when `streamELResolver` is null.

This NPE then fails deployment.

[1] https://github.com/jboss/mojarra/commit/606a22f2aaef9aa551221eda955b9dee02b5c821#diff-bc4fc2106782297b4905f575b100fa6e