### PR TITLE
Travis build for 2.3 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+
+jdk:
+  - openjdk8
+


### PR DESCRIPTION
I can't find build for 2.3 branch in https://jenkins.eclipse.org/mojarra<sup>1</sup>, so perhaps travis could be used to ensure compilability for PRs at least?

But this test https://github.com/eclipse-ee4j/mojarra/blob/5122f2bc9456d0853809759ddd90dab597ac8a77/impl/src/test/java/javax/faces/FactoryFinderTestCase.java#L107

is flickering. On the same sources it [failed earlier](https://travis-ci.org/eclipse-ee4j/mojarra/builds/568951794#L23350), and passed now.

--- 

1. other than [1_mojarra-build-and-stage](https://jenkins.eclipse.org/mojarra/job/1_mojarra-build-and-stage/) which seems to be manual