### PR TITLE
Issue 4553 - Resoures#encodeAll doesn't work anymore since 2.3.x

### DIFF
--- a/impl/src/main/java/javax/faces/component/UIViewRoot.java
+++ b/impl/src/main/java/javax/faces/component/UIViewRoot.java
@@ -945,7 +945,8 @@ public class UIViewRoot extends UIComponentBase implements UniqueIdVendor {
     public void processEvent(ComponentSystemEvent event) throws AbortProcessingException {
         FacesContext context = event.getFacesContext();
 
-        if (event instanceof PostRestoreStateEvent && context.getPartialViewContext().isPartialRequest()) {
+        if (event instanceof PostRestoreStateEvent && context.getPartialViewContext().isPartialRequest()
+                && !context.getPartialViewContext().isRenderAll()) {
             ResourceHandler resourceHandler = context.getApplication().getResourceHandler();
 
             for (UIComponent resource : getComponentResources(context)) {

--- a/impl/src/test/java/com/sun/faces/mock/MockPartialViewContext.java
+++ b/impl/src/test/java/com/sun/faces/mock/MockPartialViewContext.java
@@ -30,6 +30,8 @@ import javax.faces.event.PhaseId;
 public class MockPartialViewContext extends PartialViewContext {
 
     private Map<Object, Object> attributes;
+    private boolean partial = false;
+    private boolean renderAll = false;
 
     // ------------------------------------------------------------ Constructors
     public MockPartialViewContext() {
@@ -79,7 +81,7 @@ public class MockPartialViewContext extends PartialViewContext {
     }
 
     public boolean isPartialRequest() {
-        return false;
+        return partial;
     }
 
     public boolean isExecuteNone() {
@@ -91,11 +93,11 @@ public class MockPartialViewContext extends PartialViewContext {
     }
 
     public boolean isRenderAll() {
-        throw new UnsupportedOperationException();
+        return renderAll;
     }
 
     public void setRenderAll(boolean renderAll) {
-        throw new UnsupportedOperationException();
+        this.renderAll = renderAll;
     }
 
     public boolean isRenderNone() {
@@ -115,7 +117,8 @@ public class MockPartialViewContext extends PartialViewContext {
     }
 
     @Override
-    public void setPartialRequest(boolean arg0) {
+    public void setPartialRequest(boolean partial) {
+        this.partial = partial;
     }
 
 }

--- a/impl/src/test/java/javax/faces/component/UIViewRootTestCase.java
+++ b/impl/src/test/java/javax/faces/component/UIViewRootTestCase.java
@@ -24,10 +24,12 @@ import java.util.Locale;
 import javax.el.MethodExpression;
 import javax.el.ValueExpression;
 import javax.faces.FactoryFinder;
+import javax.faces.application.ResourceHandler;
 import javax.faces.context.FacesContext;
 import javax.faces.event.PhaseEvent;
 import javax.faces.event.PhaseId;
 import javax.faces.event.PhaseListener;
+import javax.faces.event.PostRestoreStateEvent;
 import javax.faces.render.RenderKit;
 import javax.faces.render.RenderKitFactory;
 
@@ -157,6 +159,43 @@ public class UIViewRootTestCase extends UIComponentBaseTestCase {
         assertNotNull(root.getFacet("javax_faces_location_gt"));
         components = root.getComponentResources(facesContext, "gt");
         assertTrue(components.size() == 1);
+    }
+
+ // Tests that the resources are rendered again if renderall, @all, is set
+    public void testRenderAllComponentResources() {
+        application.addComponent("javax.faces.ComponentResourceContainer", Container.class.getName());
+        UIViewRoot previousRoot = facesContext.getViewRoot();
+        UIViewRoot root = facesContext.getApplication().getViewHandler().createView(facesContext, null);
+        //from partial-request we get the resources added to the ViewRoot
+        facesContext.setViewRoot(root);
+        UIOutput script = new UIOutput();
+        script.getAttributes().putIfAbsent("name", "scriptTest");
+        script.getAttributes().putIfAbsent("library", "scriptLibrary");
+
+        root.addComponentResource(facesContext, script);
+
+        facesContext.getPartialViewContext().setPartialRequest(true);
+        //update @all
+        facesContext.getPartialViewContext().setRenderAll(true);
+
+        final PostRestoreStateEvent postRestoreStateEvent = new PostRestoreStateEvent(root);
+        ResourceHandler resourceHandler = facesContext.getApplication().getResourceHandler();
+
+        postRestoreStateEvent.setComponent(root);
+        root.processEvent(postRestoreStateEvent);
+
+        assertFalse("Resource should not be marked as rendered", resourceHandler.isResourceRendered(facesContext, "scriptTest", "scriptLibrary"));
+
+        //partial update i.e. @form
+        facesContext.getPartialViewContext().setRenderAll(false);
+        root.processEvent(postRestoreStateEvent);
+
+        assertTrue("Resource should be marked as rendered", resourceHandler.isResourceRendered(facesContext, "scriptTest", "scriptLibrary"));
+
+        facesContext.getPartialViewContext().setPartialRequest(false);
+        facesContext.getPartialViewContext().setRenderAll(false);
+        facesContext.setViewRoot(previousRoot);
+
     }
 
     // Test AbortProcessingException support


### PR DESCRIPTION
Issue: https://github.com/eclipse-ee4j/mojarra/issues/4553

The fix renders the resources on update all