### PR TITLE
Memory leak in FlashScope - expired elements are not cleared

### DIFF
--- a/impl/src/main/java/com/sun/faces/context/flash/ELFlash.java
+++ b/impl/src/main/java/com/sun/faces/context/flash/ELFlash.java
@@ -1083,13 +1083,6 @@ public class ELFlash extends Flash {
             }
             contextMap.put(CONSTANTS.DidWriteCookieAttributeName, Boolean.TRUE);
         } else {
-            // if the cookie is removed, make sure the empty maps are removed from innerMap
-            if (nextFlash != null) {
-                flashManager.expireNext();
-            }
-            if (prevFlash != null) {
-                flashManager.expirePrevious();
-            }
             removeCookie(extContext, toSet);
         }
     }

--- a/impl/src/main/java/com/sun/faces/context/flash/ELFlash.java
+++ b/impl/src/main/java/com/sun/faces/context/flash/ELFlash.java
@@ -1083,6 +1083,13 @@ public class ELFlash extends Flash {
             }
             contextMap.put(CONSTANTS.DidWriteCookieAttributeName, Boolean.TRUE);
         } else {
+            // if the cookie is removed, make sure the empty maps are removed from innerMap
+            if (nextFlash != null) {
+                flashManager.expireNext();
+            }
+            if (prevFlash != null) {
+                flashManager.expirePrevious();
+            }
             removeCookie(extContext, toSet);
         }
     }
@@ -1336,6 +1343,29 @@ public class ELFlash extends Flash {
             }
         }
 
+        void expireNext() {
+            // expire next
+            if (null != nextRequestFlashInfo) {
+                Map<String, Object> flashMap;
+                // clear the old map
+                if (null != (flashMap = nextRequestFlashInfo.getFlashMap())) {
+                    if (LOGGER.isLoggable(Level.FINEST)) {
+                        LOGGER.log(Level.FINEST, "{0} expire next[{1}]",
+                                   new Object[]{getLogPrefix(FacesContext.getCurrentInstance()),
+                                      nextRequestFlashInfo.getSequenceNumber()});
+
+                    }
+                    FacesContext context = FacesContext.getCurrentInstance();
+                    context.getApplication().publishEvent(context, PreClearFlashEvent.class,
+                                                          flashMap);
+                    flashMap.clear();
+                }
+                // remove it from the flash
+                innerMap.remove(nextRequestFlashInfo.getSequenceNumber() + "");
+                nextRequestFlashInfo = null;
+            }
+        }
+
         void expireNext_MovePreviousToNext() {
             if (null != nextRequestFlashInfo) {
                 if (LOGGER.isLoggable(Level.FINEST)) {
@@ -1412,7 +1442,7 @@ public class ELFlash extends Flash {
                     // Don't make the flash older on debug requests
                     if (!UIDebug.debugRequest(context)) {
                         previousRequestFlashInfo.setLifetimeMarker(LifetimeMarker.SecondTimeThru);
-                        nextRequestFlashInfo = null;
+                        expireNext();
                     }
                 }
                 Map<String, Object> flashMap;


### PR DESCRIPTION
Issue: #4631 

Expire 'previous' flash map and empty 'next' map at the end of RenderResponse phase. 
If the 'previous' map is needed in next request cycle, it would be moved to 'next' map - otherwise it seems it can be safely removed.