### PR TITLE
[issue-4553] Resoures#encodeAll doesn't work anymore since 2.3.x

### DIFF
--- a/impl/src/main/java/javax/faces/component/UIViewRoot.java
+++ b/impl/src/main/java/javax/faces/component/UIViewRoot.java
@@ -945,7 +945,8 @@ public class UIViewRoot extends UIComponentBase implements UniqueIdVendor {
     public void processEvent(ComponentSystemEvent event) throws AbortProcessingException {
         FacesContext context = event.getFacesContext();
 
-        if (event instanceof PostRestoreStateEvent && context.getPartialViewContext().isPartialRequest()) {
+        if (event instanceof PostRestoreStateEvent && context.getPartialViewContext().isPartialRequest()
+                && !context.getPartialViewContext().isRenderAll()) {
             ResourceHandler resourceHandler = context.getApplication().getResourceHandler();
 
             for (UIComponent resource : getComponentResources(context)) {

--- a/impl/src/test/java/com/sun/faces/mock/MockPartialViewContext.java
+++ b/impl/src/test/java/com/sun/faces/mock/MockPartialViewContext.java
@@ -30,6 +30,8 @@ import javax.faces.event.PhaseId;
 public class MockPartialViewContext extends PartialViewContext {
 
     private Map<Object, Object> attributes;
+    private boolean partial = false;
+    private boolean renderAll = false;
 
     // ------------------------------------------------------------ Constructors
     public MockPartialViewContext() {
@@ -79,7 +81,7 @@ public class MockPartialViewContext extends PartialViewContext {
     }
 
     public boolean isPartialRequest() {
-        return false;
+        return partial;
     }
 
     public boolean isExecuteNone() {
@@ -91,11 +93,11 @@ public class MockPartialViewContext extends PartialViewContext {
     }
 
     public boolean isRenderAll() {
-        throw new UnsupportedOperationException();
+        return renderAll;
     }
 
     public void setRenderAll(boolean renderAll) {
-        throw new UnsupportedOperationException();
+        this.renderAll = renderAll;
     }
 
     public boolean isRenderNone() {
@@ -115,7 +117,8 @@ public class MockPartialViewContext extends PartialViewContext {
     }
 
     @Override
-    public void setPartialRequest(boolean arg0) {
+    public void setPartialRequest(boolean partial) {
+        this.partial = partial;
     }
 
 }


### PR DESCRIPTION
Conflicts:
	impl/src/test/java/javax/faces/component/UIViewRootTestCase.java

Signed-off-by: arjantijms <arjan.tijms@gmail.com>