### PR TITLE
Fix problem introduced in JAVASERVERFACES_SPEC_PUBLIC-1329, also cons…

### DIFF
--- a/impl/src/main/java/javax/faces/component/UIInput.java
+++ b/impl/src/main/java/javax/faces/component/UIInput.java
@@ -856,9 +856,8 @@ public class UIInput extends UIOutput implements EditableValueHolder {
         // If non-null, an instanceof String, and we're configured to treat
         // zero-length Strings as null:
         //   call setSubmittedValue(null)
-        if ((considerEmptyStringNull(context)
-             && submittedValue instanceof String
-             && ((String) submittedValue).length() == 0)) {
+        boolean isEmptyStringNull = (considerEmptyStringNull(context) && submittedValue instanceof String && ((String) submittedValue).length() == 0);
+        if (isEmptyStringNull) {
             setSubmittedValue(null);
             submittedValue = null;
         }
@@ -877,13 +876,18 @@ public class UIInput extends UIOutput implements EditableValueHolder {
 
         // If our value is valid, store the new value, erase the
         // "submitted" value, and emit a ValueChangeEvent if appropriate
-        if (isValid()) {
-            Object previous = getValue();
+        Object previous = getValue();
+        if (isValid() && !isEmptyStringNull) {
             setValue(newValue);
             setSubmittedValue(null);
-            if (compareValues(previous, newValue)) {
-                queueEvent(new ValueChangeEvent(context, this, previous, newValue));
+        } else {
+            if (submittedValue == null) {
+                setSubmittedValue("");
             }
+        }
+
+        if (compareValues(previous, newValue)) {
+            queueEvent(new ValueChangeEvent(context, this, previous, newValue));
         }
 
     }

--- a/test/servlet31/faceletsEmptyAsNull/src/test/java/com/sun/faces/test/servlet31/faceletsemptyasnull/Issue2827IT.java
+++ b/test/servlet31/faceletsEmptyAsNull/src/test/java/com/sun/faces/test/servlet31/faceletsemptyasnull/Issue2827IT.java
@@ -124,8 +124,8 @@ public class Issue2827IT {
             pageAsText = page.asText();
             assertTrue(pageAsText.contains("VC1 Fired: true"));
             assertTrue(pageAsText.contains("VC2 Fired: true"));
-            assertTrue(pageAsText.contains("String model set with null: true"));
-            assertTrue(pageAsText.contains("Integer model set with null: true"));
+            assertTrue(pageAsText.contains("String model set with null: false"));
+            assertTrue(pageAsText.contains("Integer model set with null: false"));
 
             submit = (HtmlSubmitInput) page.getHtmlElementById("form:command");
             assertNotNull(submit);
@@ -144,10 +144,10 @@ public class Issue2827IT {
             assertEquals(integerInput.getValueAttribute(), "");
 
             pageAsText = page.asText();
-            assertTrue(pageAsText.contains("VC1 Fired: false"));
-            assertTrue(pageAsText.contains("VC2 Fired: false"));
-            assertTrue(pageAsText.contains("String model set with null: true"));
-            assertTrue(pageAsText.contains("Integer model set with null: true"));
+            assertTrue(pageAsText.contains("VC1 Fired: true"));
+            assertTrue(pageAsText.contains("VC2 Fired: true"));
+            assertTrue(pageAsText.contains("String model set with null: false"));
+            assertTrue(pageAsText.contains("Integer model set with null: false"));
         }
     }
 }


### PR DESCRIPTION
…ider Submitted value "" when EMPTY_STRING_AS_NULL_PARAM_NAME is enabled.

2.3 branch PR: https://github.com/eclipse-ee4j/mojarra/pull/4644
Fix #4550 
As commit https://github.com/javaserverfaces/mojarra/commit/4c74d1f8cff1a60dafcb4df805ab2de935e7404f#diff-d9a3cf30923f6318a8387c91e42aa0d4R295-R302 changed null to "" when EmptyStringNull is considered. 
It also needs this same change in UIInput