### PR TITLE
2nd part fix for issue4550, If the component is NOT valid, the associ…

### DIFF
--- a/impl/src/main/java/javax/faces/component/UIInput.java
+++ b/impl/src/main/java/javax/faces/component/UIInput.java
@@ -886,7 +886,7 @@ public class UIInput extends UIOutput implements EditableValueHolder {
             }
         }
 
-        if (compareValues(previous, newValue)) {
+        if (isValid() && compareValues(previous, newValue)) {
             queueEvent(new ValueChangeEvent(context, this, previous, newValue));
         }
 


### PR DESCRIPTION
2nd part fix for #4550, If the component is NOT valid, the associated ValueChangeListener must NOT be invoked

This fixes an unfortunate EE8 TCK failure made in https://github.com/eclipse-ee4j/mojarra/pull/4643

3.0 Branch PR: https://github.com/eclipse-ee4j/mojarra/pull/4682
2.3 Branch PR: https://github.com/eclipse-ee4j/mojarra/pull/4683
Signed-off-by: Chao Wang <chaowan@redhat.com>