### PR TITLE
2nd part fix for issue4550, If the component is NOT valid, the associ…

### DIFF
--- a/impl/src/main/java/javax/faces/component/UIInput.java
+++ b/impl/src/main/java/javax/faces/component/UIInput.java
@@ -1026,7 +1026,7 @@ public class UIInput extends UIOutput implements EditableValueHolder {
             }
         }
 
-        if (compareValues(previous, newValue)) {
+        if (isValid() && compareValues(previous, newValue)) {
             queueEvent(new ValueChangeEvent(context, this, previous, newValue));
         }
 


### PR DESCRIPTION
2nd part fix for #4550, If the component is NOT valid, the associated ValueChangeListener must NOT be invoked

This fixes an unfortunate EE8 TCK failure made in https://github.com/eclipse-ee4j/mojarra/pull/4643

master branch PR: https://github.com/eclipse-ee4j/mojarra/pull/4681
3.0 Branch PR: https://github.com/eclipse-ee4j/mojarra/pull/4682

Signed-off-by: Chao Wang <chaowan@redhat.com>
(cherry picked from commit 75a7f210aa121d6447df698e75ddf07b916e1d52)