### PR TITLE
[Issue 4677] IdMapper can create repeated ids in clustered environments

### DIFF
--- a/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
+++ b/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
@@ -1338,6 +1338,10 @@ public class WebConfiguration {
               "com.sun.faces.enableDistributable",
               false
         ),
+        UseFaceletsID(
+              "com.sun.faces.useFaceletsID",
+              false
+        ),
         EnableFaceletsResourceResolverResolveCompositeComponents(
               "com.sun.faces.enableFaceletsResourceResolverCompositeComponents",
               false

--- a/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFacelet.java
+++ b/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFacelet.java
@@ -82,7 +82,7 @@ final class DefaultFacelet extends Facelet implements XMLFrontMatterSaver {
         this.src = src;
         this.root = root;
         this.alias = alias;
-        this.mapper = factory.idMappers.get(alias);
+        this.mapper = factory.idMappers != null? factory.idMappers.get(alias) : null;
         this.createTime = System.currentTimeMillis();
         this.refreshPeriod = this.factory.getRefreshPeriod();
 
@@ -109,7 +109,7 @@ final class DefaultFacelet extends Facelet implements XMLFrontMatterSaver {
 
         IdMapper idMapper = IdMapper.getMapper(facesContext);
         boolean mapperSet = false;
-        if (idMapper == null) {
+        if (idMapper == null && this.mapper != null) {
             IdMapper.setMapper(facesContext, this.mapper);
             mapperSet = true;
         }

--- a/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFaceletFactory.java
+++ b/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFaceletFactory.java
@@ -17,6 +17,8 @@
 package com.sun.faces.facelets.impl;
 
 import com.sun.faces.RIConstants;
+import com.sun.faces.config.WebConfiguration;
+import static com.sun.faces.config.WebConfiguration.BooleanWebContextInitParameter.UseFaceletsID;
 import com.sun.faces.context.FacesFileNotFoundException;
 import java.net.MalformedURLException;
 import javax.faces.FactoryFinder;
@@ -123,11 +125,19 @@ public class DefaultFaceletFactory {
             FaceletCache cache) {
         Util.notNull("compiler", compiler);
         Util.notNull("resolver", resolver);
+
+        FacesContext facesContext = FacesContext.getCurrentInstance();
+        if (facesContext == null) {
+            throw new IllegalStateException("DefaultFaceletFactory cannot locate the faces context");
+        }
+        ExternalContext externalContext = facesContext.getExternalContext();
+        WebConfiguration config = WebConfiguration.getInstance(externalContext);
+
         this.compiler = compiler;
         this.cachePerContract = new ConcurrentHashMap<>();
         this.resolver = resolver;
         this.baseUrl = resolver.resolveUrl("/");
-        this.idMappers = new Cache<>(new IdMapperFactory());
+        this.idMappers = config.isOptionEnabled(UseFaceletsID)? null : new Cache<>(new IdMapperFactory());
         // this.location = url;
         refreshPeriod = (refreshPeriod >= 0) ? refreshPeriod * 1000 : -1;
         this.refreshPeriod = refreshPeriod;

--- a/test/servlet31/faceletsID/pom.xml
+++ b/test/servlet31/faceletsID/pom.xml
@@ -19,24 +19,18 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
     <parent>
-        <groupId>com.sun.faces.test</groupId>
+        <groupId>com.sun.faces.test.servlet31</groupId>
         <artifactId>pom</artifactId>
         <version>3.0.0-m01-SNAPSHOT</version>
     </parent>
-    
-    <groupId>com.sun.faces.test.servlet31</groupId>
-    <artifactId>pom</artifactId>
-    <packaging>pom</packaging>
-    
-    <name>Mojarra ${project.version} - Test - Servlet 3.1</name>
-    
-    <modules>
-        <module>facelets</module>
-        <module>faceletsID</module>
-        <module>faceletsEmptyAsNull</module>
-        <module>resourcehandler</module>
-    </modules>
-    
+    <artifactId>faceletsID</artifactId>
+    <packaging>war</packaging>
+    <name>Mojarra ${project.version} - Test - Servlet 3.1 - FaceletsID</name>
+    <build>
+        <finalName>test-servlet31-faceletsID</finalName>
+    </build>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 </project>

--- a/test/servlet31/faceletsID/src/main/java/com/sun/faces/test/servlet31/faceletsID/TestBean.java
+++ b/test/servlet31/faceletsID/src/main/java/com/sun/faces/test/servlet31/faceletsID/TestBean.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.test.servlet31.faceletsID;
+
+import java.io.Serializable;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Named;
+
+@Named("testBean")
+@RequestScoped
+public class TestBean implements Serializable {
+
+    private String param;
+
+    public String getParam() {
+        return param;
+    }
+
+    public void setParam(String param) {
+        this.param = param;
+    }
+
+    public void run() {
+        // no-op
+    }
+}

--- a/test/servlet31/faceletsID/src/main/webapp/WEB-INF/web.xml
+++ b/test/servlet31/faceletsID/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+    <context-param>
+        <param-name>javax.faces.PROJECT_STAGE</param-name>
+        <param-value>${webapp.projectStage}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>javax.faces.PARTIAL_STATE_SAVING</param-name>
+        <param-value>${webapp.partialStateSaving}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
+        <param-value>${webapp.stateSavingMethod}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>javax.faces.SERIALIZE_SERVER_STATE</param-name>
+        <param-value>${webapp.serializeServerState}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>com.sun.faces.useFaceletsID</param-name>
+        <param-value>true</param-value>
+    </context-param>
+    <servlet>
+        <servlet-name>Faces Servlet</servlet-name>
+        <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>Faces Servlet</servlet-name>
+        <url-pattern>/faces/*</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+    <welcome-file-list>
+        <welcome-file>faces/index.xhtml</welcome-file>
+    </welcome-file-list>
+</web-app>

--- a/test/servlet31/faceletsID/src/main/webapp/index.xhtml
+++ b/test/servlet31/faceletsID/src/main/webapp/index.xhtml
@@ -1,0 +1,36 @@
+<!--
+
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://java.sun.com/jsf/html"
+      xmlns:f="http://java.sun.com/jsf/core"
+      xmlns:ui="http://java.sun.com/jsf/facelets">
+
+<h:head>
+    <title>faceletsID</title>
+</h:head>
+
+<h:body>
+  <h:form>
+    <h:inputText value="#{testBean.param}"/>
+    <h:commandButton value="submit" type="submit" action="#{testBean.run}"/>
+  </h:form>
+</h:body>
+</html>

--- a/test/servlet31/faceletsID/src/test/java/com/sun/faces/test/servlet31/faceletsID/FaceletIDITCase.java
+++ b/test/servlet31/faceletsID/src/test/java/com/sun/faces/test/servlet31/faceletsID/FaceletIDITCase.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.test.servlet31.faceletsID;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.DomElement;
+import com.gargoylesoftware.htmlunit.html.DomNodeList;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.hamcrest.CoreMatchers;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * <p>Simple test to ensure that context param <em>com.sun.faces.useFaceletsID</em>
+ * really disables the IdMapper and IDs are generated using the facelet ID.</p>
+ *
+ * @author rmartinc
+ */
+public class FaceletIDITCase {
+
+    private String webUrl;
+    private WebClient webClient;
+
+    @Before
+    public void setUp() {
+        webUrl = System.getProperty("integration.url");
+        webClient = new WebClient();
+    }
+
+    @After
+    public void tearDown() {
+        webClient.close();
+    }
+
+    @Test
+    public void testUsingFaceletsID() throws Exception {
+        HtmlPage page = webClient.getPage(webUrl + "faces/index.xhtml");
+        DomNodeList<DomElement> nodes = page.getElementsByTagName("form");
+
+        Assert.assertEquals(1, nodes.size());
+        HtmlForm form = (HtmlForm) nodes.get(0);
+
+        Assert.assertThat("ID is not using IdMapper", form.getId(),
+                CoreMatchers.not(CoreMatchers.startsWith("j_idt")));
+        Assert.assertThat("Name is not using IdMapper", form.getAttribute("name"),
+                CoreMatchers.not(CoreMatchers.startsWith("j_idt")));
+    }
+}


### PR DESCRIPTION
Fix for #4677. The idea is using a new context parameter that removes the IdMapper and uses the facelet ID directly.