### PR TITLE
Issue4550 alternative master

### DIFF
--- a/impl/src/main/java/javax/faces/component/UIInput.java
+++ b/impl/src/main/java/javax/faces/component/UIInput.java
@@ -856,8 +856,9 @@ public class UIInput extends UIOutput implements EditableValueHolder {
         // If non-null, an instanceof String, and we're configured to treat
         // zero-length Strings as null:
         //   call setSubmittedValue(null)
-        boolean isEmptyStringNull = (considerEmptyStringNull(context) && submittedValue instanceof String && ((String) submittedValue).length() == 0);
-        if (isEmptyStringNull) {
+        if ((considerEmptyStringNull(context)
+             && submittedValue instanceof String
+             && ((String) submittedValue).length() == 0)) {
             setSubmittedValue(null);
             submittedValue = null;
         }
@@ -876,18 +877,13 @@ public class UIInput extends UIOutput implements EditableValueHolder {
 
         // If our value is valid, store the new value, erase the
         // "submitted" value, and emit a ValueChangeEvent if appropriate
-        Object previous = getValue();
-        if (isValid() && !isEmptyStringNull) {
+        if (isValid()) {
+            Object previous = getValue();
             setValue(newValue);
             setSubmittedValue(null);
-        } else {
-            if (submittedValue == null) {
-                setSubmittedValue("");
+            if (compareValues(previous, newValue)) {
+                queueEvent(new ValueChangeEvent(context, this, previous, newValue));
             }
-        }
-
-        if (compareValues(previous, newValue)) {
-            queueEvent(new ValueChangeEvent(context, this, previous, newValue));
         }
 
     }

--- a/impl/src/main/java/javax/faces/component/UIInput.java
+++ b/impl/src/main/java/javax/faces/component/UIInput.java
@@ -849,6 +849,10 @@ public class UIInput extends UIOutput implements EditableValueHolder {
             if (isRequired() && isSetAlwaysValidateRequired(context)) {
                 // continue as below
             } else {
+                if(considerEmptyStringNull(context)) {
+                    // https://github.com/eclipse-ee4j/mojarra/issues/4550
+                    validateValue(context,  getConvertedValue(context, submittedValue));
+                }
                 return;
             }
         }

--- a/impl/src/main/java/javax/faces/component/UIViewParameter.java
+++ b/impl/src/main/java/javax/faces/component/UIViewParameter.java
@@ -268,27 +268,8 @@ public class UIViewParameter extends UIInput {
             context.renderResponse();
         }
         else {
-            if (myConsiderEmptyStringNull(context)) {
-                // JAVASERVERFACES_SPEC_PUBLIC-1329: If the EMPTY_STRING_SUBMITTED_VALUES_AS_NULL
-                // config is set, ensure that logic gets a chance to be executed
-                // in UIInput.processValidators().
-                if (null == submittedValue) {
-                    setSubmittedValue("");
-                }
-            }
             super.processValidators(context);
         }
-    }
-    
-    private boolean myConsiderEmptyStringNull(FacesContext ctx) {
-
-        if (emptyStringIsNull == null) {
-            String val = ctx.getExternalContext().getInitParameter(EMPTY_STRING_AS_NULL_PARAM_NAME);
-            emptyStringIsNull = Boolean.valueOf(val);
-        }
-
-        return emptyStringIsNull;
-        
     }
     
     

--- a/test/javaee6/viewParamNullValueAjax/pom.xml
+++ b/test/javaee6/viewParamNullValueAjax/pom.xml
@@ -17,28 +17,20 @@
 
 --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
-
-    <parent>
-        <groupId>com.sun.faces.test</groupId>
-        <artifactId>pom</artifactId>
-        <version>3.0.0-m01-SNAPSHOT</version>
-    </parent>
-
-    <groupId>com.sun.faces.test.javaee6</groupId>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
     <artifactId>pom</artifactId>
-    <packaging>pom</packaging>
-    <name>Mojarra ${project.version} - Test - JavaEE 6</name>
-
-    <modules>
-        <module>correctScanningEar</module>
-        <module>correctScanningJar</module>
-        <module>correctScanningTest</module>
-        <module>correctScanningWar1</module>
-        <module>correctScanningWar2</module>
-        <module>resource</module>
-        <module>viewParamBeanValidatorNotNull</module>
-        <module>viewParamNullValueAjax</module>
-  </modules>
+    <groupId>com.sun.faces.test.javaee6</groupId>
+    <version>3.0.0-m01-SNAPSHOT</version>
+  </parent>
   
+  <artifactId>viewParamNullValueAjax</artifactId>
+  <packaging>war</packaging>
+  <name>Mojarra ${project.version} - Test - JavaEE 6 - viewParameter with null value for Ajax</name>
+  
+  <build>
+    <finalName>test-javaee6-viewParamNullValueAjax</finalName>
+  </build>
+  
+
 </project>

--- a/test/javaee6/viewParamNullValueAjax/src/main/java/com/sun/faces/test/javaee6/viewParamNullValueAjax/TestView.java
+++ b/test/javaee6/viewParamNullValueAjax/src/main/java/com/sun/faces/test/javaee6/viewParamNullValueAjax/TestView.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.test.javaee6.viewParamNullValueAjax;
+
+import java.io.Serializable;
+
+import javax.faces.view.ViewScoped;
+import javax.inject.Named;
+
+@ViewScoped
+@Named
+public class TestView implements Serializable {
+
+    private String testString;
+
+    public void onView() {
+        testString = "Test Rhuan";
+        System.out.println("initializing: " + testString);
+    }
+
+    public void someMethod() {
+        System.out.println(testString);
+    }
+
+    public String getTestString() {
+        return testString;
+    }
+
+    public void setTestString(String testString) {
+        System.out.println("Setting value: " + testString);
+        this.testString = testString;
+    }
+}

--- a/test/javaee6/viewParamNullValueAjax/src/main/webapp/WEB-INF/beans.xml
+++ b/test/javaee6/viewParamNullValueAjax/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="all" 
+       version="1.1">
+</beans>

--- a/test/javaee6/viewParamNullValueAjax/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/test/javaee6/viewParamNullValueAjax/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE glassfish-web-app PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Servlet 3.0//EN" "http://glassfish.org/dtds/glassfish-web-app_3_0-1.dtd">
+<!--
+
+    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<glassfish-web-app error-url="">
+  <context-root>/test-javaee6-viewParamNullValueAjax</context-root>
+  <class-loader delegate="true"/>
+  <jsp-config>
+    <property name="keepgenerated" value="true">
+      <description>Keep a copy of the generated servlet class' java code.</description>
+    </property>
+  </jsp-config>
+</glassfish-web-app>

--- a/test/javaee6/viewParamNullValueAjax/src/main/webapp/WEB-INF/web.xml
+++ b/test/javaee6/viewParamNullValueAjax/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved. 
+	This program and the accompanying materials are made available under the 
+	terms of the Eclipse Public License v. 2.0, which is available at http://www.eclipse.org/legal/epl-2.0. 
+	This Source Code may also be made available under the following Secondary 
+	Licenses when the conditions for such availability set forth in the Eclipse 
+	Public License v. 2.0 are satisfied: GNU General Public License, version 
+	2 with the GNU Classpath Exception, which is available at https://www.gnu.org/software/classpath/license.html. 
+	SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 -->
+
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee web-app_3_1.xsd"
+	version="3.1">
+	<context-param>
+		<param-name>javax.faces.INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL</param-name>
+		<param-value>true</param-value>
+	</context-param>
+	<context-param>
+		<param-name>javax.faces.ENABLE_WEBSOCKET_ENDPOINT</param-name>
+		<param-value>true</param-value>
+	</context-param>
+	<context-param>
+		<param-name>javax.faces.PROJECT_STAGE</param-name>
+		<param-value>${webapp.projectStage}</param-value>
+	</context-param>
+	<context-param>
+		<param-name>javax.faces.PARTIAL_STATE_SAVING</param-name>
+		<param-value>${webapp.partialStateSaving}</param-value>
+	</context-param>
+	<context-param>
+		<param-name>javax.faces.STATE_SAVING_METHOD</param-name>
+		<param-value>${webapp.stateSavingMethod}</param-value>
+	</context-param>
+	<context-param>
+		<param-name>javax.faces.SERIALIZE_SERVER_STATE</param-name>
+		<param-value>${webapp.serializeServerState}</param-value>
+	</context-param>
+
+	<servlet>
+		<servlet-name>Faces Servlet</servlet-name>
+		<servlet-class>javax.faces.webapp.FacesServlet</servlet-class>
+		<load-on-startup>1</load-on-startup>
+	</servlet>
+	<servlet-mapping>
+		<servlet-name>Faces Servlet</servlet-name>
+		<url-pattern>/faces/*</url-pattern>
+	</servlet-mapping>
+	<welcome-file-list>
+		<welcome-file>faces/viewparam-nullvalue-ajax.xhtml</welcome-file>
+	</welcome-file-list>
+</web-app>

--- a/test/javaee6/viewParamNullValueAjax/src/main/webapp/viewparam-nullvalue-ajax.xhtml
+++ b/test/javaee6/viewParamNullValueAjax/src/main/webapp/viewparam-nullvalue-ajax.xhtml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:ui="http://java.sun.com/jsf/facelets"
+	xmlns:f="http://java.sun.com/jsf/core"
+	xmlns:h="http://java.sun.com/jsf/html">
+<f:metadata>
+	<f:viewAction action="#{testView.onView}" />
+	<f:viewParam name="test" value="#{testView.testString}" />
+</f:metadata>
+
+<h:head>
+	<title>issue 4550 viewparameter bug</title>
+</h:head>
+
+<h:body>
+	<h:form id="form">
+		<h:commandButton id="ajaxCommandButton" value="1. ajax request"
+			action="#{testView.someMethod()}">
+			<f:ajax />
+		</h:commandButton>
+
+		<br />            
+        after an ajax request any subsequent call (btn 1 - ajax or btn 2 - non ajax) causes the null value on all view parameters
+        <br />
+
+		<h:commandButton id="commandButton"
+			value="2. second click causes null value"
+			action="#{testView.someMethod()}" />
+
+		<h:outputText id="testText"
+			value="the test text valus is #{testView.testString}" />
+	</h:form>
+</h:body>
+</html>

--- a/test/javaee6/viewParamNullValueAjax/src/test/java/com/sun/faces/test/javaee6/viewParamNullValueAjax/Issue4550IT.java
+++ b/test/javaee6/viewParamNullValueAjax/src/test/java/com/sun/faces/test/javaee6/viewParamNullValueAjax/Issue4550IT.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.test.javaee6.viewParamNullValueAjax;
+
+import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
+import com.sun.faces.test.junit.JsfTestRunner;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+
+@RunWith(JsfTestRunner.class)
+public class Issue4550IT {
+
+    private static String TEST_STRING = "Test Rhuan";
+
+    /**
+     * Stores the web URL.
+     */
+    private String webUrl;
+    /**
+     * Stores the web client.
+     */
+    private WebClient webClient;
+
+    /**
+     * Setup before testing.
+     * 
+     * @throws Exception when a serious error occurs.
+     */
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+    }
+
+    /**
+     * Cleanup after testing.
+     * 
+     * @throws Exception when a serious error occurs.
+     */
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+    }
+
+    /**
+     * Setup before testing.
+     */
+    @Before
+    public void setUp() {
+        webUrl = System.getProperty("integration.url");
+        webClient = new WebClient();
+    }
+
+    @Test
+    public void testViewParamNullValueAjax() throws Exception {
+        HtmlPage page = webClient.getPage(webUrl + "faces/viewparam-nullvalue-ajax.xhtml");
+
+        // Ajax submit click
+        HtmlSubmitInput submit = (HtmlSubmitInput) page.getHtmlElementById("form:ajaxCommandButton");
+        assertNotNull(submit);
+        page = (HtmlPage) submit.click();
+        String pageAsText = page.asText();
+        assertTrue(pageAsText.contains(TEST_STRING));
+
+        // Ajax submit click
+        submit = (HtmlSubmitInput) page.getHtmlElementById("form:ajaxCommandButton");
+        assertNotNull(submit);
+        page = (HtmlPage) submit.click();
+        pageAsText = page.asText();
+        assertTrue(pageAsText.contains(TEST_STRING));
+
+        // Non Ajax submit click
+        submit = (HtmlSubmitInput) page.getHtmlElementById("form:commandButton");
+        assertNotNull(submit);
+        page = (HtmlPage) submit.click();
+        pageAsText = page.asText();
+        assertTrue(pageAsText.contains(TEST_STRING));
+    }
+
+    @After
+    public void tearDown() {
+        webClient.close();
+    }
+}

--- a/test/servlet31/faceletsEmptyAsNull/src/test/java/com/sun/faces/test/servlet31/faceletsemptyasnull/Issue2827IT.java
+++ b/test/servlet31/faceletsEmptyAsNull/src/test/java/com/sun/faces/test/servlet31/faceletsemptyasnull/Issue2827IT.java
@@ -124,8 +124,8 @@ public class Issue2827IT {
             pageAsText = page.asText();
             assertTrue(pageAsText.contains("VC1 Fired: true"));
             assertTrue(pageAsText.contains("VC2 Fired: true"));
-            assertTrue(pageAsText.contains("String model set with null: false"));
-            assertTrue(pageAsText.contains("Integer model set with null: false"));
+            assertTrue(pageAsText.contains("String model set with null: true"));
+            assertTrue(pageAsText.contains("Integer model set with null: true"));
 
             submit = (HtmlSubmitInput) page.getHtmlElementById("form:command");
             assertNotNull(submit);
@@ -144,10 +144,10 @@ public class Issue2827IT {
             assertEquals(integerInput.getValueAttribute(), "");
 
             pageAsText = page.asText();
-            assertTrue(pageAsText.contains("VC1 Fired: true"));
-            assertTrue(pageAsText.contains("VC2 Fired: true"));
-            assertTrue(pageAsText.contains("String model set with null: false"));
-            assertTrue(pageAsText.contains("Integer model set with null: false"));
+            assertTrue(pageAsText.contains("VC1 Fired: false"));
+            assertTrue(pageAsText.contains("VC2 Fired: false"));
+            assertTrue(pageAsText.contains("String model set with null: true"));
+            assertTrue(pageAsText.contains("Integer model set with null: true"));
         }
     }
 }


### PR DESCRIPTION
As I mentioned in #issue4550

javaserverfaces/mojarra@4c74d1f  changed `submittedValue` from `null` to `""` if `javax.faces.INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL` is configured to true
```
            if (myConsiderEmptyStringNull(context)) {
                // JAVASERVERFACES_SPEC_PUBLIC-1329: If the EMPTY_STRING_SUBMITTED_VALUES_AS_NULL
                // config is set, ensure that logic gets a chance to be executed
                // in UIInput.processValidators().
                if (null == submittedValue) {
                    setSubmittedValue("");
                }
            }
```
And it essentially makes a difference in `validate` [method](https://github.com/eclipse-ee4j/mojarra/blob/2.3.14-RELEASE/impl/src/main/java/javax/faces/component/UIInput.java#L982-#L991) in UIInput.java

```
        // Submitted value == null means "the component was not submitted
        // at all".
        Object submittedValue = getSubmittedValue();
        if (submittedValue == null) {
            if (isRequired() && isSetAlwaysValidateRequired(context)) {
                // continue as below
            } else {
                return;
            }
        }
```
If `submittedValue` is null, it returns immediately as it considers `the component was not submitted at all`.

However, `submittedValue` becomes `""`, so it continues to executed in order to validate and set the new values.


Previous fix caused another issue as reported in https://github.com/eclipse-ee4j/mojarra/issues/4704. Here, the new fix just address the JAVASERVERFACES_SPEC_PUBLIC-1329 validation requirement inside UIInput.java rather than UIViewParameter.java. If javax.faces.INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL is enabled, for null value input, it still give a chance to validate "" value in UIInput.validate() method, then return immediately.

3.0 branch PR: https://github.com/eclipse-ee4j/mojarra/pull/4707
2.3 branch PR: https://github.com/eclipse-ee4j/mojarra/pull/4708

WFLY issue: https://issues.redhat.com/browse/WFLY-13497


