### PR TITLE
This fixes #4716, make the extra validation only on UIViewParameter.

### DIFF
--- a/impl/src/main/java/javax/faces/component/UIInput.java
+++ b/impl/src/main/java/javax/faces/component/UIInput.java
@@ -986,8 +986,9 @@ public class UIInput extends UIOutput implements EditableValueHolder {
             if (isRequired() && isSetAlwaysValidateRequired(context)) {
                 // continue as below
             } else {
-                if(considerEmptyStringNull(context)) {
+                if (this instanceof UIViewParameter && considerEmptyStringNull(context)) {
                     // https://github.com/eclipse-ee4j/mojarra/issues/4550
+                    // https://github.com/eclipse-ee4j/mojarra/issues/4716
                     validateValue(context,  getConvertedValue(context, submittedValue));
                 }
                 return;


### PR DESCRIPTION
Signed-off-by: Chao Wang <chaowan@redhat.com>
(cherry picked from commit 217b1886757660e201f4abdd92c59afcb53f52ff)

Fix for https://github.com/eclipse-ee4j/mojarra/issues/4716

Last pull request https://github.com/eclipse-ee4j/mojarra/pull/4706 addressed the JAVASERVERFACES_SPEC_PUBLIC-1329 validation requirement inside UIInput.java rather than UIViewParameter.java. However, the extra validation should have only applied on UIViewParameter.

master branch PR: https://github.com/eclipse-ee4j/mojarra/pull/4717
3.0 branch PR: https://github.com/eclipse-ee4j/mojarra/pull/4718