### PR TITLE
Issue 4734, don't call getConvertedValue on null value.

### DIFF
--- a/impl/src/main/java/jakarta/faces/component/UIInput.java
+++ b/impl/src/main/java/jakarta/faces/component/UIInput.java
@@ -933,7 +933,7 @@ public class UIInput extends UIOutput implements EditableValueHolder {
                 if (this instanceof UIViewParameter && considerEmptyStringNull(context)) {
                     // https://github.com/eclipse-ee4j/mojarra/issues/4550
                     // https://github.com/eclipse-ee4j/mojarra/issues/4716
-                    validateValue(context,  getConvertedValue(context, submittedValue));
+                    validateValue(context, submittedValue);
                 }
                 return;
             }


### PR DESCRIPTION
Signed-off-by: Chao Wang <chaowan@redhat.com>
(cherry picked from commit a439da6c62da9894a9d647a703ddbf9040bffa3e)

3.0 branch PR, possible solution for #4734. 
Master branch PR: https://github.com/eclipse-ee4j/mojarra/pull/4788