### PR TITLE
Performance-optimized version of ComponentSupport.findChildByTagId()

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/tag/jsf/ComponentSupport.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/jsf/ComponentSupport.java
@@ -237,63 +237,8 @@ public final class ComponentSupport {
      * @return the UI component
      */
     public static UIComponent findChildByTagId(FacesContext context, UIComponent parent, String id) {
-        UIComponent c = null;
-        UIViewRoot root = context.getViewRoot();
-        boolean hasDynamicComponents = (null != root && 
-                root.getAttributes().containsKey(RIConstants.TREE_HAS_DYNAMIC_COMPONENTS));
-        String cid = null;
-        List<UIComponent> components;
-        String facetName = getFacetName(parent);
-        if (null != facetName) {
-            c = parent.getFacet(facetName);
-            // We will have a facet name, but no corresponding facet in the
-            // case of facets with composite components.  In this case,
-            // we must do the brute force search.
-            if (null != c) {
-                cid = (String) c.getAttributes().get(MARK_CREATED);
-                if (id.equals(cid)) {
-                    return c;
-                }
-            } 
-        }
-        if (0 < parent.getFacetCount()) {
-            components = new ArrayList<>();
-            components.addAll(parent.getFacets().values());
-            components.addAll(parent.getChildren());
-        } else {
-            components = parent.getChildren();
-        }
-
-        int len = components.size();
-        for (int i = 0; i < len; i++) {
-            c = components.get(i);
-            cid = (String) c.getAttributes().get(MARK_CREATED);
-            if (id.equals(cid)) {
-                return c;
-            }
-            if (c instanceof UIPanel && c.getAttributes().containsKey(IMPLICIT_PANEL)) {
-                for (UIComponent c2 : c.getChildren()) {
-                    cid = (String) c2.getAttributes().get(MARK_CREATED);
-                    if (id.equals(cid)) {
-                        return c2;
-                    }
-                }
-            }
-            if (hasDynamicComponents) {
-                /*
-                 * Make sure we look for the child recursively it might have moved
-                 * into a different parent in the parent hierarchy. Note currently
-                 * we are only looking down the tree. Maybe it would be better
-                 * to use the VisitTree API instead.
-                 */
-                UIComponent foundChild = findChildByTagId(context, c, id);
-                if (foundChild != null) {
-                    return foundChild;
-                }
-            }
-        }
-
-        return null;
+        // fast path - get the child from the descendant mark id cache
+        return parent.getDescendantMarkIdCache().get(id);
     }
     
     /**

--- a/impl/src/main/java/javax/faces/component/ComponentStateHelper.java
+++ b/impl/src/main/java/javax/faces/component/ComponentStateHelper.java
@@ -16,8 +16,10 @@
 
 package javax.faces.component;
 
+import static com.sun.faces.facelets.tag.jsf.ComponentSupport.MARK_CREATED;
 import static com.sun.faces.util.Util.coalesce;
 import static com.sun.faces.util.Util.isEmpty;
+import static javax.faces.component.UIComponent.PropertyKeys;
 import static javax.faces.component.UIComponentBase.restoreAttachedState;
 import static javax.faces.component.UIComponentBase.saveAttachedState;
 
@@ -112,6 +114,15 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
      */
     @Override
     public Object put(Serializable key, String mapKey, Object value) {
+        if (MARK_CREATED.equals(mapKey)) {
+            if (PropertyKeys.attributes.equals(key)) {
+                UIComponent parent = component.getParent();
+                if (parent != null) {
+                    // remember this component by its mark id
+                    parent.addToDescendantMarkIdCache(component);
+                }
+            }
+        }
 
         Object ret = null;
         if (component.initialStateMarked()) {

--- a/impl/src/main/java/javax/faces/component/UIComponent.java
+++ b/impl/src/main/java/javax/faces/component/UIComponent.java
@@ -16,6 +16,7 @@
 
 package javax.faces.component;
 
+import static com.sun.faces.facelets.tag.jsf.ComponentSupport.MARK_CREATED;
 import static com.sun.faces.util.Util.isAnyNull;
 import static com.sun.faces.util.Util.isOneOf;
 import static java.util.Collections.emptyMap;
@@ -1253,6 +1254,100 @@ public abstract class UIComponent implements PartialStateHolder, TransientStateH
         }
         
         return found;
+    }
+
+    /**
+     * Private hash map, storing the mark ids - see {@link com.sun.faces.facelets.tag.jsf.ComponentSupport#MARK_CREATED} -
+     * of <b>all</b> tree descendants of this component together with their corresponding {@link UIComponent}s.
+     */
+    private Map<String, UIComponent> descendantMarkIdCache = new HashMap<String, UIComponent>();
+
+    /**
+     * Adds the mark id of the specified {@link UIComponent} <code>otherComponent</code> to the mark id cache of this component,
+     * including all its descendant mark ids. Changes are propagated up the component tree.
+     */
+    public void addToDescendantMarkIdCache(UIComponent otherComponent) {
+        String markId = (String) otherComponent.getAttributes().get(MARK_CREATED);
+        if (markId != null) {
+            addSingleDescendantMarkId(markId, otherComponent);
+        }
+        Map<String, UIComponent> otherMarkIds = otherComponent.getDescendantMarkIdCache();
+        if (!otherMarkIds.isEmpty()) {
+            addAllDescendantMarkIds(otherMarkIds);
+        }
+    }
+
+    /**
+     * Adds the specified <code>markId</code> and its corresponding {@link UIComponent} <code>otherComponent</code>
+     * to the mark id cache of this component. Changes are propagated up the component tree.
+     */
+    private void addSingleDescendantMarkId(String markId, UIComponent otherComponent) {
+        descendantMarkIdCache.put(markId, otherComponent);
+        UIComponent parent = getParent();
+        if (parent != null) {
+            parent.addSingleDescendantMarkId(markId, otherComponent);
+        }
+    }
+
+    /**
+     * Adds all specified <code>otherMarkIds</code> to the mark id cache of this component.
+     * Changes are propagated up the component tree.
+     */
+    private void addAllDescendantMarkIds(Map<String, UIComponent> otherMarkIds) {
+        descendantMarkIdCache.putAll(otherMarkIds);
+        UIComponent parent = getParent();
+        if (parent != null) {
+            parent.addAllDescendantMarkIds(otherMarkIds);
+        }
+    }
+
+    /**
+     * Removes the mark id of the specified {@link UIComponent} <code>otherComponent</code> from the mark id cache of this component,
+     * including all its descendant mark ids. Changes are propagated up the component tree.
+     */
+    public void removeFromDescendantMarkIdCache(UIComponent otherComponent) {
+        String markId = (String) otherComponent.getAttributes().get(MARK_CREATED);
+        if (markId != null) {
+            removeSingleDescendantMarkId(markId);
+        }
+        Map<String, UIComponent> otherMarkIds = otherComponent.getDescendantMarkIdCache();
+        if (!otherMarkIds.isEmpty()) {
+            removeAllDescendantMarkIds(otherMarkIds);
+        }
+    }
+
+    /**
+     * Removes the specified <code>markId</code> from the mark id cache of this component.
+     * Changes are propagated up the component tree.
+     */
+    private void removeSingleDescendantMarkId(String markId) {
+        descendantMarkIdCache.remove(markId);
+        UIComponent parent = getParent();
+        if (parent != null) {
+            parent.removeSingleDescendantMarkId(markId);
+        }
+    }
+
+    /**
+     * Removes all specified <code>otherMarkIds</code> from the mark id cache of this component.
+     * Changes are propagated up the component tree.
+     */
+    private void removeAllDescendantMarkIds(Map<String, UIComponent> otherMarkIds) {
+        Iterator<String> iterator = otherMarkIds.keySet().iterator();
+        while (iterator.hasNext()) {
+            descendantMarkIdCache.remove(iterator.next());
+        }
+        UIComponent parent = getParent();
+        if (parent != null) {
+            parent.removeAllDescendantMarkIds(otherMarkIds);
+        }
+    }
+
+    /**
+     * Returns the mark id cache of this component.
+     */
+    public Map<String, UIComponent> getDescendantMarkIdCache() {
+        return descendantMarkIdCache;
     }
     
 


### PR DESCRIPTION
Hi,

this is Marc from IBM. Not sure where the right place to say "Hello" is, so I will try here. Since I haven't contributed to Mojarra yet, let me quickly introduce myself. I am a Java Performance Analyst and work in the IBM Lab in Boeblingen, Germany. Nowadays, I spend most of my time improving the performance of IBM products, but I also have a long history of analyzing and optimizing the performance of customer Java applications.

One of our IBM Mainframe customers is running their COVID-19 tracing application based on Eclipse Mojarra and they asked me to analyze its performance, since they are struggling with the high amount of CPU that their application consumes. I found a number of tuning opportunities in the Mojarra code, and this patch here is one of them. Since the customer hasn't been able to test my patches yet, I can only provide an educated guess, but my expectation is that the combination of all patches will save ca. 20-25% of all Java method calls in the customer's situation.

Let me explain my `findChildByTagId()` patch a bit: In the original version of the code, the logic in `ComponentSupport.java` performs a BFS for the child with `MARK_ID` "id". While this works very well in small component trees, it quickly becomes quite a heavy call when the component tree underneath of the "parent" `UIComponent` is large. In the customer's situation, I have seen tree depths of up to 12 and breadths of the individual nodes of more than 140 in the traces. So you can imagine how many visits it may take until the search is complete. This is particularly heavy when the child doesn't exist and the entire tree has to be searched almost all of the time.

What my patch does is that it stores the `MARK_ID`s of **all** descendants of a `UIComponent` in a hash map that belongs to the component, along with references to the descendant components. I called this the `descendantMarkIdCache`. Now when `findChildByTagId()` is called in `ComponentSupport`, the only operation that has to be performed is a lookup the `descendantMarkIdCache` hash map of "parent". There is no more searching in the component tree.

Of course, remembering all descendants of a component in a hash map comes at a certain cost, but I have done a number of measurements in order to validate the effectiveness of my patch and the outcome was that it is still much cheaper compared to the current BFS approach. In one test case, the pages/sec throughput increased by ca. 23%, which is equivalent to ca. 18% savings in CPU consumption. The more complex - i.e. nested - the Facelet is, the more the `descendantMarkIdCache` pays off.

I still have to perform a more in depth analysis regarding the additional Java heap consumption caused by the `findChildByTagId()` patch, but from my initial cursory check the increase in heap consumption should be rather moderate.

I have run every Mojarra integration test that completed successfully without my patches also with my patches enabled: glassfish, javaee6/6web/7/8, servlet30/31/40. The outcome was that all integration tests passed successfully.

I am really looking forward to your comments on this patch!


Cheers,
Marc

Signed-off-by: Marc Beyerle <marc.beyerle@de.ibm.com>