### PR TITLE
Performance-optimized version of ResourceImpl.getURL()

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceImpl.java
@@ -101,6 +101,12 @@ public class ResourceImpl extends Resource implements Externalizable {
      */
     private long maxAge;
 
+    /**
+     * The URL of this {@link ResourceImpl} object is valid exactly as long as this {@link ResourceImpl} object itself is valid.
+     * Therefore, resolve the URL only once and re-use the already resolved URL value for subsequent calls to {@link ResourceImpl#getURL()}.
+     */
+    private URL resolvedUrl = null;
+
 
     // ------------------------------------------------------------ Constructors
 
@@ -165,7 +171,17 @@ public class ResourceImpl extends Resource implements Externalizable {
      */
     @Override
     public URL getURL() {
-        return resourceInfo.getHelper().getURL(resourceInfo, FacesContext.getCurrentInstance());
+        if (resolvedUrl != null) {
+            // fast path - re-use the already resolved url
+            return resolvedUrl;
+        }
+
+        URL url = resourceInfo.getHelper().getURL(resourceInfo, FacesContext.getCurrentInstance());
+
+        // remember this url for subsequent calls to this method
+        resolvedUrl = url;
+
+        return url;
     }
 
     /**


### PR DESCRIPTION
This is the second of my patches for the customer situation mentioned in pull request #4808. The idea of this patch here is rather simple: I noticed that in the customer's traces, there are a number of expensive, **twofold** `ResourceImpl.getURL()` calls on the _exact_ same `ResourceImpl` instance. Those expensive calls are caused by `ResourceImpl` calling `ClasspathResourceHelper.getURL()`, which in turn has to scan .jar files, etc.

My assumption is that the URL of a `ResourceImpl` instance doesn't change during the lifetime of a request. Note that I'm not proposing to statically cache a `ResourceImpl`'s URL. I only try to avoid performing a _second_ expensive call to `ClasspathResourceHelper.getURL()` inside of a `ResourceImpl` instance's `getURL()` method.

Even with my patch enabled, the URL of a `ResourceImpl` instance is determined every time a resource is accessed for the first time in a request. My patch only avoids the second - and all subsequent - URL resolutions.

Again, I have run every Mojarra integration test that completed successfully without my patches also with my patches enabled: glassfish, javaee6/6web/7/8, servlet30/31/40. The outcome was that all integration tests passed successfully.

Signed-off-by: Marc Beyerle <marc.beyerle@de.ibm.com>