### PR TITLE
[Issue 4812] New WARNING error message on undeploy when there are duplicate registrations of ConfigureListener

### DIFF
--- a/impl/src/main/java/com/sun/faces/config/ConfigureListener.java
+++ b/impl/src/main/java/com/sun/faces/config/ConfigureListener.java
@@ -359,10 +359,8 @@ public class ConfigureListener implements ServletRequestListener, HttpSessionLis
             if( configManager != null ) {
               configManager.destroy(context, initContext);
               ConfigManager.removeInstance(context);
-            } else {
-              if (LOGGER.isLoggable(WARNING)) {
-                  LOGGER.log(WARNING, "Unexpected state during contextDestroyed: no ConfigManager instance in current ServletContext but one is expected to exist.");
-              }
+            } else if (WebConfiguration.getInstanceWithoutCreating(context) != null && LOGGER.isLoggable(WARNING)) {
+                LOGGER.log(WARNING, "Unexpected state during contextDestroyed: no ConfigManager instance in current ServletContext but one is expected to exist.");
             }
             FactoryFinder.releaseFactories();
             ReflectionUtils.clearCache(Thread.currentThread().getContextClassLoader());


### PR DESCRIPTION
Fix for issue #4812 

As commented the same idea applied before for #3801 is used. The message is only displayed if the `WebConfiguration` instance is not null (if it is null then it was removed before by the first listener).

@arjantijms The PR is only sent to the 2.3 branch, if you need it to other branches (3.0 for example) please just let me know.