### PR TITLE
#4800: Resources: set cache-control-header instead of expires-header (JSF 2.3)

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceImpl.java
@@ -188,16 +188,11 @@ public class ResourceImpl extends Resource implements Externalizable {
                 responseHeaders = new HashMap<>(6, 1.0f);
             }
 
-            long expiresTime;
             if (FacesContext.getCurrentInstance().isProjectStage(Development)) {
-                expiresTime = new Date().getTime();
+                responseHeaders.put("Cache-Control", "no-store, must-revalidate");
             } else {
-                expiresTime = new Date().getTime() + maxAge;
+                responseHeaders.put("Cache-Control", "max-age=" + (maxAge/1000));
             }
-            
-            SimpleDateFormat format = new SimpleDateFormat(RFC1123_DATE_PATTERN, US);
-            format.setTimeZone(GMT);
-            responseHeaders.put("Expires", format.format(new Date(expiresTime)));
 
             URL url = getURL();
             InputStream in = null;
@@ -211,6 +206,8 @@ public class ResourceImpl extends Resource implements Externalizable {
                 if (lastModified == 0) {
                     lastModified = initialTime;
                 }
+                SimpleDateFormat format = new SimpleDateFormat(RFC1123_DATE_PATTERN, US);
+                format.setTimeZone(GMT);
                 responseHeaders.put("Last-Modified", format.format(new Date(lastModified)));
                 if (lastModified != 0 && contentLength != -1) {
                     responseHeaders.put("ETag", "W/\""

--- a/test/servlet30/resource/src/test/java/com/sun/faces/test/servlet30/resource/Issue2932IT.java
+++ b/test/servlet30/resource/src/test/java/com/sun/faces/test/servlet30/resource/Issue2932IT.java
@@ -45,6 +45,6 @@ public class Issue2932IT {
         assertEquals(200, page.getWebResponse().getStatusCode());
         assertNotNull(page.getWebResponse().getResponseHeaderValue("Last-Modified"));
         assertNotNull(page.getWebResponse().getResponseHeaderValue("ETag"));
-        assertNotNull(page.getWebResponse().getResponseHeaderValue("Expires"));
+        assertNotNull(page.getWebResponse().getResponseHeaderValue("Cache-Control"));
     }
 }

--- a/test/servlet31/resourcehandler/src/main/java/com/sun/faces/test/servlet31/resourcehandler/ResourceHandlerTestServlet.java
+++ b/test/servlet31/resourcehandler/src/main/java/com/sun/faces/test/servlet31/resourcehandler/ResourceHandlerTestServlet.java
@@ -401,7 +401,7 @@ public class ResourceHandlerTestServlet extends HttpServlet {
         response.getWriter().println(Arrays.equals(control, test));
         response.getWriter().println(wrapper.containsHeader("content-length"));
         response.getWriter().println(wrapper.containsHeader("last-modified"));
-        response.getWriter().println(wrapper.containsHeader("expires"));
+        response.getWriter().println(wrapper.containsHeader("cache-control"));
         response.getWriter().println(wrapper.containsHeader("etag"));
     }
     
@@ -419,7 +419,7 @@ public class ResourceHandlerTestServlet extends HttpServlet {
         response.getWriter().println(Arrays.equals(control, test));
         response.getWriter().println(wrapper.containsHeader("content-length"));
         response.getWriter().println(wrapper.containsHeader("last-modified"));
-        response.getWriter().println(wrapper.containsHeader("expires"));
+        response.getWriter().println(wrapper.containsHeader("cache-control"));
         response.getWriter().println(wrapper.containsHeader("etag"));
     }
     
@@ -514,7 +514,7 @@ public class ResourceHandlerTestServlet extends HttpServlet {
         response.getWriter().println(Arrays.equals(control, test));
         response.getWriter().println(wrapper.containsHeader("content-length"));
         response.getWriter().println(wrapper.containsHeader("last-modified"));
-        response.getWriter().println(wrapper.containsHeader("expires"));
+        response.getWriter().println(wrapper.containsHeader("cache-control"));
         response.getWriter().println(wrapper.containsHeader("etag"));
         response.getWriter().println(wrapper.containsHeader("content-encoding"));
     }
@@ -534,7 +534,7 @@ public class ResourceHandlerTestServlet extends HttpServlet {
         response.getWriter().println(Arrays.equals(control, test));
         response.getWriter().println(wrapper.containsHeader("content-length"));
         response.getWriter().println(wrapper.containsHeader("last-modified"));
-        response.getWriter().println(wrapper.containsHeader("expires"));
+        response.getWriter().println(wrapper.containsHeader("cache-control"));
         response.getWriter().println(wrapper.containsHeader("etag"));
         response.getWriter().println(wrapper.containsHeader("content-encoding"));
     }
@@ -553,7 +553,7 @@ public class ResourceHandlerTestServlet extends HttpServlet {
          response.getWriter().println(Arrays.equals(control, test));
          response.getWriter().println(wrapper.containsHeader("content-length"));
          response.getWriter().println(wrapper.containsHeader("last-modified"));
-         response.getWriter().println(wrapper.containsHeader("expires"));
+         response.getWriter().println(wrapper.containsHeader("cache-control"));
          response.getWriter().println(wrapper.containsHeader("etag"));
          response.getWriter().println(!wrapper.containsHeader("content-encoding"));
     }
@@ -569,7 +569,7 @@ public class ResourceHandlerTestServlet extends HttpServlet {
          response.getWriter().println(Arrays.equals(control, test));
          response.getWriter().println(wrapper.containsHeader("content-length"));
          response.getWriter().println(wrapper.containsHeader("last-modified"));
-         response.getWriter().println(wrapper.containsHeader("expires"));
+         response.getWriter().println(wrapper.containsHeader("cache-control"));
          response.getWriter().println(wrapper.containsHeader("etag"));
          response.getWriter().println(!wrapper.containsHeader("content-encoding"));
     }
@@ -590,7 +590,7 @@ public class ResourceHandlerTestServlet extends HttpServlet {
         response.getWriter().println(Arrays.equals(control, test));
         response.getWriter().println(wrapper.containsHeader("content-length"));
         response.getWriter().println(wrapper.containsHeader("last-modified"));
-        response.getWriter().println(wrapper.containsHeader("expires"));
+        response.getWriter().println(wrapper.containsHeader("cache-control"));
         response.getWriter().println(wrapper.containsHeader("etag"));
         response.getWriter().println(!wrapper.containsHeader("content-encoding"));
     }
@@ -614,7 +614,7 @@ public class ResourceHandlerTestServlet extends HttpServlet {
         response.getWriter().println(Arrays.equals(control, test));
         response.getWriter().println(wrapper.containsHeader("content-length"));
         response.getWriter().println(wrapper.containsHeader("last-modified"));
-        response.getWriter().println(wrapper.containsHeader("expires"));
+        response.getWriter().println(wrapper.containsHeader("cache-control"));
         response.getWriter().println(wrapper.containsHeader("etag"));
         response.getWriter().println(!wrapper.containsHeader("content-encoding"));
     }
@@ -634,7 +634,7 @@ public class ResourceHandlerTestServlet extends HttpServlet {
         response.getWriter().println(Arrays.equals(control, test));
         response.getWriter().println(wrapper.containsHeader("content-length"));
         response.getWriter().println(wrapper.containsHeader("last-modified"));
-        response.getWriter().println(wrapper.containsHeader("expires"));
+        response.getWriter().println(wrapper.containsHeader("cache-control"));
         response.getWriter().println(wrapper.containsHeader("etag"));
         response.getWriter().println(wrapper.containsHeader("content-encoding"));
     }
@@ -650,7 +650,7 @@ public class ResourceHandlerTestServlet extends HttpServlet {
         response.getWriter().println(Arrays.equals(control, test));
         response.getWriter().println(wrapper.containsHeader("content-length"));
         response.getWriter().println(wrapper.containsHeader("last-modified"));
-        response.getWriter().println(wrapper.containsHeader("expires"));
+        response.getWriter().println(wrapper.containsHeader("cache-control"));
         response.getWriter().println(wrapper.containsHeader("etag"));
         response.getWriter().println(!wrapper.containsHeader("content-encoding"));
     }


### PR DESCRIPTION
Signed-off-by: Christoph Straßer <christoph.strasser78@gmail.com>