### PR TITLE
#4820 Faces 3.0 Does Not Support JavaEE NameSpace in Flow.xml Files (forward port to 4.0)

### DIFF
--- a/impl/src/main/java/com/sun/faces/config/processor/FacesConfigNamespaceContext.java
+++ b/impl/src/main/java/com/sun/faces/config/processor/FacesConfigNamespaceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,9 +23,19 @@ import javax.xml.namespace.NamespaceContext;
 
 class FacesConfigNamespaceContext implements NamespaceContext {
 
+    private String defaultNamespace = null;
+
+    FacesConfigNamespaceContext() {
+        this.defaultNamespace = "https://jakarta.ee/xml/ns/jakartaee";
+    }
+
+    FacesConfigNamespaceContext(String namespace) {
+        this.defaultNamespace = namespace;
+    }
+
     @Override
     public String getNamespaceURI(String prefix) {
-        return "https://jakarta.ee/xml/ns/jakartaee";
+        return this.defaultNamespace;
     }
 
     @Override

--- a/impl/src/main/java/com/sun/faces/config/processor/FacesFlowDefinitionConfigProcessor.java
+++ b/impl/src/main/java/com/sun/faces/config/processor/FacesFlowDefinitionConfigProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -279,7 +279,7 @@ public class FacesFlowDefinitionConfigProcessor extends AbstractConfigProcessor 
         }
 
         XPath xpath = XPathFactory.newInstance().newXPath();
-        xpath.setNamespaceContext(new FacesConfigNamespaceContext());
+        xpath.setNamespaceContext(new FacesConfigNamespaceContext(namespace));
 
         String nameStr = "";
         NodeList nameList = (NodeList) xpath.evaluate("./ns1:name/text()", document.getDocumentElement(), XPathConstants.NODESET);

--- a/impl/src/test/java/com/sun/faces/config/processor/FacesConfigNamespaceContextTest.java
+++ b/impl/src/test/java/com/sun/faces/config/processor/FacesConfigNamespaceContextTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.config.processor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+public class FacesConfigNamespaceContextTest {
+
+	@Test
+	public void testJavaEENSWithoutParameter() throws ParserConfigurationException, XPathExpressionException {
+		Document docFlowConfig = createFacesConfig("simple", "http://xmlns.jcp.org/xml/ns/javaee", "2.2");
+		XPath xpath = XPathFactory.newInstance().newXPath();
+		xpath.setNamespaceContext(new FacesConfigNamespaceContext());
+		NodeList returns = (NodeList) xpath.evaluate(".//ns1:flow-return", docFlowConfig, XPathConstants.NODESET);
+		assertNotNull(returns);
+		// xpath fails to return nodes because namespace does not match
+		assertEquals(0, returns.getLength());
+	}
+
+	@Test
+	public void testJavaEENSWithParameter() throws ParserConfigurationException, XPathExpressionException {
+		Document docFlowConfig = createFacesConfig("simple", "http://xmlns.jcp.org/xml/ns/javaee", "2.2");
+		String namespace = docFlowConfig.getDocumentElement().getNamespaceURI();
+		XPath xpath = XPathFactory.newInstance().newXPath();
+		xpath.setNamespaceContext(new FacesConfigNamespaceContext(namespace));
+		NodeList returns = (NodeList) xpath.evaluate(".//ns1:flow-return", docFlowConfig, XPathConstants.NODESET);
+		assertNotNull(returns);
+		assertEquals(1, returns.getLength());
+	}
+
+	@Test
+	public void testJakartaEENSWithoutParameter() throws ParserConfigurationException, XPathExpressionException {
+		Document docFlowConfig = createFacesConfig("simple", "https://jakarta.ee/xml/ns/jakartaee", "3.0");
+		XPath xpath = XPathFactory.newInstance().newXPath();
+		xpath.setNamespaceContext(new FacesConfigNamespaceContext());
+		NodeList returns = (NodeList) xpath.evaluate(".//ns1:flow-return", docFlowConfig, XPathConstants.NODESET);
+		assertNotNull(returns);
+		assertEquals(1, returns.getLength());
+	}
+
+	@Test
+	public void testJakartaEENSWithParameter() throws ParserConfigurationException, XPathExpressionException {
+		Document docFlowConfig = createFacesConfig("simple", "https://jakarta.ee/xml/ns/jakartaee", "3.0");
+		String namespace = docFlowConfig.getDocumentElement().getNamespaceURI();
+		XPath xpath = XPathFactory.newInstance().newXPath();
+		xpath.setNamespaceContext(new FacesConfigNamespaceContext(namespace));
+		NodeList returns = (NodeList) xpath.evaluate(".//ns1:flow-return", docFlowConfig, XPathConstants.NODESET);
+		assertNotNull(returns);
+		assertEquals(1, returns.getLength());
+	}
+
+	private Document createFacesConfig(String flowName, String namespace, String version)
+			throws ParserConfigurationException {
+		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+		documentBuilderFactory.setNamespaceAware(true);
+		DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+		Document docFlowConfig = documentBuilder.newDocument();
+		Element eleFacesConfig = docFlowConfig.createElementNS(namespace, "faces-config");
+		eleFacesConfig.setAttribute("version", version);
+		Element flowDefinition = docFlowConfig.createElementNS(namespace, "flow-definition");
+		flowDefinition.setAttribute("id", flowName);
+		eleFacesConfig.appendChild(flowDefinition);
+		final String flowReturnStr = flowName + "-return";
+
+		Element flowReturn = docFlowConfig.createElementNS(namespace, "flow-return");
+		flowReturn.setAttribute("id", flowReturnStr);
+		flowDefinition.appendChild(flowReturn);
+
+		Element fromOutcome = docFlowConfig.createElementNS(namespace, "from-outcome");
+		flowReturn.appendChild(fromOutcome);
+		fromOutcome.setTextContent("/" + flowReturnStr);
+		docFlowConfig.appendChild(eleFacesConfig);
+		return docFlowConfig;
+	}
+
+}


### PR DESCRIPTION
Introduce a constructor to use given namespace instead of default

#4826 cherry-picked on master