### PR TITLE
Fix #4830: UIRepeat must clear var when finished

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/component/UIRepeat.java
+++ b/impl/src/main/java/com/sun/faces/facelets/component/UIRepeat.java
@@ -329,6 +329,18 @@ public class UIRepeat extends UINamingContainer {
         }
     }
 
+    private void clearValue(FacesContext ctx) {
+        if (var != null || varStatus != null) {
+            Map<String,Object> attrs = ctx.getExternalContext().getRequestMap();
+            if (var != null) {
+                attrs.remove(var);
+            }
+            if (varStatus != null) {
+                attrs.remove(varStatus);
+            }
+        }
+    }
+
     private Map<String, SavedState> childState;
 
     private Map<String, SavedState> getChildState() {
@@ -689,6 +701,7 @@ public class UIRepeat extends UINamingContainer {
             if (visitRows) {
                 setIndex(facesContext, oldRowIndex);
             }
+            clearValue(facesContext);
         }
 
         // Return false to allow the visit to continue


### PR DESCRIPTION
In the `finally` of visitTree the `var` must be removed from the context