### PR TITLE
Log throwables using throwable parameter in AjaxExceptionHandlerImpl

### DIFF
--- a/impl/src/main/java/com/sun/faces/context/AjaxExceptionHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/context/AjaxExceptionHandlerImpl.java
@@ -17,8 +17,6 @@
 package com.sun.faces.context;
 
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -178,10 +176,7 @@ public class AjaxExceptionHandlerImpl extends ExceptionHandlerWrapper {
             writer.endDocument();
 
             if (LOGGER.isLoggable(Level.SEVERE)) {
-                StringWriter sw = new StringWriter();
-                PrintWriter pw = new PrintWriter(sw);
-                t.printStackTrace(pw);
-                LOGGER.log(Level.SEVERE, sw.toString());
+                LOGGER.log(Level.SEVERE, t.toString(), t);
             }
 
             context.responseComplete();


### PR DESCRIPTION
```
Formatting the stacktrace of throwables into the log message prevents
analysis tools that integrate using log handlers from analyzing the
exception properly. Log using the Throwable parameter instead, which
should look almost the same in classical text logs, but enables
analytics using log handler integrations to work properly.

Fixes #4839
```

---

In #4839 I was instructed to open a PR for this and add tests. However, I don't quite know how I would go about testing logging output.

I am happy to add a test if you can point me to a similar test already in the repo. Otherwise I believe the change is small and obvious enough to be mergeable as-is.