### PR TITLE
Fix failing f:websocket tests because of HtmlUnit internal issues

### DIFF
--- a/test2/faces23/websocket/pom.xml
+++ b/test2/faces23/websocket/pom.xml
@@ -32,6 +32,6 @@
     <name>Mojarra ${project.version} - Test - Faces 2.3 - websocket</name>
 
     <build>
-        <finalName>test-faces23-getviews</finalName>
+        <finalName>test-faces23-websocket</finalName>
     </build>
 </project>

--- a/test2/faces23/websocket/src/main/webapp/WEB-INF/web.xml
+++ b/test2/faces23/websocket/src/main/webapp/WEB-INF/web.xml
@@ -19,7 +19,7 @@
 
 <web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee web-app_3_1.xsd"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
          version="3.1"
 >
     <context-param>

--- a/test2/faces23/websocket/src/main/webapp/spec1396DefaultWebsocket.xhtml
+++ b/test2/faces23/websocket/src/main/webapp/spec1396DefaultWebsocket.xhtml
@@ -20,28 +20,23 @@
 <html lang="en"
     xmlns="http://www.w3.org/1999/xhtml"
     xmlns:f="http://xmlns.jcp.org/jsf/core"
-    xmlns:h="http://xmlns.jcp.org/jsf/html"
->
+    xmlns:h="http://xmlns.jcp.org/jsf/html">
+
+
+
     <h:head>
-        <title>Issue4332IT - websocket with sync post</title>
+        <title>Spec1396IT - websocket - default</title>
     </h:head>
     <h:body>
         <h:form id="form">
-            <h:commandButton id="postback" value="postback" />
-            <h:commandButton id="button" value="push" action="#{issue4332.send}"><f:ajax /></h:commandButton>
+            <h:commandButton id="button" value="push" action="#{spec1396.send}"><f:ajax /></h:commandButton>
         </h:form>
-
-        <script>
-            function onmessageFunction(message) {
-                document.getElementById("message").value = message;
-            }
-        </script>
 
         <div id="opened" />
         <div id="message" />
 
         <f:websocket channel="push"
             onopen="function(){document.getElementById('opened').innerHTML='yes';}"
-            onmessage="onmessageFunction" />
+            onmessage="function(message){document.getElementById('message').innerHTML=message;}" />
     </h:body>
 </html>

--- a/test2/faces23/websocket/src/main/webapp/spec1396UserScopedWebsocket.xhtml
+++ b/test2/faces23/websocket/src/main/webapp/spec1396UserScopedWebsocket.xhtml
@@ -25,21 +25,18 @@
 
 
     <h:head>
-        <title>Spec1396IT - websocket</title>
+        <title>Spec1396IT - websocket - user scoped</title>
     </h:head>
     <h:body>
         <h:form id="form">
             <h:commandButton id="button" value="push" action="#{spec1396.send}"><f:ajax /></h:commandButton>
         </h:form>
 
-        <f:websocket channel="push" onmessage="function(message){document.getElementById('form:button').value=message;}" />
-        
-        <div id="user" />
-        <f:websocket channel="user" user="user" onmessage="function(message){document.getElementById('user').innerHTML=message;}" />
+        <div id="opened" />
+        <div id="message" />
 
-        <h:outputText id="ajaxOutput" value="#{spec1396.ajaxOutput}" />
-        <f:websocket channel="view" scope="view">
-            <f:ajax event="renderAjaxOutput" render="ajaxOutput" />
-        </f:websocket>
+        <f:websocket channel="user" user="user" 
+            onopen="function(){document.getElementById('opened').innerHTML='yes';}"
+            onmessage="function(message){document.getElementById('message').innerHTML=message;}" />
     </h:body>
 </html>

--- a/test2/faces23/websocket/src/main/webapp/spec1396ViewScopedWebsocket.xhtml
+++ b/test2/faces23/websocket/src/main/webapp/spec1396ViewScopedWebsocket.xhtml
@@ -20,28 +20,23 @@
 <html lang="en"
     xmlns="http://www.w3.org/1999/xhtml"
     xmlns:f="http://xmlns.jcp.org/jsf/core"
-    xmlns:h="http://xmlns.jcp.org/jsf/html"
->
+    xmlns:h="http://xmlns.jcp.org/jsf/html">
+
+
+
     <h:head>
-        <title>Issue4332IT - websocket with sync post</title>
+        <title>Spec1396IT - websocket - view scoped</title>
     </h:head>
     <h:body>
         <h:form id="form">
-            <h:commandButton id="postback" value="postback" />
-            <h:commandButton id="button" value="push" action="#{issue4332.send}"><f:ajax /></h:commandButton>
+            <h:commandButton id="button" value="push" action="#{spec1396.send}"><f:ajax /></h:commandButton>
         </h:form>
 
-        <script>
-            function onmessageFunction(message) {
-                document.getElementById("message").value = message;
-            }
-        </script>
-
         <div id="opened" />
-        <div id="message" />
+        <div id="message"><h:outputText id="ajaxOutput" value="#{spec1396.ajaxOutput}" /></div>
 
-        <f:websocket channel="push"
-            onopen="function(){document.getElementById('opened').innerHTML='yes';}"
-            onmessage="onmessageFunction" />
+        <f:websocket channel="view" scope="view" onopen="function(){document.getElementById('opened').innerHTML='yes';}">
+            <f:ajax event="renderAjaxOutput" render="ajaxOutput" />
+        </f:websocket>
     </h:body>
 </html>


### PR DESCRIPTION
Currently used HtmlUnit version appears to be unable to wait until a websocket is opened and also to dislike having more than one websocket open in same session. So tests had to be split. While at it, tests have also been polished.