### PR TITLE
#4881 Empty lists are discarded during state-saving

### DIFF
--- a/impl/src/main/java/javax/faces/component/ComponentStateHelper.java
+++ b/impl/src/main/java/javax/faces/component/ComponentStateHelper.java
@@ -204,7 +204,9 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
             defaultMap.put(key, items);
         }
         
-        items.add(value);
+        if (value != null) {
+            items.add(value);
+        }
     }
 
     /**
@@ -291,15 +293,27 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
             }
             
             if (value instanceof Map) {
-                for (Map.Entry<String, Object> entry : ((Map<String, Object>) value).entrySet()) {
-                    put(serializable, entry.getKey(), entry.getValue());
+                Map<?,?> values = (Map<?,?>)value;
+
+                if (values.size() > 0) {
+                    for (Map.Entry<String, Object> entry : ((Map<String, Object>) value).entrySet()) {
+                        put(serializable, entry.getKey(), entry.getValue());
+                    }
+                }
+                else {
+                    put(serializable, null, null); // TODO - WIP
                 }
             } else if (value instanceof List) {
                 defaultMap.remove(serializable);
                 deltaMap.remove(serializable);
-                
+
                 List<?> values = (List<?>) value;
-                values.stream().forEach(o -> add(serializable, o));
+                if (values.size() > 0) {
+                    values.stream().forEach(o -> add(serializable, o));
+                }
+                else {
+                    add(serializable, null); // TODO - WIP
+                }
             } else {
                 put(serializable, value);
                 handleAttribute(serializable.toString(), value);

--- a/impl/src/main/java/javax/faces/component/ComponentStateHelper.java
+++ b/impl/src/main/java/javax/faces/component/ComponentStateHelper.java
@@ -305,7 +305,7 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
                     }
                 }
                 else {
-                    put(serializable, null, null); // TODO - WIP
+                    // TODO - how to handle maps without entries?
                 }
             } else if (value instanceof List) {
                 defaultMap.remove(serializable);

--- a/impl/src/main/java/javax/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/javax/faces/component/UIComponentBase.java
@@ -1328,15 +1328,12 @@ public abstract class UIComponentBase extends UIComponent {
 
         if (newWillSucceed && attachedObject instanceof Collection) {
             Collection attachedCollection = (Collection) attachedObject;
-            List<StateHolderSaver> resultList = null;
+            List<StateHolderSaver> resultList = new ArrayList<>(attachedCollection.size() + 1);
+            resultList.add(new StateHolderSaver(context, mapOrCollectionClass));
             for (Object item : attachedCollection) {
                 if (item != null) {
                     if (item instanceof StateHolder && ((StateHolder) item).isTransient()) {
                         continue;
-                    }
-                    if (resultList == null) {
-                        resultList = new ArrayList<>(attachedCollection.size() + 1);
-                        resultList.add(new StateHolderSaver(context, mapOrCollectionClass));
                     }
                     resultList.add(new StateHolderSaver(context, item));
                 }
@@ -1344,7 +1341,8 @@ public abstract class UIComponentBase extends UIComponent {
             result = resultList;
         } else if (newWillSucceed && attachedObject instanceof Map) {
             Map<Object, Object> attachedMap = (Map<Object, Object>) attachedObject;
-            List<StateHolderSaver> resultList = null;
+            List<StateHolderSaver> resultList = new ArrayList<>(attachedMap.size() * 2 + 1);
+            resultList.add(new StateHolderSaver(context, mapOrCollectionClass));
             Object key, value;
             for (Map.Entry<Object, Object> entry : attachedMap.entrySet()) {
                 key = entry.getKey();
@@ -1354,10 +1352,6 @@ public abstract class UIComponentBase extends UIComponent {
                 value = entry.getValue();
                 if (value instanceof StateHolder && ((StateHolder) value).isTransient()) {
                     continue;
-                }
-                if (resultList == null) {
-                    resultList = new ArrayList<>(attachedMap.size() * 2 + 1);
-                    resultList.add(new StateHolderSaver(context, mapOrCollectionClass));
                 }
                 resultList.add(new StateHolderSaver(context, key));
                 resultList.add(new StateHolderSaver(context, value));


### PR DESCRIPTION
Compare with MyFaces BehaviorBase#restoreAttachedState as reference.
https://github.com/apache/myfaces/blob/master/api/src/main/java/jakarta/faces/component/behavior/BehaviorBase.java#L198

PrimeFaces-issues related to this PR:
primefaces/primefaces#7026
primefaces/primefaces#7181
primefaces/primefaces#6427

After this is merged we should do the same for master. (=4.0)