### PR TITLE
CDI - make sure current state works with CDI 4.

### DIFF
--- a/impl/src/main/java/com/sun/faces/cdi/CdiProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CdiProducer.java
@@ -148,12 +148,7 @@ abstract class CdiProducer<T> implements Bean<T>, PassivationCapable, Serializab
         return false;
     }
 
-    /**
-     * Is this nullable.
-     *
-     * @return false.
-     */
-    @Override
+    // TODO to be removed once using CDI API 4.x
     public boolean isNullable() {
         return false;
     }

--- a/impl/src/main/java/com/sun/faces/push/WebsocketSessionManager.java
+++ b/impl/src/main/java/com/sun/faces/push/WebsocketSessionManager.java
@@ -282,8 +282,8 @@ public class WebsocketSessionManager {
 
     private static void fireEvent(Session session, CloseReason reason, AnnotationLiteral<?> qualifier) {
         Serializable user = (Serializable) session.getUserProperties().get("user");
-        Util.getCdiBeanManager(FacesContext.getCurrentInstance())
-                .fireEvent(new WebsocketEvent(getChannel(session), user, reason != null ? reason.getCloseCode() : null), qualifier);
+        Util.getCdiBeanManager(FacesContext.getCurrentInstance()).getEvent().select(WebsocketEvent.class, qualifier)
+                .fire(new WebsocketEvent(getChannel(session), user, reason != null ? reason.getCloseCode() : null));
     }
 
 }


### PR DESCRIPTION
I was testing WFLY with latest CDI API (4.0.0.Alpha1) where there was a number of removals of long deprecated methods.
See eclipse-ee4j/cdi#472

This causes mojarra to crash during TCK runs so I had to create a custom artifact and replace it within WFLY - this PR a sum of changes I needed to make it work.

Since you are bound to eventually bounce into the very same issue, I thought I might as well contribute. But whether you accept it or not is OFC completely up to you :-)

Oh and I should note - the current state of this PR will work with CDI 2/3 as well as CDI 4 so there should be no harm in having it applied right away.