### PR TITLE
JSF 2.3: javax.faces.FacesException: Unable to find CDI BeanManager

### DIFF
--- a/impl/src/main/java/com/sun/faces/el/ELUtils.java
+++ b/impl/src/main/java/com/sun/faces/el/ELUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -207,7 +207,7 @@ public class ELUtils {
         if (beanManager == null) {
             // TODO: use version enum and >=
             if (getFacesConfigXmlVersion(facesContext).equals("2.3") || getWebXmlVersion(facesContext).equals("4.0")) {
-                throw new FacesException("Unable to find CDI BeanManager");
+                return false;
             }
         } else {
             CdiExtension cdiExtension = getBeanReference(beanManager, CdiExtension.class);


### PR DESCRIPTION
With JSF 2.3 there is one exception that does not allow the web application to start:

```
<Sep 30, 2020, 9:04:50,584 AM Pacific Daylight Time> <Error> <javax.enterprise.resource.webcontainer.jsf.config> <BEA-000000> <Critical error during deployment: 

javax.faces.FacesException: Unable to find CDI BeanManager
    at com.sun.faces.el.ELUtils.tryAddCDIELResolver(ELUtils.java:288)
    at com.sun.faces.el.ELUtils.buildFacesResolver(ELUtils.java:218)
    at com.sun.faces.application.ApplicationAssociate.initializeELResolverChains(ApplicationAssociate.java:467)
    at com.sun.faces.application.applicationimpl.ExpressionLanguage.performOneTimeELInitialization(ExpressionLanguage.java:188)
    at com.sun.faces.application.applicationimpl.ExpressionLanguage.getELResolver(ExpressionLanguage.java:122)
    Truncated. see log file for complete stacktrace
> 
<Sep 30, 2020, 9:04:50,587 AM Pacific Daylight Time> <Warning> <HTTP> <BEA-101162> <User defined listener com.sun.faces.config.ConfigureListener failed: java.lang.RuntimeException: javax.faces.FacesException: Unable to find CDI BeanManager.
java.lang.RuntimeException: javax.faces.FacesException: Unable to find CDI BeanManager
    at com.sun.faces.config.ConfigureListener.contextInitialized(ConfigureListener.java:284)
    at weblogic.servlet.internal.EventsManager$FireContextListenerAction.run(EventsManager.java:719)
    at weblogic.security.acl.internal.AuthenticatedSubject.doAs(AuthenticatedSubject.java:344)
    at weblogic.security.service.SecurityManager.runAsForUserCode(SecurityManager.java:197)
    at weblogic.servlet.provider.WlsSecurityProvider.runAsForUserCode(WlsSecurityProvider.java:203)
    Truncated. see log file for complete stacktrace
Caused By: javax.faces.FacesException: Unable to find CDI BeanManager
    at com.sun.faces.el.ELUtils.tryAddCDIELResolver(ELUtils.java:288)
    at com.sun.faces.el.ELUtils.buildFacesResolver(ELUtils.java:218)
    at com.sun.faces.application.ApplicationAssociate.initializeELResolverChains(ApplicationAssociate.java:467)
    at com.sun.faces.application.applicationimpl.ExpressionLanguage.performOneTimeELInitialization(ExpressionLanguage.java:188)
    at com.sun.faces.application.applicationimpl.ExpressionLanguage.getELResolver(ExpressionLanguage.java:122)
    Truncated. see log file for complete stacktrace
> 
<Sep 30, 2020, 9:04:50,631 AM Pacific Daylight Time> <Error> <Deployer> <BEA-149231> <Unable to set the activation state to true for the application "EmptyCDIWebApp".
weblogic.application.ModuleException: javax.faces.FacesException: Unable to find CDI BeanManager
    at weblogic.application.internal.ExtensibleModuleWrapper.start(ExtensibleModuleWrapper.java:140)
    at weblogic.application.internal.flow.ModuleListenerInvoker.start(ModuleListenerInvoker.java:124)
    at weblogic.application.internal.flow.ModuleStateDriver$3.next(ModuleStateDriver.java:233)
    at weblogic.application.internal.flow.ModuleStateDriver$3.next(ModuleStateDriver.java:228)
    at weblogic.application.utils.StateMachineDriver.nextState(StateMachineDriver.java:45)
    Truncated. see log file for complete stacktrace
Caused By: javax.faces.FacesException: Unable to find CDI BeanManager
    at com.sun.faces.el.ELUtils.tryAddCDIELResolver(ELUtils.java:288)
    at com.sun.faces.el.ELUtils.buildFacesResolver(ELUtils.java:218)
    at com.sun.faces.application.ApplicationAssociate.initializeELResolverChains(ApplicationAssociate.java:467)
    at com.sun.faces.application.applicationimpl.ExpressionLanguage.performOneTimeELInitialization(ExpressionLanguage.java:188)
    at com.sun.faces.application.applicationimpl.ExpressionLanguage.getELResolver(ExpressionLanguage.java:122)
    Truncated. see log file for complete stacktrace
```
It doesn’t seem to matter if we use the implicit resolver.

Applying this fix the application is working.