### PR TITLE
JSF 2.3: Query param values containing equals sign not correctly parsed in NavigationHandlerImpl findImplicitMatch

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/NavigationHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/NavigationHandlerImpl.java
@@ -875,7 +875,7 @@ public class NavigationHandlerImpl extends ConfigurableNavigationHandler {
 
                 String[] queryElements = Util.split(appMap, queryString, "&amp;|&");
                 for (int i = 0, len = queryElements.length; i < len; i++) {
-                    String[] elements = Util.split(appMap, queryElements[i], "=");
+                    String[] elements = Util.split(appMap, queryElements[i], "=", 2);
                     if (elements.length == 2) {
                         String rightHandSide = elements[1];
                         String sanitized = null != rightHandSide && 2 < rightHandSide.length() ? rightHandSide.trim() : "";

--- a/impl/src/main/java/com/sun/faces/util/Util.java
+++ b/impl/src/main/java/com/sun/faces/util/Util.java
@@ -982,7 +982,6 @@ public class Util {
         return fd;
     }
    
-
     /**
      * <p>A slightly more efficient version of 
      * <code>String.split()</code> which caches
@@ -995,13 +994,29 @@ public class Util {
      * @return the result of <code>Pattern.spit(String, int)</code>
      */
     public synchronized static String[] split(Map<String, Object> appMap, String toSplit, String regex) {
+        return split(appMap, toSplit, regex, 0);
+    }
+    
+    /**
+     * <p>A slightly more efficient version of 
+     * <code>String.split()</code> which caches
+     * the <code>Pattern</code>s in an LRUMap instead of
+     * creating a new <code>Pattern</code> on each
+     * invocation. Limited by splitLimit.</p>
+     * @param appMap the Application Map
+     * @param toSplit the string to split
+     * @param regex the regex used for splitting
+     * @param splitLimit split result threshold
+     * @return the result of <code>Pattern.spit(String, int)</code>
+     */
+    public synchronized static String[] split(Map<String, Object> appMap, String toSplit, String regex, int splitLimit) {
         Map<String, Pattern> patternCache = getPatternCache(appMap);
         Pattern pattern = patternCache.get(regex);
         if (pattern == null) {
             pattern = Pattern.compile(regex);
             patternCache.put(regex, pattern);
         }
-        return  pattern.split(toSplit, 0);
+        return  pattern.split(toSplit, splitLimit);
     }
 
      public synchronized static String[] split(ServletContext sc,

--- a/impl/src/main/java/com/sun/faces/util/Util.java
+++ b/impl/src/main/java/com/sun/faces/util/Util.java
@@ -1016,7 +1016,7 @@ public class Util {
             pattern = Pattern.compile(regex);
             patternCache.put(regex, pattern);
         }
-        return  pattern.split(toSplit, splitLimit);
+        return pattern.split(toSplit, splitLimit);
     }
 
      public synchronized static String[] split(ServletContext sc,
@@ -1027,7 +1027,7 @@ public class Util {
             pattern = Pattern.compile(regex);
             patternCache.put(regex, pattern);
         }
-        return  pattern.split(toSplit, 0);
+        return pattern.split(toSplit, 0);
     }
 
 

--- a/impl/src/main/java/com/sun/faces/util/Util.java
+++ b/impl/src/main/java/com/sun/faces/util/Util.java
@@ -118,7 +118,7 @@ public class Util {
     /**
      * RegEx patterns
      */
-    private static final String PATTERN_CACKE_KEY = RIConstants.FACES_PREFIX + "patternCache";
+    private static final String PATTERN_CACHE_KEY = RIConstants.FACES_PREFIX + "patternCache";
     
     private static final String FACES_SERVLET_CLASS = FacesServlet.class.getName();
 
@@ -129,10 +129,10 @@ public class Util {
 
     private static Map<String, Pattern> getPatternCache(Map<String, Object> appMap) {
         @SuppressWarnings("unchecked")
-        Map<String, Pattern> result = (Map<String, Pattern>) appMap.get(PATTERN_CACKE_KEY);
+        Map<String, Pattern> result = (Map<String, Pattern>) appMap.get(PATTERN_CACHE_KEY);
         if (result == null) {
             result = new LRUMap<>(15);
-            appMap.put(PATTERN_CACKE_KEY, result);
+            appMap.put(PATTERN_CACHE_KEY, result);
         }
         
         return result;
@@ -140,10 +140,10 @@ public class Util {
 
     private static Map<String, Pattern> getPatternCache(ServletContext sc) {
         @SuppressWarnings("unchecked")
-        Map<String, Pattern> result = (Map<String, Pattern>) sc.getAttribute(PATTERN_CACKE_KEY);
+        Map<String, Pattern> result = (Map<String, Pattern>) sc.getAttribute(PATTERN_CACHE_KEY);
         if (result == null) {
             result = new LRUMap<>(15);
-            sc.setAttribute(PATTERN_CACKE_KEY, result);
+            sc.setAttribute(PATTERN_CACHE_KEY, result);
         }
 
         return result;

--- a/impl/src/test/java/com/sun/faces/util/TestUtil_local.java
+++ b/impl/src/test/java/com/sun/faces/util/TestUtil_local.java
@@ -17,11 +17,13 @@
 // TestUtil_local.java
 package com.sun.faces.util;
 
-import junit.framework.TestCase;
-
+import java.util.HashMap;
 import java.util.Locale;
+import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.fail;
+
+import junit.framework.TestCase;
 
 /**
  * <B>TestUtil_local.java</B> is a class ...
@@ -93,6 +95,22 @@ public class TestUtil_local extends TestCase {
             Util.getLocaleFromString("12-");
         } catch (Exception exception) {
         }
+    }
+    
+    public void testSplit() {
+        String[] result = null;
+        
+        result = Util.split(new HashMap<String,Object>(), "fooBarKey=Zm9vQmFyVmFsdWU====", "=", 2);
+        assertEquals(2, result.length);
+        assertEquals(result[1], "Zm9vQmFyVmFsdWU====");
+        
+        result = Util.split(new HashMap<String,Object>(), "fooBarKey=Zm9vQmFyVmFsdWU=", "=", 2);
+        assertEquals(2, result.length);
+        assertEquals(result[1], "Zm9vQmFyVmFsdWU=");
+        
+        result = Util.split(new HashMap<String,Object>(), "fooBarKey2=Zm9vQmFyVmFsdWUy", "=", 2);
+        assertEquals(2, result.length);
+        assertEquals(result[1], "Zm9vQmFyVmFsdWUy");
     }
 
 } // end of class TestUtil_local


### PR DESCRIPTION
URI query parameters are allowed to contain non-escaped equals signs. The existing method that splits the values between the ampersands of the query fragment defaults to a limit of 0, which will result in a string array of unlimited length:

From [NavigationHandlerImpl.java](https://github.com/eclipse-ee4j/mojarra/blob/master/impl/src/main/java/com/sun/faces/application/NavigationHandlerImpl.java):

`String[] elements = Util.split(appMap, queryElements[i], "=");`

and from [Util.java](https://github.com/eclipse-ee4j/mojarra/blob/master/impl/src/main/java/com/sun/faces/util/Util.java):

```
public synchronized static String[] split(Map<String, Object> appMap, String toSplit, String regex) {
        Map<String, Pattern> patternCache = getPatternCache(appMap);
        Pattern pattern = patternCache.get(regex);
        if (pattern == null) {
            pattern = Pattern.compile(regex);
            patternCache.put(regex, pattern);
        }
        return pattern.split(toSplit, 0);
    }
```

Additionally, if using key=value convention in the query parameters and the value portion is a padded hash or similar that ends in one or more equals signs, the trailing equals signs are silently stripped from the end of the value (e.g. "Zm9vQmFyVmFsdWU=" becomes "Zm9vQmFyVmFsdWU"). While the missing padding won't always be an issue, it can be if the application is expecting to exactly match a string value.

A fix for this issue would be to only split on the first equals sign in the parameter, leaving any other equals signs untouched in the value. This PR overloads the existing Util.split method with an optional splitLimit instead of the current default of 0, thought it leaves the existing Util.split signature in place with a limit of 0.

This PR also includes a minor typo fix in the Util class - `PATTERN_CACKE_KEY` renamed to `PATTERN_CACHE_KEY`.

My particular use case is with 2.3, but if this PR is acceptable I'm happy to create PRs for master and 3.0, as well.