### PR TITLE
Fixed copypaste mistake in UIComponentBase#subscribeToEvent() javadoc

### DIFF
--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -733,8 +733,8 @@ public abstract class UIComponentBase extends UIComponent {
      * <p class="changed_modified_4_0">
      * The listener instance referenced by argument <code>componentListener</code> may not already be installed as a listener for events of type
      * <code>eventClass</code> originating from this specific instance of <code>UIComponent</code>. When doing the
-     * comparison to determine if an existing listener is equal to the argument <code>componentListener</code> (and thus
-     * must be removed), the <code>equals()</code> method on the <em>existing listener</em> must be invoked, passing the
+     * comparison to determine if an existing listener is equal to the argument <code>componentListener</code>,
+     * the <code>equals()</code> method on the <em>existing listener</em> must be invoked, passing the
      * argument <code>componentListener</code>, rather than the other way around.
      * </p>
      *


### PR DESCRIPTION
Fixed copypaste mistake in javadoc; it was copypasted from
unsubscribeFromEvent() method but not fully readjusted

https://github.com/eclipse-ee4j/faces-api/issues/1558