### PR TITLE
Continue renaming remaining occurrences of old names

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/ConverterPropertyEditorBase.java
+++ b/impl/src/main/java/com/sun/faces/application/ConverterPropertyEditorBase.java
@@ -65,7 +65,7 @@ public abstract class ConverterPropertyEditorBase extends PropertyEditorSupport 
         Object appAssociate = facesContextClass.getMethod("getCurrentInstance").invoke(null);
 
         if (appAssociate == null) {
-            throw new IllegalStateException("Unable to find Deployed JSF Application.  You're deployment environment may not support"
+            throw new IllegalStateException("Unable to find Deployed Faces Application.  You're deployment environment may not support"
                     + "ConverterPropertyEditors.  Try restarting your server or turn off " + "com.sun.faces.registerConverterPropertyEditors");
         }
 

--- a/impl/src/main/java/com/sun/faces/application/NavigationHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/NavigationHandlerImpl.java
@@ -603,7 +603,7 @@ public class NavigationHandlerImpl extends ConfigurableNavigationHandler {
 
         // If the navigation rules do not have a match...
         if (caseStruct == null && outcome != null && viewId != null) {
-            // Treat empty string equivalent to null outcome. JSF 2.0 Rev a
+            // Treat empty string equivalent to null outcome. Faces 2.0 Rev a
             // Changelog issue C063.
             if (0 == outcome.length()) {
                 outcome = null;

--- a/impl/src/main/java/com/sun/faces/application/applicationimpl/InstanceFactory.java
+++ b/impl/src/main/java/com/sun/faces/application/applicationimpl/InstanceFactory.java
@@ -882,7 +882,7 @@ public class InstanceFactory {
 
     /**
      * <p>
-     * To enable EL Coercion to use JSF Custom converters, this method will call
+     * To enable EL Coercion to use Faces Custom converters, this method will call
      * <code>PropertyEditorManager.registerEditor()</code>, passing the <code>ConverterPropertyEditor</code> class for the
      * <code>targetClass</code> if the target class is not one of the standard by-type converter target classes.
      *

--- a/impl/src/main/java/com/sun/faces/application/applicationimpl/Version.java
+++ b/impl/src/main/java/com/sun/faces/application/applicationimpl/Version.java
@@ -29,7 +29,7 @@ public class Version {
     private Boolean isFaces23;
 
     /**
-     * Are we running in JSF 2.3+
+     * Are we running in Faces 2.3+
      *
      * @return true if we are, false otherwise.
      */
@@ -40,7 +40,7 @@ public class Version {
             if (beanManager == null) {
                 isFaces23 = false;
             } else {
-                isFaces23 = getBeanReference(beanManager, CdiExtension.class).isAddBeansForJSFImplicitObjects();
+                isFaces23 = getBeanReference(beanManager, CdiExtension.class).isAddBeansForFacesImplicitObjects();
             }
         }
 

--- a/impl/src/main/java/com/sun/faces/application/resource/ClientResourceInfo.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ClientResourceInfo.java
@@ -204,7 +204,7 @@ public class ClientResourceInfo extends ResourceInfo {
         if (library == null && localePrefix != null) {
             sb.append('/').append(localePrefix);
         }
-        // Specialcasing for handling JSF script in uncompressed state
+        // Specialcasing for handling Faces script in uncompressed state
         if (isDevStage && FACES_SCRIPT_LIBRARY_NAME.equals(libraryName) && FACES_SCRIPT_RESOURCE_NAME.equals(name)) {
             sb.append('/').append("faces-uncompressed.js");
         } else {

--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceHelper.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceHelper.java
@@ -389,7 +389,7 @@ public abstract class ResourceHelper {
      *
      * <p>
      * Implementation Note: It is safe to cast to a <code>HttpServletResponse</code> as this method will only be called when
-     * handling a resource request. Resource serving is outside of the JSF and Portlet lifecycle.
+     * handling a resource request. Resource serving is outside of the Faces and Portlet lifecycle.
      * </p>
      *
      * @param ctx the {@link FacesContext} for the current request

--- a/impl/src/main/java/com/sun/faces/cdi/CdiExtension.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CdiExtension.java
@@ -65,7 +65,7 @@ public class CdiExtension implements Extension {
 
     private Set<Type> managedPropertyTargetTypes = new HashSet<>();
 
-    private boolean addBeansForJSFImplicitObjects;
+    private boolean addBeansForFacesImplicitObjects;
 
     /**
      * Stores the logger.
@@ -89,7 +89,7 @@ public class CdiExtension implements Extension {
      * @param afterBeanDiscovery the after bean discovery.
      */
     public void afterBean(final @Observes AfterBeanDiscovery afterBeanDiscovery, BeanManager beanManager) {
-        if (addBeansForJSFImplicitObjects) {
+        if (addBeansForFacesImplicitObjects) {
             afterBeanDiscovery.addBean(new ApplicationProducer());
             afterBeanDiscovery.addBean(new ApplicationMapProducer());
             afterBeanDiscovery.addBean(new CompositeComponentProducer());
@@ -225,12 +225,12 @@ public class CdiExtension implements Extension {
         return forClassToDataModelClass;
     }
 
-    public boolean isAddBeansForJSFImplicitObjects() {
-        return addBeansForJSFImplicitObjects;
+    public boolean isAddBeansForFacesImplicitObjects() {
+        return addBeansForFacesImplicitObjects;
     }
 
     public void setAddBeansForJSFImplicitObjects(boolean addBeansForJSFImplicitObjects) {
-        this.addBeansForJSFImplicitObjects = addBeansForJSFImplicitObjects;
+        this.addBeansForFacesImplicitObjects = addBeansForJSFImplicitObjects;
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/CdiProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CdiProducer.java
@@ -107,7 +107,7 @@ abstract class CdiProducer<T> implements Bean<T>, PassivationCapable, Serializab
      * Destroy the instance.
      *
      * <p>
-     * Since most artifact that the sub classes are producing are artifacts that the JSF runtime really is managing the
+     * Since most artifact that the sub classes are producing are artifacts that the Faces runtime really is managing the
      * destroy method here does not need to do anything.
      * </p>
      *

--- a/impl/src/main/java/com/sun/faces/config/ConfigureListener.java
+++ b/impl/src/main/java/com/sun/faces/config/ConfigureListener.java
@@ -400,7 +400,7 @@ public class ConfigureListener implements ServletRequestListener, HttpSessionLis
      * included in WEB-INF are modified.
      */
     private void reload(ServletContext servletContext) {
-        LOGGER.log(INFO, () -> format("Reloading JSF configuration for context {0}", servletContext.getContextPath()));
+        LOGGER.log(INFO, () -> format("Reloading Faces configuration for context {0}", servletContext.getContextPath()));
 
         // tear down the application
         try {

--- a/impl/src/main/java/com/sun/faces/config/FacesInitializer.java
+++ b/impl/src/main/java/com/sun/faces/config/FacesInitializer.java
@@ -99,7 +99,7 @@ public class FacesInitializer implements ServletContainerInitializer {
             InitFacesContext initFacesContext = new InitFacesContext(servletContext);
             try {
                 if (appHasSomeFacesContent) {
-                    // Only look at mapping concerns if there is JSF content
+                    // Only look at mapping concerns if there is Faces content
                     handleMappingConcerns(servletContext);
                 }
                 // Other concerns also handled if there is an existing Faces Servlet mapping
@@ -143,7 +143,7 @@ public class FacesInitializer implements ServletContainerInitializer {
                 if (cdi != null) {
                     Instance<CdiExtension> extension = cdi.select(CdiExtension.class);
                     if (extension.isResolvable()) {
-                        return extension.get().isAddBeansForJSFImplicitObjects();
+                        return extension.get().isAddBeansForFacesImplicitObjects();
                     }
                 }
 

--- a/impl/src/main/java/com/sun/faces/config/processor/ConfigProcessor.java
+++ b/impl/src/main/java/com/sun/faces/config/processor/ConfigProcessor.java
@@ -23,7 +23,7 @@ import jakarta.servlet.ServletContext;
 
 /**
  * <p>
- * This interface provides a CoR structure for processing JSF configuration resources.
+ * This interface provides a CoR structure for processing Faces configuration resources.
  * </p>
  */
 public interface ConfigProcessor {

--- a/impl/src/main/java/com/sun/faces/context/flash/FlashELResolver.java
+++ b/impl/src/main/java/com/sun/faces/context/flash/FlashELResolver.java
@@ -162,7 +162,7 @@ public class FlashELResolver extends ELResolver {
 
     /**
      * <p>
-     * Not intended for manual invocation. Only called by the JSF Runtime.
+     * Not intended for manual invocation. Only called by the Faces Runtime.
      * </p>
      */
 

--- a/impl/src/main/java/com/sun/faces/el/ELUtils.java
+++ b/impl/src/main/java/com/sun/faces/el/ELUtils.java
@@ -211,7 +211,7 @@ public class ELUtils {
             }
         } else {
             CdiExtension cdiExtension = getBeanReference(beanManager, CdiExtension.class);
-            if (cdiExtension.isAddBeansForJSFImplicitObjects()) {
+            if (cdiExtension.isAddBeansForFacesImplicitObjects()) {
                 composite.add(beanManager.getELResolver());
                 return true;
             }

--- a/impl/src/main/java/com/sun/faces/facelets/compiler/CompilationManager.java
+++ b/impl/src/main/java/com/sun/faces/facelets/compiler/CompilationManager.java
@@ -414,7 +414,7 @@ final class CompilationManager {
         TagAttribute attr = tag.getAttributes().get("jsfc");
         if (attr != null) {
             if (log.isLoggable(Level.FINE)) {
-                log.fine(attr + " JSF Facelet Compile Directive Found");
+                log.fine(attr + " Facelet Compile Directive Found");
             }
             String value = attr.getValue();
             String namespace, localName;

--- a/impl/src/main/java/com/sun/faces/facelets/tag/DefaultTagDecorator.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/DefaultTagDecorator.java
@@ -106,7 +106,7 @@ class DefaultTagDecorator implements TagDecorator {
         // we only handle html tags!
         if (!("".equals(ns) || "http://www.w3.org/1999/xhtml".equals(ns))) {
             throw new FaceletException("Elements with namespace " + ns + " may not have attributes in namespace " + Namespace.faces.uri + "." + " Namespace "
-                    + Namespace.faces.uri + " is intended for otherwise non-JSF-aware markup, such as <input type=\"text\" " + Namespace.faces.name() + ":id >"
+                    + Namespace.faces.uri + " is intended for otherwise non-Faces-aware markup, such as <input type=\"text\" " + Namespace.faces.name() + ":id >"
                     + " It is not valid to have <h:commandButton faces:id=\"button\" />.");
         }
         for (Mapper mapper : Mapper.values()) {

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentSupport.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentSupport.java
@@ -333,7 +333,7 @@ public final class ComponentSupport {
     }
 
     /**
-     * According to JSF 1.2 tag specs, this helper method will use the TagAttribute passed in determining the Locale
+     * According to Faces 1.2 tag specs, this helper method will use the TagAttribute passed in determining the Locale
      * intended.
      *
      * @param ctx FaceletContext to evaluate from

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
@@ -86,7 +86,7 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
     }
 
     /**
-     * Method handles UIComponent tree creation in accordance with the JSF 1.2 spec.
+     * Method handles UIComponent tree creation in accordance with the Faces 1.2 spec.
      * <ol>
      * <li>First determines this UIComponent's id by calling
      * {@link jakarta.faces.view.facelets.ComponentHandler#getTagId()}.</li>

--- a/impl/src/main/java/com/sun/faces/facelets/tag/ui/SchemaCompliantRemoveHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/ui/SchemaCompliantRemoveHandler.java
@@ -33,7 +33,7 @@ public class SchemaCompliantRemoveHandler extends TagHandler {
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
         throw new FaceletException(
-                "Error: The Facelet parser is responsible for handling the <ui:remove> element.  This TagHandler implementation is only provided to allow the faces.facelets.taglib.xml file to be compliant with web-facelettaglibrary_2_2.xsd.  If you are seeing this exception, there is something wrong with how the JSF runtime is configuring its Facelets compiler.");
+                "Error: The Facelet parser is responsible for handling the <ui:remove> element.  This TagHandler implementation is only provided to allow the faces.facelets.taglib.xml file to be compliant with web-facelettaglibrary_2_2.xsd.  If you are seeing this exception, there is something wrong with how the Faces runtime is configuring its Facelets compiler.");
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/lifecycle/LifecycleFactoryImpl.java
+++ b/impl/src/main/java/com/sun/faces/lifecycle/LifecycleFactoryImpl.java
@@ -32,7 +32,7 @@ import jakarta.faces.lifecycle.Lifecycle;
 import jakarta.faces.lifecycle.LifecycleFactory;
 
 /**
- * <B>LifecycleFactoryImpl</B> is the stock implementation of Lifecycle in the JSF RI.
+ * <B>LifecycleFactoryImpl</B> is the stock implementation of Lifecycle in the Faces RI.
  * <P>
  *
  * @see jakarta.faces.lifecycle.LifecycleFactory

--- a/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
@@ -979,7 +979,7 @@ public class RenderKitUtils {
 
     /**
      * <p>
-     * Only install the JSF script resource if it doesn't exist. The resource component will be installed with the target
+     * Only install the Faces script resource if it doesn't exist. The resource component will be installed with the target
      * "head".
      *
      * @param context the <code>FacesContext</code> for the current request

--- a/impl/src/main/java/com/sun/faces/util/RequestStateManager.java
+++ b/impl/src/main/java/com/sun/faces/util/RequestStateManager.java
@@ -99,7 +99,7 @@ public class RequestStateManager {
     public static final String FACELET_FACTORY = "com.sun.faces.FACELET_FACTORY";
 
     /**
-     * Used to indicate whether or not JSF script has already been installed.
+     * Used to indicate whether or not Faces script has already been installed.
      */
     public static final String SCRIPT_STATE = "com.sun.faces.SCRIPT_STATE";
 

--- a/impl/src/main/java/jakarta/faces/application/ViewHandler.java
+++ b/impl/src/main/java/jakarta/faces/application/ViewHandler.java
@@ -110,7 +110,7 @@ public abstract class ViewHandler {
 
     /**
      * <p class="changed_added_2_0">
-     * Allow the web application to define <span class="changed_modified_4_0">a list of alternate suffixes</span> for Facelet based XHTML pages containing Jakarta Server Faces
+     * Allow the web application to define <span class="changed_modified_4_0">a list of alternate suffixes</span> for Facelet based XHTML pages containing Jakarta Faces
      * content. <span class="changed_added_4_0">This list is a space separated list of values of the form
      * <i><code>.&lt;extension&gt;</code></i>. The first physical resource whose extension matches one of the configured
      * extensions will be the suffix used to create the view ID.</span> If this init parameter is not specified, the default value is taken from the value of the constant

--- a/impl/src/main/java/jakarta/faces/view/ViewDeclarationLanguage.java
+++ b/impl/src/main/java/jakarta/faces/view/ViewDeclarationLanguage.java
@@ -546,7 +546,7 @@ public abstract class ViewDeclarationLanguage {
      * argument {@code viewId}. If no match is found, return an empty list. See section JSF.7.7.2 for the specification of
      * the default implementation. For backward compatibility with prior implementations, an implementation is provided that
      * returns {@code null}, but any implementation compliant with the version of the specification in which this method was
-     * introduced must implement it as specified in JSF.7.7.2.
+     * introduced must implement it as specified in section JSF.7.7.2.
      * </p>
      *
      * @param context the {@code FacesContext} for this request

--- a/impl/src/main/resources/com/sun/faces/metadata/taglib/faces.core.taglib.xml
+++ b/impl/src/main/resources/com/sun/faces/metadata/taglib/faces.core.taglib.xml
@@ -639,7 +639,7 @@
     <tag>
         <description><![CDATA[
 
-            <p class="changed_added_2_0">Allow JSF page authors to
+            <p class="changed_added_2_0">Allow Jakarta Faces page authors to
             install <code>ComponentSystemEventListener</code>
             instances
             on a component in a page.</p>

--- a/impl/src/main/resources/com/sun/faces/metadata/taglib/faces.facelets.taglib.xml
+++ b/impl/src/main/resources/com/sun/faces/metadata/taglib/faces.facelets.taglib.xml
@@ -852,13 +852,8 @@ attribute must be an absolute path starting with "/".</span>
         <div class="changed_added_2_0">
 	
         <p><span class="changed_modified_2_2
-        changed_modified_2_3">Use</span> this tag as an alternative to
-        <code>h:dataTable</code> or <code>c:forEach</code>, especially
-        when you are using the <code>jsfc</code> feature of
-        Facelets. You can specify this component as the value of the
-        <code>jsfc</code> attribute, like this:
-        &lt;div... jsfc="ui:repeat" value="#{contacts}"
-        var="contact"&gt;...  </p> </div>
+        changed_modified_2_3 changed_modified_4_0">Use</span> this tag as an alternative to
+        <code>h:dataTable</code> or <code>c:forEach</code></p> </div>
         
         ]]></description>
         <tag-name>repeat</tag-name>

--- a/impl/src/main/resources/com/sun/faces/metadata/taglib/faces.facelets.taglib.xml
+++ b/impl/src/main/resources/com/sun/faces/metadata/taglib/faces.facelets.taglib.xml
@@ -1028,14 +1028,7 @@ attribute must be an absolute path starting with "/".</span>
 
 
             <div class="changed_added_2_0">
-            <p>Remove content from a page. This tag is often used in
-            conjunction with the <code>jsfc</code> feature of
-            Facelets,
-            to wrap additional markup. When Facelets removes markup from a page
-            by substituting markup items that have
-            a <code>jsfc</code> attribute with the specified
-            component, Facelets also removes anything in the page that
-            is contained in a <code>ui:remove</code> tag.</p>
+            <p>Remove content from a page.</p>
             </div>
 
         ]]></description>

--- a/impl/src/main/resources/com/sun/faces/web-facesconfig_3_0.xsd
+++ b/impl/src/main/resources/com/sun/faces/web-facesconfig_3_0.xsd
@@ -243,8 +243,8 @@
           files of the application for annotations, as specified by
           the specification.
           
-          If "WEB-INF/faces-config.xml" is not present, the JavaServer
-          Faces runtime will assume metadata-complete to be "false".
+          If "WEB-INF/faces-config.xml" is not present, the
+          Jakarta Server Faces runtime will assume metadata-complete to be "false".
           
           The value of this attribute will have no impact on
           runtime annotations such as @ResourceDependency or


### PR DESCRIPTION
- Rename single occurrence of "Jakarta Server Faces" to "Jakarta Faces" in javadoc
- Rename single occurrence of "JavaServer Faces" to "Jakarta Server Faces" in 3.0 XSD
- Remove references to "jsfc" in Facelets taglib doc (those are actually unspecified in Faces spec itself, it's better to consider them a Mojarra-specific feature for now, shall probably need to be reevaluated for inclusion in a future spec)
- Rename "JSF" to "Faces" in Mojarra impl itself