### PR TITLE
Fix Java 11 javadoc errors

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/ApplicationAssociate.java
+++ b/impl/src/main/java/com/sun/faces/application/ApplicationAssociate.java
@@ -588,6 +588,9 @@ public class ApplicationAssociate {
      * <p>
      * 
      * values: ResourceBundleBean instances.
+     * 
+     * @param var the variable name
+     * @param bundle the application resource bundle
      */
 
     public void addResourceBundle(String var, ApplicationResourceBundle bundle) {

--- a/impl/src/main/java/com/sun/faces/application/PropertyEditorHelper.java
+++ b/impl/src/main/java/com/sun/faces/application/PropertyEditorHelper.java
@@ -43,6 +43,9 @@ public class PropertyEditorHelper {
 
     /**
      * Convert the <code>textValue</code> to an object of type targetClass by delegating to a converter.
+     * @param targetClass the target class
+     * @param textValue the text value
+     * @return the conversion result
      */
     public Object convertToObject(Class<?> targetClass, String textValue) {
         UIComponent component = getComponent();
@@ -64,6 +67,9 @@ public class PropertyEditorHelper {
 
     /**
      * Convert an object of type targetClass to text by delegating to a converter obtained from the Faces application.
+     * @param targetClass the target class
+     * @param value the value
+     * @return the conversion result
      */
     public String convertToString(Class<?> targetClass, Object value) {
         UIComponent component = getComponent();
@@ -97,9 +103,9 @@ public class PropertyEditorHelper {
     /**
      * Add a conversion error message in the case of a PropertyEditor based conversion error.
      *
-     * @param context
-     * @param component
-     * @param ce
+     * @param context the involved faces context
+     * @param component the involved component
+     * @param ce the converter exception
      */
     protected void addConversionErrorMessage(FacesContext context, UIComponent component, ConverterException ce) {
         String converterMessageString = null;

--- a/impl/src/main/java/com/sun/faces/application/ViewMemberInstanceFactoryMetadataMap.java
+++ b/impl/src/main/java/com/sun/faces/application/ViewMemberInstanceFactoryMetadataMap.java
@@ -25,8 +25,8 @@ import com.sun.faces.util.MetadataWrapperMap;
  * Used to hold metadata for classes that are members of views. Does not support annotation scanning for these classes,
  * as they are not eligible for injection.
  *
- * @param <K>
- * @param <V>
+ * @param <K> key
+ * @param <V> value
  */
 public class ViewMemberInstanceFactoryMetadataMap<K, V> extends MetadataWrapperMap<String, Object> {
 

--- a/impl/src/main/java/com/sun/faces/application/WebappLifecycleListener.java
+++ b/impl/src/main/java/com/sun/faces/application/WebappLifecycleListener.java
@@ -48,7 +48,7 @@ import jakarta.servlet.http.HttpSessionListener;
 /**
  * <p>
  * Central location for web application lifecycle events.
- * <p>
+ * </p>
  * <p>
  * The main purpose of this class is detect when we should be invoking methods marked with the <code>@PreDestroy</code>
  * annotation.

--- a/impl/src/main/java/com/sun/faces/application/annotation/AnnotationManager.java
+++ b/impl/src/main/java/com/sun/faces/application/annotation/AnnotationManager.java
@@ -132,6 +132,7 @@ public class AnnotationManager {
      * </p>
      *
      * @param ctx FacesContext available during application initialization
+     * @param annotationType the involved annotation type
      * @param annotatedClasses <code>Collection</code> of class names known to contain one or more Faces configuration
      * annotations
      */

--- a/impl/src/main/java/com/sun/faces/application/annotation/ConfigAnnotationHandler.java
+++ b/impl/src/main/java/com/sun/faces/application/annotation/ConfigAnnotationHandler.java
@@ -50,6 +50,7 @@ public interface ConfigAnnotationHandler {
 
     /**
      * <code>Push</code> the configuration based on the collected metadata to the current application.
+     * @param ctx the involved faces context
      */
     void push(FacesContext ctx);
 

--- a/impl/src/main/java/com/sun/faces/application/applicationimpl/Events.java
+++ b/impl/src/main/java/com/sun/faces/application/applicationimpl/Events.java
@@ -66,15 +66,8 @@ public class Events {
 
     private ReentrantLisneterInvocationGuard listenerInvocationGuard = new ReentrantLisneterInvocationGuard();
 
-    /**
-     * @see jakarta.faces.application.Application#publishEvent(FacesContext, Class, Object)
-     */
-    public void publishEvent(FacesContext context, Class<? extends SystemEvent> systemEventClass, Object source, ProjectStage projectStage) {
-        publishEvent(context, systemEventClass, null, source, projectStage);
-    }
-
-    /**
-     * @see jakarta.faces.application.Application#publishEvent(FacesContext, Class, Object)
+    /*
+     * @see jakarta.faces.application.Application#publishEvent(FacesContext, Class, Class, Object)
      */
     public void publishEvent(FacesContext context, Class<? extends SystemEvent> systemEventClass, Class<?> sourceBaseType, Object source,
             ProjectStage projectStage) {
@@ -118,14 +111,14 @@ public class Events {
         }
     }
 
-    /**
+    /*
      * @see Application#subscribeToEvent(Class, jakarta.faces.event.SystemEventListener)
      */
     public void subscribeToEvent(Class<? extends SystemEvent> systemEventClass, SystemEventListener listener) {
         subscribeToEvent(systemEventClass, null, listener);
     }
 
-    /**
+    /*
      * @see Application#subscribeToEvent(Class, Class, jakarta.faces.event.SystemEventListener)
      */
     public void subscribeToEvent(Class<? extends SystemEvent> systemEventClass, Class<?> sourceClass, SystemEventListener listener) {
@@ -136,7 +129,7 @@ public class Events {
         getListeners(systemEventClass, sourceClass).add(listener);
     }
 
-    /**
+    /*
      * @see Application#unsubscribeFromEvent(Class, Class, jakarta.faces.event.SystemEventListener)
      */
     public void unsubscribeFromEvent(Class<? extends SystemEvent> systemEventClass, Class<?> sourceClass, SystemEventListener listener) {

--- a/impl/src/main/java/com/sun/faces/application/applicationimpl/ExpressionLanguage.java
+++ b/impl/src/main/java/com/sun/faces/application/applicationimpl/ExpressionLanguage.java
@@ -52,7 +52,7 @@ public class ExpressionLanguage {
         elResolvers = new CompositeELResolver();
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#addELContextListener(jakarta.el.ELContextListener)
      */
     public void addELContextListener(ELContextListener listener) {
@@ -61,7 +61,7 @@ public class ExpressionLanguage {
         }
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#removeELContextListener(jakarta.el.ELContextListener)
      */
     public void removeELContextListener(ELContextListener listener) {
@@ -70,7 +70,7 @@ public class ExpressionLanguage {
         }
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#getELContextListeners()
      */
     public ELContextListener[] getELContextListeners() {
@@ -81,7 +81,7 @@ public class ExpressionLanguage {
         return EMPTY_EL_CTX_LIST_ARRAY;
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#getELResolver()
      */
     public ELResolver getELResolver() {
@@ -96,7 +96,7 @@ public class ExpressionLanguage {
         return compositeELResolver;
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#addELResolver(jakarta.el.ELResolver)
      */
     public void addELResolver(ELResolver resolver) {
@@ -117,14 +117,14 @@ public class ExpressionLanguage {
         }
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#getExpressionFactory()
      */
     public ExpressionFactory getExpressionFactory() {
         return associate.getExpressionFactory();
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#evaluateExpressionGet(jakarta.faces.context.FacesContext, String, Class)
      */
     @SuppressWarnings("unchecked")

--- a/impl/src/main/java/com/sun/faces/application/applicationimpl/InstanceFactory.java
+++ b/impl/src/main/java/com/sun/faces/application/applicationimpl/InstanceFactory.java
@@ -166,7 +166,7 @@ public class InstanceFactory {
         }
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#addComponent(java.lang.String, java.lang.String)
      */
     public void addComponent(String componentType, String componentClass) {
@@ -299,14 +299,14 @@ public class InstanceFactory {
         return createComponentApplyAnnotations(context, componentExpression, componentType, rendererType, true);
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#getComponentTypes()
      */
     public Iterator<String> getComponentTypes() {
         return componentMap.keySet().iterator();
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#addBehavior(String, String)
      */
     public void addBehavior(String behaviorId, String behaviorClass) {
@@ -325,7 +325,7 @@ public class InstanceFactory {
         }
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#createBehavior(String)
      */
     public Behavior createBehavior(String behaviorId) throws FacesException {
@@ -349,7 +349,7 @@ public class InstanceFactory {
         return behavior;
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#getBehaviorIds()
      */
     public Iterator<String> getBehaviorIds() {
@@ -381,7 +381,7 @@ public class InstanceFactory {
         }
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#addConverter(Class, String)
      */
     public void addConverter(Class<?> targetClass, String converterClass) {
@@ -406,7 +406,7 @@ public class InstanceFactory {
         }
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#createConverter(String)
      */
     public Converter<?> createConverter(String converterId) {
@@ -434,7 +434,7 @@ public class InstanceFactory {
         return converter;
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#createConverter(Class)
      */
     public Converter createConverter(Class<?> targetClass) {
@@ -499,7 +499,7 @@ public class InstanceFactory {
         return returnVal;
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#getConverterIds()
      */
     public Iterator<String> getConverterIds() {
@@ -507,14 +507,14 @@ public class InstanceFactory {
 
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#getConverterTypes()
      */
     public Iterator<Class<?>> getConverterTypes() {
         return converterTypeMap.keySet().iterator();
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#addValidator(String, String)
      */
     public void addValidator(String validatorId, String validatorClass) {
@@ -534,7 +534,7 @@ public class InstanceFactory {
 
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#createValidator(String)
      */
     public Validator<?> createValidator(String validatorId) throws FacesException {
@@ -558,14 +558,14 @@ public class InstanceFactory {
         return validator;
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#getValidatorIds()
      */
     public Iterator<String> getValidatorIds() {
         return validatorMap.keySet().iterator();
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#addDefaultValidatorId(String)
      */
     public synchronized void addDefaultValidatorId(String validatorId) {
@@ -575,7 +575,7 @@ public class InstanceFactory {
         defaultValidatorIds.add(validatorId);
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#getDefaultValidatorInfo()
      */
     public Map<String, String> getDefaultValidatorInfo() {

--- a/impl/src/main/java/com/sun/faces/application/applicationimpl/Singletons.java
+++ b/impl/src/main/java/com/sun/faces/application/applicationimpl/Singletons.java
@@ -66,14 +66,14 @@ public class Singletons {
         associate = applicationAssociate;
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#getViewHandler()
      */
     public ViewHandler getViewHandler() {
         return viewHandler;
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#setViewHandler(jakarta.faces.application.ViewHandler)
      */
     public synchronized void setViewHandler(ViewHandler viewHandler) {
@@ -88,14 +88,14 @@ public class Singletons {
         }
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#getResourceHandler()
      */
     public ResourceHandler getResourceHandler() {
         return resourceHandler;
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#setResourceHandler(jakarta.faces.application.ResourceHandler)
      */
     public synchronized void setResourceHandler(ResourceHandler resourceHandler) {
@@ -110,14 +110,14 @@ public class Singletons {
         }
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#getStateManager()
      */
     public StateManager getStateManager() {
         return stateManager;
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#setStateManager(jakarta.faces.application.StateManager)
      */
     public synchronized void setStateManager(StateManager stateManager) {
@@ -132,14 +132,14 @@ public class Singletons {
         }
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#getActionListener()
      */
     public ActionListener getActionListener() {
         return actionListener;
     }
 
-    /**
+    /*
      * @see Application#setActionListener(jakarta.faces.event.ActionListener)
      */
     public synchronized void setActionListener(ActionListener actionListener) {
@@ -153,14 +153,14 @@ public class Singletons {
         }
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#getNavigationHandler()
      */
     public NavigationHandler getNavigationHandler() {
         return navigationHandler;
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#setNavigationHandler(jakarta.faces.application.NavigationHandler)
      */
     public synchronized void setNavigationHandler(NavigationHandler navigationHandler) {
@@ -189,14 +189,14 @@ public class Singletons {
         }
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#getSupportedLocales()
      */
     public Iterator<Locale> getSupportedLocales() {
         return coalesce(supportedLocales, Collections.<Locale>emptyList()).iterator();
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#setSupportedLocales(java.util.Collection)
      */
     public synchronized void setSupportedLocales(Collection<Locale> newLocales) {
@@ -211,14 +211,14 @@ public class Singletons {
 
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#getDefaultLocale()
      */
     public Locale getDefaultLocale() {
         return defaultLocale;
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#setDefaultLocale(java.util.Locale)
      */
     public synchronized void setDefaultLocale(Locale locale) {
@@ -232,7 +232,7 @@ public class Singletons {
         }
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#setMessageBundle(String)
      */
     public synchronized void setMessageBundle(String messageBundle) {
@@ -245,28 +245,28 @@ public class Singletons {
         }
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#getMessageBundle()
      */
     public String getMessageBundle() {
         return messageBundle;
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#getDefaultRenderKitId()
      */
     public String getDefaultRenderKitId() {
         return defaultRenderKitId;
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#setDefaultRenderKitId(String)
      */
     public void setDefaultRenderKitId(String renderKitId) {
         defaultRenderKitId = renderKitId;
     }
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#getResourceBundle(jakarta.faces.context.FacesContext, String)
      */
     public ResourceBundle getResourceBundle(FacesContext context, String var) {

--- a/impl/src/main/java/com/sun/faces/application/applicationimpl/Stage.java
+++ b/impl/src/main/java/com/sun/faces/application/applicationimpl/Stage.java
@@ -39,7 +39,7 @@ public class Stage {
 
     private ProjectStage projectStage;
 
-    /**
+    /*
      * @see jakarta.faces.application.Application#getProjectStage()
      */
     public ProjectStage getProjectStage(Application application) {

--- a/impl/src/main/java/com/sun/faces/application/resource/ClientResourceInfo.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ClientResourceInfo.java
@@ -49,6 +49,7 @@ public class ClientResourceInfo extends ResourceInfo {
      * resource will be the same as the {@link ResourceHelper} of the {@link LibraryInfo}.
      *
      * @param library the library containing this resource
+     * @param contract the contract info
      * @param name the resource name
      * @param version the version of this resource (if any)
      * @param compressible if this resource should be compressed

--- a/impl/src/main/java/com/sun/faces/application/resource/LibraryInfo.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/LibraryInfo.java
@@ -20,7 +20,7 @@ package com.sun.faces.application.resource;
  * <p>
  * <code>LibraryInfo</code> is a simple wrapper class for information pertinent to building a complete resource path
  * using a Library and/or Contract.
- * <p>
+ * </p>
  */
 public class LibraryInfo {
 

--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceHelper.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceHelper.java
@@ -212,6 +212,7 @@ public abstract class ResourceHelper {
      * @param contract the name of the contract
      * @param ctx the {@link jakarta.faces.context.FacesContext} for the current request @return a {@link LibraryInfo} if a
      * matching library based off the inputs can be found, otherwise returns <code>null</code>
+     * @return library info
      */
     public abstract LibraryInfo findLibrary(String libraryName, String localePrefix, String contract, FacesContext ctx);
 

--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceImpl.java
@@ -111,6 +111,10 @@ public class ResourceImpl extends Resource implements Externalizable {
 
     /**
      * Creates a new instance of ResourceBase
+     * @param resourceInfo the resource info
+     * @param contentType the resource content type
+     * @param initialTime the resource initial time
+     * @param maxAge the resource max age
      */
     public ResourceImpl(ResourceInfo resourceInfo, String contentType, long initialTime, long maxAge) {
 

--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceManager.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceManager.java
@@ -100,6 +100,8 @@ public class ResourceManager {
     /**
      * Constructs a new <code>ResourceManager</code>. Note: if the current {@link ProjectStage} is
      * {@link ProjectStage#Development} caching or {@link ResourceInfo} instances will not occur.
+     * @param appMap the application map
+     * @param cache the resource cache
      */
     public ResourceManager(Map<String, Object> appMap, ResourceCache cache) {
         this.cache = cache;

--- a/impl/src/main/java/com/sun/faces/application/view/ViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/ViewHandlingStrategy.java
@@ -40,7 +40,7 @@ import jakarta.faces.view.ViewDeclarationLanguage;
 /**
  * <p>
  * This represents how a particular page description language is to be rendered/restored.
- * <p>
+ * </p>
  */
 public abstract class ViewHandlingStrategy extends ViewDeclarationLanguage {
 

--- a/impl/src/main/java/com/sun/faces/application/view/ViewScopeEventListener.java
+++ b/impl/src/main/java/com/sun/faces/application/view/ViewScopeEventListener.java
@@ -41,7 +41,7 @@ public class ViewScopeEventListener implements ViewMapListener {
      * Handle the system event.
      *
      * @param se the system event.
-     * @throws AbortProcessingException
+     * @throws AbortProcessingException when processing needs to be aborted.
      */
     @Override
     public void processEvent(SystemEvent se) throws AbortProcessingException {

--- a/impl/src/main/java/com/sun/faces/application/view/ViewScopeExtension.java
+++ b/impl/src/main/java/com/sun/faces/application/view/ViewScopeExtension.java
@@ -71,6 +71,7 @@ public class ViewScopeExtension implements Extension {
      * After bean discovery.
      *
      * @param event the event.
+     * @param beanManager the bean manager.
      */
     public void afterBeanDiscovery(@Observes AfterBeanDiscovery event, BeanManager beanManager) {
         LOGGER.finest("Adding @ViewScoped context to CDI runtime");

--- a/impl/src/main/java/com/sun/faces/application/view/ViewScopeManager.java
+++ b/impl/src/main/java/com/sun/faces/application/view/ViewScopeManager.java
@@ -98,7 +98,7 @@ public class ViewScopeManager implements HttpSessionListener, ViewMapListener {
      *
      * @param facesContext The faces context
      * @param viewMap The view to locate
-     * @return
+     * @return located ID
      */
     protected static String locateViewMapId(FacesContext facesContext, Map<String, Object> viewMap) {
         Object session = facesContext.getExternalContext().getSession(true);
@@ -202,6 +202,7 @@ public class ViewScopeManager implements HttpSessionListener, ViewMapListener {
      * Get our instance.
      *
      * @param facesContext the FacesContext.
+     * @return our instance.
      */
     public static ViewScopeManager getInstance(FacesContext facesContext) {
         if (!facesContext.getExternalContext().getApplicationMap().containsKey(VIEW_SCOPE_MANAGER)) {
@@ -225,7 +226,7 @@ public class ViewScopeManager implements HttpSessionListener, ViewMapListener {
      * Process the system event.
      *
      * @param systemEvent the system event.
-     * @throws AbortProcessingException when processing needs to be aborter.
+     * @throws AbortProcessingException when processing needs to be aborted.
      */
     @Override
     public void processEvent(SystemEvent systemEvent) throws AbortProcessingException {

--- a/impl/src/main/java/com/sun/faces/cdi/CdiConverter.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CdiConverter.java
@@ -127,7 +127,7 @@ public class CdiConverter implements Converter, StateHolder {
      * We ignore the call as our proxy is always non-transient.
      * </p>
      *
-     * @param transientValue
+     * @param transientValue whether converter should be set to transient
      */
     @Override
     public void setTransient(boolean transientValue) {

--- a/impl/src/main/java/com/sun/faces/cdi/CdiExtension.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CdiExtension.java
@@ -87,6 +87,7 @@ public class CdiExtension implements Extension {
      * After bean discovery.
      *
      * @param afterBeanDiscovery the after bean discovery.
+     * @param beanManager the bean manager.
      */
     public void afterBean(final @Observes AfterBeanDiscovery afterBeanDiscovery, BeanManager beanManager) {
         if (addBeansForFacesImplicitObjects) {
@@ -123,6 +124,7 @@ public class CdiExtension implements Extension {
     /**
      * Processing of beans
      *
+     * @param <T> the generic bean type
      * @param event the process bean event
      * @param beanManager the current bean manager
      */

--- a/impl/src/main/java/com/sun/faces/cdi/CdiUtils.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CdiUtils.java
@@ -191,6 +191,7 @@ public final class CdiUtils {
     }
 
     /**
+     * @param <T> the generic bean type
      * @param beanManager the bean manager
      * @param type the required bean type the reference must have
      * @param qualifiers the required qualifiers the reference must have
@@ -215,6 +216,7 @@ public final class CdiUtils {
     /**
      * Returns concrete (non-proxied) bean instance of given class in current context.
      *
+     * @param <T> the generic bean type
      * @param type the required bean type the instance must have
      * @param create whether to auto-create bean if not exist
      * @return a bean instance adhering to the required type
@@ -240,6 +242,7 @@ public final class CdiUtils {
     /**
      * Finds an annotation in an Annotated, taking stereo types into account
      *
+     * @param <A> the generic annotation type
      * @param beanManager the current bean manager
      * @param annotated the Annotated in which to search
      * @param annotationType the type of the annotation to search for
@@ -314,6 +317,9 @@ public final class CdiUtils {
 
     /**
      * Returns the current injection point.
+     * @param beanManager the involved bean manager
+     * @param creationalContext the involved creational context
+     * @return the current injection point
      */
     public static InjectionPoint getCurrentInjectionPoint(BeanManager beanManager, CreationalContext<?> creationalContext) {
         Bean<? extends Object> bean = beanManager.resolve(beanManager.getBeans(InjectionPoint.class));
@@ -329,6 +335,10 @@ public final class CdiUtils {
 
     /**
      * Returns the qualifier annotation of the given qualifier class from the given injection point.
+     * @param <A> the type of given qualifier class 
+     * @param injectionPoint the injection point
+     * @param qualifierClass the qualifier class to be filtered
+     * @return the qualifier annotation
      */
     public static <A extends Annotation> A getQualifier(InjectionPoint injectionPoint, Class<A> qualifierClass) {
         for (Annotation annotation : injectionPoint.getQualifiers()) {
@@ -342,6 +352,9 @@ public final class CdiUtils {
 
     /**
      * Returns true if given scope is active in current context.
+     * @param <S> the type of given scope
+     * @param scope the scope to be checked
+     * @return whether given scope is active
      */
     public static <S extends Annotation> boolean isScopeActive(Class<S> scope) {
         BeanManager beanManager = Util.getCdiBeanManager(FacesContext.getCurrentInstance());

--- a/impl/src/main/java/com/sun/faces/cdi/clientwindow/ClientWindowScopeManager.java
+++ b/impl/src/main/java/com/sun/faces/cdi/clientwindow/ClientWindowScopeManager.java
@@ -62,6 +62,7 @@ public class ClientWindowScopeManager implements HttpSessionListener {
      * Get our instance.
      *
      * @param facesContext the FacesContext.
+     * @return our instance
      */
     public static ClientWindowScopeManager getInstance(FacesContext facesContext) {
         if (!facesContext.getExternalContext().getApplicationMap().containsKey(CLIENT_WINDOW_SCOPE_MANAGER)) {

--- a/impl/src/main/java/com/sun/faces/component/PassthroughElement.java
+++ b/impl/src/main/java/com/sun/faces/component/PassthroughElement.java
@@ -75,6 +75,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * </p>
      * <p>
      * Contents: Javascript code executed when a pointer button is clicked over this element.
+     * @return the value of the <code>onclick</code> property. 
      */
     public java.lang.String getOnclick() {
         return (java.lang.String) getStateHelper().eval(PropertyKeys.onclick);
@@ -85,6 +86,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * <p>
      * Set the value of the <code>onclick</code> property.
      * </p>
+     * @param onclick the value of the <code>onclick</code> property.
      */
     public void setOnclick(java.lang.String onclick) {
         getStateHelper().put(PropertyKeys.onclick, onclick);
@@ -97,6 +99,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * </p>
      * <p>
      * Contents: Javascript code executed when a pointer button is double clicked over this element.
+     * @return the value of the <code>ondblclick</code> property.
      */
     public java.lang.String getOndblclick() {
         return (java.lang.String) getStateHelper().eval(PropertyKeys.ondblclick);
@@ -107,6 +110,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * <p>
      * Set the value of the <code>ondblclick</code> property.
      * </p>
+     * @param ondblclick the value of the <code>ondblclick</code> property.
      */
     public void setOndblclick(java.lang.String ondblclick) {
         getStateHelper().put(PropertyKeys.ondblclick, ondblclick);
@@ -119,6 +123,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * </p>
      * <p>
      * Contents: Javascript code executed when a key is pressed down over this element.
+     * @return the value of the <code>onkeydown</code> property.
      */
     public java.lang.String getOnkeydown() {
         return (java.lang.String) getStateHelper().eval(PropertyKeys.onkeydown);
@@ -129,6 +134,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * <p>
      * Set the value of the <code>onkeydown</code> property.
      * </p>
+     * @param onkeydown the value of the <code>onkeydown</code> property.
      */
     public void setOnkeydown(java.lang.String onkeydown) {
         getStateHelper().put(PropertyKeys.onkeydown, onkeydown);
@@ -141,6 +147,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * </p>
      * <p>
      * Contents: Javascript code executed when a key is pressed and released over this element.
+     * @return the value of the <code>onkeypress</code> property.
      */
     public java.lang.String getOnkeypress() {
         return (java.lang.String) getStateHelper().eval(PropertyKeys.onkeypress);
@@ -151,6 +158,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * <p>
      * Set the value of the <code>onkeypress</code> property.
      * </p>
+     * @param onkeypress the value of the <code>onkeypress</code> property.
      */
     public void setOnkeypress(java.lang.String onkeypress) {
         getStateHelper().put(PropertyKeys.onkeypress, onkeypress);
@@ -163,6 +171,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * </p>
      * <p>
      * Contents: Javascript code executed when a key is released over this element.
+     * @return the value of the <code>onkeyup</code> property.
      */
     public java.lang.String getOnkeyup() {
         return (java.lang.String) getStateHelper().eval(PropertyKeys.onkeyup);
@@ -173,6 +182,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * <p>
      * Set the value of the <code>onkeyup</code> property.
      * </p>
+     * @param onkeyup the value of the <code>onkeyup</code> property.
      */
     public void setOnkeyup(java.lang.String onkeyup) {
         getStateHelper().put(PropertyKeys.onkeyup, onkeyup);
@@ -185,6 +195,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * </p>
      * <p>
      * Contents: Javascript code executed when a pointer button is pressed down over this element.
+     * @return the value of the <code>onmousedown</code> property.
      */
     public java.lang.String getOnmousedown() {
         return (java.lang.String) getStateHelper().eval(PropertyKeys.onmousedown);
@@ -195,6 +206,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * <p>
      * Set the value of the <code>onmousedown</code> property.
      * </p>
+     * @param onmousedown the value of the <code>onmousedown</code> property.
      */
     public void setOnmousedown(java.lang.String onmousedown) {
         getStateHelper().put(PropertyKeys.onmousedown, onmousedown);
@@ -207,6 +219,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * </p>
      * <p>
      * Contents: Javascript code executed when a pointer button is moved within this element.
+     * @return the value of the <code>onmousemove</code> property.
      */
     public java.lang.String getOnmousemove() {
         return (java.lang.String) getStateHelper().eval(PropertyKeys.onmousemove);
@@ -217,6 +230,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * <p>
      * Set the value of the <code>onmousemove</code> property.
      * </p>
+     * @param onmousemove the value of the <code>onmousemove</code> property.
      */
     public void setOnmousemove(java.lang.String onmousemove) {
         getStateHelper().put(PropertyKeys.onmousemove, onmousemove);
@@ -229,6 +243,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * </p>
      * <p>
      * Contents: Javascript code executed when a pointer button is moved away from this element.
+     * @return the value of the <code>onmouseout</code> property.
      */
     public java.lang.String getOnmouseout() {
         return (java.lang.String) getStateHelper().eval(PropertyKeys.onmouseout);
@@ -239,6 +254,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * <p>
      * Set the value of the <code>onmouseout</code> property.
      * </p>
+     * @param onmouseout the value of the <code>onmouseout</code> property.
      */
     public void setOnmouseout(java.lang.String onmouseout) {
         getStateHelper().put(PropertyKeys.onmouseout, onmouseout);
@@ -251,6 +267,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * </p>
      * <p>
      * Contents: Javascript code executed when a pointer button is moved onto this element.
+     * @return the value of the <code>onmouseover</code> property.
      */
     public java.lang.String getOnmouseover() {
         return (java.lang.String) getStateHelper().eval(PropertyKeys.onmouseover);
@@ -261,6 +278,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * <p>
      * Set the value of the <code>onmouseover</code> property.
      * </p>
+     * @param onmouseover the value of the <code>onmouseover</code> property.
      */
     public void setOnmouseover(java.lang.String onmouseover) {
         getStateHelper().put(PropertyKeys.onmouseover, onmouseover);
@@ -273,6 +291,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * </p>
      * <p>
      * Contents: Javascript code executed when a pointer button is released over this element.
+     * @return the value of the <code>onmouseup</code> property.
      */
     public java.lang.String getOnmouseup() {
         return (java.lang.String) getStateHelper().eval(PropertyKeys.onmouseup);
@@ -283,6 +302,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * <p>
      * Set the value of the <code>onmouseup</code> property.
      * </p>
+     * @param onmouseup the value of the <code>onmouseup</code> property.
      */
     public void setOnmouseup(java.lang.String onmouseup) {
         getStateHelper().put(PropertyKeys.onmouseup, onmouseup);
@@ -295,6 +315,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * </p>
      * <p>
      * Contents: CSS style(s) to be applied when this component is rendered.
+     * @return the value of the <code>style</code> property.
      */
     public java.lang.String getStyle() {
         return (java.lang.String) getStateHelper().eval(PropertyKeys.style);
@@ -305,6 +326,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * <p>
      * Set the value of the <code>style</code> property.
      * </p>
+     * @param style the value of the <code>style</code> property.
      */
     public void setStyle(java.lang.String style) {
         getStateHelper().put(PropertyKeys.style, style);
@@ -318,6 +340,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * <p>
      * Contents: Space-separated list of CSS style class(es) to be applied when this element is rendered. This value must be
      * passed through as the "class" property on generated markup.
+     * @return the value of the <code>styleClass</code> property.
      */
     public java.lang.String getStyleClass() {
         return (java.lang.String) getStateHelper().eval(PropertyKeys.styleClass);
@@ -328,6 +351,7 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
      * <p>
      * Set the value of the <code>styleClass</code> property.
      * </p>
+     * @param styleClass the value of the <code>styleClass</code> property.
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);

--- a/impl/src/main/java/com/sun/faces/component/behavior/AjaxBehaviors.java
+++ b/impl/src/main/java/com/sun/faces/component/behavior/AjaxBehaviors.java
@@ -85,7 +85,7 @@ public class AjaxBehaviors implements Serializable {
      * <p>
      * Push the {@link AjaxBehavior} instance onto the <code>List</code>.
      * </p>
-     *
+     * @param context the faces context
      * @param ajaxBehavior the {@link AjaxBehavior} instance
      * @param eventName the name of the event that the behavior is associated with.
      *

--- a/impl/src/main/java/com/sun/faces/component/search/SearchExpressionHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/component/search/SearchExpressionHandlerImpl.java
@@ -456,11 +456,11 @@ public class SearchExpressionHandlerImpl extends SearchExpressionHandler {
     }
 
     /**
-     * Extract the first command from the expression. @child(1):myId => @child(1) myId:@parent => myId
+     * Extract the first command from the expression. {@code @child(1):myId => @child(1) myId:@parent => myId}
      *
-     * @param facesContext
-     * @param expression
-     * @return
+     * @param facesContext the faces context
+     * @param expression the expression
+     * @return the first command from the expression
      */
     protected String extractFirstCommand(FacesContext facesContext, String expression) {
         // we can't use a split(":") or split(" ") as keyword parameters might contain spaces or commas

--- a/impl/src/main/java/com/sun/faces/component/validator/ComponentValidators.java
+++ b/impl/src/main/java/com/sun/faces/component/validator/ComponentValidators.java
@@ -167,7 +167,7 @@ public class ComponentValidators {
      * Pushes the provided <code>ValidatorInfo</code> onto the stack.
      * </p>
      *
-     * @param info
+     * @param info validator info
      */
     public void pushValidatorInfo(ValidatorInfo info) {
 

--- a/impl/src/main/java/com/sun/faces/config/ConfigManager.java
+++ b/impl/src/main/java/com/sun/faces/config/ConfigManager.java
@@ -180,6 +180,7 @@ public class ConfigManager {
     }
 
     /**
+     * @param servletContext the involved servlet context
      * @return a <code>ConfigManager</code> instance
      */
     public static ConfigManager getInstance(ServletContext servletContext) {
@@ -187,6 +188,7 @@ public class ConfigManager {
     }
 
     /**
+     * @param ctx the involved faces context
      * @return the results of the annotation scan task
      */
     public static Map<Class<? extends Annotation>, Set<Class<?>>> getAnnotatedClasses(FacesContext ctx) {
@@ -216,6 +218,7 @@ public class ConfigManager {
      * </p>
      *
      * @param servletContext the <code>ServletContext</code> for the application that requires initialization
+     * @param facesContext the involved initialization faces context
      */
     public void initialize(ServletContext servletContext, InitFacesContext facesContext) {
         if (!hasBeenInitialized(servletContext)) {

--- a/impl/src/main/java/com/sun/faces/config/InitFacesContext.java
+++ b/impl/src/main/java/com/sun/faces/config/InitFacesContext.java
@@ -173,7 +173,7 @@ public class InitFacesContext extends NoOpFacesContext {
      * entry(s) with matching ServletContext from initContextServletContext map. Then remove entries from threadInitContext
      * map where the entry value(s) match the initFacesContext (associated with the ServletContext).
      *
-     * @param servletContext
+     * @param servletContext the involved servlet context
      */
     public static void cleanupInitMaps(ServletContext servletContext) {
 

--- a/impl/src/main/java/com/sun/faces/config/manager/FacesSchema.java
+++ b/impl/src/main/java/com/sun/faces/config/manager/FacesSchema.java
@@ -257,10 +257,10 @@ public enum FacesSchema {
          * E.g. "https://jakarta.ee/xml/ns/jakartaee", "4.0", "faces-config" maps to <code>FACES_40</code>
          * </p>
          *
-         * @param documentNS
-         * @param version
-         * @param localName
-         * @return
+         * @param documentNS document's namespace
+         * @param version document's version
+         * @param localName document's root element
+         * @return the matching faces schema
          */
         public static FacesSchema fromDocumentId(String documentNS, String version, String localName) {
             switch (documentNS) {

--- a/impl/src/main/java/com/sun/faces/config/manager/documents/DocumentOrderingWrapper.java
+++ b/impl/src/main/java/com/sun/faces/config/manager/documents/DocumentOrderingWrapper.java
@@ -126,6 +126,7 @@ public class DocumentOrderingWrapper {
 
     /**
      * Constructs a new <code>DocumentOrderingWrapper</code> for the specified <code>Document</code>.
+     * @param document the document info
      */
     public DocumentOrderingWrapper(DocumentInfo document) {
         documentInfo = document;
@@ -184,6 +185,7 @@ public class DocumentOrderingWrapper {
     }
 
     /**
+     * @param id the id to search for
      * @return <code>true</code> if this document is before the specified <code>id</code>, otherwise <code>false</code>
      */
     public boolean isBefore(String id) {
@@ -191,6 +193,7 @@ public class DocumentOrderingWrapper {
     }
 
     /**
+     * @param id the id to search for
      * @return <code>true</code> if this document is after the specified <code>id</code>, otherwise <code>false</code>
      */
     public boolean isAfter(String id) {
@@ -270,6 +273,7 @@ public class DocumentOrderingWrapper {
     /**
      * Sort the provided array of <code>Document</code>s per the requirements of the 2.0 specification. Note, that this
      * method only provides partial ordering and not absolute ordering.
+     * @param documents the documents to sort
      */
     public static void sort(DocumentOrderingWrapper[] documents) {
 

--- a/impl/src/main/java/com/sun/faces/config/processor/ConfigProcessor.java
+++ b/impl/src/main/java/com/sun/faces/config/processor/ConfigProcessor.java
@@ -30,6 +30,8 @@ public interface ConfigProcessor {
 
     /**
      * Called to initialize the per-application metadata used by the ConfigProcessor
+     * @param servletContext the involved servlet context
+     * @param facesContext the involved faces context
      */
     void initializeClassMetadataMap(ServletContext servletContext, FacesContext facesContext);
 
@@ -40,7 +42,8 @@ public interface ConfigProcessor {
      *
      * @param servletContext the <code>ServletContext</code> for the application being configured
      * @param facesContext the current faces context
-     * @param documentInfos @throws Exception if an error occurs during processing
+     * @param documentInfos the document infos
+     * @throws Exception if an error occurs during processing
      */
     void process(ServletContext servletContext, FacesContext facesContext, DocumentInfo[] documentInfos) throws Exception;
 

--- a/impl/src/main/java/com/sun/faces/context/AjaxExceptionHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/context/AjaxExceptionHandlerImpl.java
@@ -63,7 +63,6 @@ public class AjaxExceptionHandlerImpl extends ExceptionHandlerWrapper {
     }
 
     /**
-     * @return
      * @see ExceptionHandler#getHandledExceptionQueuedEvent()
      */
     @Override

--- a/impl/src/main/java/com/sun/faces/context/ExternalContextImpl.java
+++ b/impl/src/main/java/com/sun/faces/context/ExternalContextImpl.java
@@ -763,9 +763,6 @@ public class ExternalContextImpl extends ExternalContext {
 
     /**
      * @see ExternalContext#addResponseCookie(String, String, java.util.Map)
-     * @param name
-     * @param value
-     * @param properties
      */
     @Override
     public void addResponseCookie(String name, String value, Map<String, Object> properties) {

--- a/impl/src/main/java/com/sun/faces/context/StateContext.java
+++ b/impl/src/main/java/com/sun/faces/context/StateContext.java
@@ -160,6 +160,8 @@ public class StateContext {
     /**
      * Installs a <code>SystemEventListener</code> on the <code>UIViewRoot</code> to track components added to or removed
      * from the view.
+     * @param ctx the involved faces context
+     * @param root the involved view root
      */
     public void startTrackViewModifications(FacesContext ctx, UIViewRoot root) {
         if (modListener == null) {
@@ -239,6 +241,7 @@ public class StateContext {
 
     /**
      * Get the dynamic list (of adds and removes).
+     * @return the dynamic list
      */
     public List<ComponentStruct> getDynamicActions() {
         return modListener != null ? modListener.getDynamicActions() : null;

--- a/impl/src/main/java/com/sun/faces/context/flash/ELFlash.java
+++ b/impl/src/main/java/com/sun/faces/context/flash/ELFlash.java
@@ -640,6 +640,9 @@ public class ELFlash extends Flash {
      * necessary because the call to extContext.flushBuffer() is too late, the response has already been committed by that
      * point. outgoingResponseIsRedirect is false.
      * </p>
+     * 
+     * @param context the involved faces context
+     * @param outgoingResponseIsRedirect whether outgoing response is redirect
      */
     public void doLastPhaseActions(FacesContext context, boolean outgoingResponseIsRedirect) {
         Map<Object, Object> contextMap = context.getAttributes();

--- a/impl/src/main/java/com/sun/faces/facelets/FaceletContextImplBase.java
+++ b/impl/src/main/java/com/sun/faces/facelets/FaceletContextImplBase.java
@@ -33,7 +33,7 @@ public abstract class FaceletContextImplBase extends FaceletContext {
     /**
      * Push the passed TemplateClient onto the stack for Definition Resolution
      *
-     * @param client
+     * @param client the template client
      * @see TemplateClient
      */
     public abstract void pushClient(TemplateClient client);
@@ -41,6 +41,7 @@ public abstract class FaceletContextImplBase extends FaceletContext {
     /**
      * Pop the last added TemplateClient
      *
+     * @param client the template client
      * @see TemplateClient
      */
     public abstract void popClient(TemplateClient client);
@@ -54,10 +55,10 @@ public abstract class FaceletContextImplBase extends FaceletContext {
      * @param parent the UIComponent to apply to
      * @param name name or null of the definition you want to apply
      * @return true if successfully applied, otherwise false
-     * @throws IOException
-     * @throws FaceletException
-     * @throws FacesException
-     * @throws ELException
+     * @throws IOException when an I/O exception occurs
+     * @throws FaceletException when a Facelet exception occurs
+     * @throws FacesException when a Faces exception occurs
+     * @throws ELException when an EL exception occurs
      */
     public abstract boolean includeDefinition(UIComponent parent, String name) throws IOException, FaceletException, FacesException, ELException;
 

--- a/impl/src/main/java/com/sun/faces/facelets/TemplateClient.java
+++ b/impl/src/main/java/com/sun/faces/facelets/TemplateClient.java
@@ -44,10 +44,10 @@ public interface TemplateClient {
      * 
      * @return true if this client matched/applied the definition for the passed name
      * 
-     * @throws IOException
-     * @throws FacesException
-     * @throws FaceletException
-     * @throws ELException
+     * @throws IOException when an I/O exception occurs
+     * @throws FaceletException when a Facelet exception occurs
+     * @throws FacesException when a Faces exception occurs
+     * @throws ELException when an EL exception occurs
      */
     boolean apply(FaceletContext ctx, UIComponent parent, String name) throws IOException;
 

--- a/impl/src/main/java/com/sun/faces/facelets/el/ELText.java
+++ b/impl/src/main/java/com/sun/faces/facelets/el/ELText.java
@@ -29,9 +29,11 @@ import jakarta.el.ELContext;
 import jakarta.el.ELException;
 import jakarta.el.ExpressionFactory;
 import jakarta.el.ValueExpression;
+import jakarta.faces.FacesException;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
 import jakarta.faces.view.Location;
+import jakarta.faces.view.facelets.FaceletException;
 
 /**
  * Handles parsing EL Strings in accordance with the EL-API Specification. The parser accepts either <code>${..}</code>
@@ -246,8 +248,8 @@ public class ELText {
      *
      * @param out Writer to write to
      * @param ctx current ELContext state
-     * @throws ELException
-     * @throws IOException
+     * @throws ELException when an EL exception occurs
+     * @throws IOException when an I/O exception occurs
      */
     public void write(Writer out, ELContext ctx) throws ELException, IOException {
         out.write(literal);
@@ -261,7 +263,7 @@ public class ELText {
      * Evaluates the ELText to a String
      *
      * @param ctx current ELContext state
-     * @throws ELException
+     * @throws ELException when an EL exception occurs
      * @return the evaluated String
      */
     public String toString(ELContext ctx) throws ELException {
@@ -291,7 +293,7 @@ public class ELText {
      *
      * @param in String to parse
      * @return ELText instance that knows if the String was literal or not
-     * @throws jakarta.el.ELException
+     * @throws ELException when an EL exception occurs
      */
     public static ELText parse(String in) throws ELException {
         return parse(null, null, in);
@@ -314,8 +316,9 @@ public class ELText {
      * @param fact ExpressionFactory to use
      * @param ctx ELContext to validate against
      * @param in String to parse
+     * @param alias the alias
      * @return ELText that can be re-applied later
-     * @throws jakarta.el.ELException
+     * @throws ELException when an EL exception occurs
      */
     public static ELText parse(ExpressionFactory fact, ELContext ctx, String in, String alias) throws ELException {
         char[] ca = in.toCharArray();

--- a/impl/src/main/java/com/sun/faces/facelets/el/VariableMapperWrapper.java
+++ b/impl/src/main/java/com/sun/faces/facelets/el/VariableMapperWrapper.java
@@ -38,7 +38,7 @@ public class VariableMapperWrapper extends VariableMapper {
     private Map vars;
 
     /**
-     *
+     * @param orig the original variable mapper to be wrapped
      */
     public VariableMapperWrapper(VariableMapper orig) {
         super();

--- a/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFaceletFactory.java
+++ b/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFaceletFactory.java
@@ -152,7 +152,7 @@ public class DefaultFaceletFactory {
      *
      * @return resolved URL
      *
-     * @throws IOException
+     * @throws IOException when an I/O exception occurs
      */
     public URL resolveURL(URL source, String path) throws IOException {
         // PENDING(FCAPUTO): always go to the resolver to make resource library contracts work with relative urls
@@ -171,14 +171,15 @@ public class DefaultFaceletFactory {
      * Create a Facelet from the passed URL. This method checks if the cached Facelet needs to be refreshed before
      * returning. If so, uses the passed URL to build a new instance;
      *
+     * @param context the involved faces context
      * @param url source url
      *
      * @return Facelet instance
      *
-     * @throws IOException
-     * @throws FaceletException
-     * @throws FacesException
-     * @throws ELException
+     * @throws IOException when an I/O exception occurs
+     * @throws FaceletException when a Facelet exception occurs
+     * @throws FacesException when a Faces exception occurs
+     * @throws ELException when an EL exception occurs
      */
     public Facelet getFacelet(FacesContext context, URL url) throws IOException {
         Facelet result = getCache(context).getFacelet(url);

--- a/impl/src/main/java/com/sun/faces/facelets/tag/AbstractTagLibrary.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/AbstractTagLibrary.java
@@ -499,7 +499,7 @@ public abstract class AbstractTagLibrary implements TagLibrary {
      * Add a ComponentHandlerImpl with the specified componentType and rendererType, aliased by the tag name.
      *
      * @see jakarta.faces.application.Application#createComponent(java.lang.String)
-     * @param name name to use, "foo" would be &lt;my:foo />
+     * @param name name to use, "foo" would be {@code <my:foo />}
      * @param componentType componentType to use
      * @param rendererType rendererType to use
      */
@@ -511,7 +511,7 @@ public abstract class AbstractTagLibrary implements TagLibrary {
      * Add a ComponentHandlerImpl with the specified componentType and rendererType, aliased by the tag name. The Facelet
      * will be compiled with the specified HandlerType (which must extend AbstractComponentHandler).
      *
-     * @param name name to use, "foo" would be &lt;my:foo />
+     * @param name name to use, "foo" would be {@code <my:foo />}
      * @param componentType componentType to use
      * @param rendererType rendererType to use
      * @param handlerType a Class that extends ComponentHandler
@@ -525,7 +525,7 @@ public abstract class AbstractTagLibrary implements TagLibrary {
      *
      * @see ConverterHandler
      * @see jakarta.faces.application.Application#createConverter(java.lang.String)
-     * @param name name to use, "foo" would be &lt;my:foo />
+     * @param name name to use, "foo" would be {@code <my:foo />}
      * @param converterId id to pass to Application instance
      */
     protected final void addConverter(String name, String converterId) {
@@ -538,7 +538,7 @@ public abstract class AbstractTagLibrary implements TagLibrary {
      * @see ConverterHandler
      * @see ConverterConfig
      * @see jakarta.faces.application.Application#createConverter(java.lang.String)
-     * @param name name to use, "foo" would be &lt;my:foo />
+     * @param name name to use, "foo" would be {@code <my:foo />}
      * @param converterId id to pass to Application instance
      * @param type TagHandler type that takes in a ConverterConfig
      */
@@ -551,7 +551,7 @@ public abstract class AbstractTagLibrary implements TagLibrary {
      *
      * @see ValidatorHandler
      * @see jakarta.faces.application.Application#createValidator(java.lang.String)
-     * @param name name to use, "foo" would be &lt;my:foo />
+     * @param name name to use, "foo" would be {@code <my:foo />}
      * @param validatorId id to pass to Application instance
      */
     protected final void addValidator(String name, String validatorId) {
@@ -564,7 +564,7 @@ public abstract class AbstractTagLibrary implements TagLibrary {
      * @see ValidatorHandler
      * @see ValidatorConfig
      * @see jakarta.faces.application.Application#createValidator(java.lang.String)
-     * @param name name to use, "foo" would be &lt;my:foo />
+     * @param name name to use, "foo" would be {@code <my:foo />}
      * @param validatorId id to pass to Application instance
      * @param type TagHandler type that takes in a ValidatorConfig
      */
@@ -591,7 +591,7 @@ public abstract class AbstractTagLibrary implements TagLibrary {
      * Use the specified HandlerType in compiling Facelets. HandlerType must extend TagHandler.
      *
      * @see TagHandler
-     * @param name name to use, "foo" would be &lt;my:foo />
+     * @param name name to use, "foo" would be {@code <my:foo />}
      * @param handlerType must extend TagHandler
      */
     protected final void addTagHandler(String name, Class handlerType) {
@@ -602,7 +602,7 @@ public abstract class AbstractTagLibrary implements TagLibrary {
      * Add a UserTagHandler specified a the URL source.
      *
      * @see UserTagHandler
-     * @param name name to use, "foo" would be &lt;my:foo />
+     * @param name name to use, "foo" would be {@code <my:foo />}
      * @param source source where the Facelet (Tag) source is
      */
     protected final void addUserTag(String name, URL source) {
@@ -613,7 +613,7 @@ public abstract class AbstractTagLibrary implements TagLibrary {
      * Add a CompositeComponentTagHandler for the specified resource.
      *
      * @see UserTagHandler
-     * @param name name to use, "foo" would be &lt;my:foo />
+     * @param name name to use, "foo" would be {@code <my:foo />}
      * @param resourceId source where the Facelet (Tag) source is
      */
     protected final void addCompositeComponentTag(String name, String resourceId) {

--- a/impl/src/main/java/com/sun/faces/facelets/tag/TagLibrary.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/TagLibrary.java
@@ -36,6 +36,7 @@ public interface TagLibrary {
      *
      * @param ns namespace
      * @param t the tag instance currently active at the time this method is called. May be null
+     * @return whether the namespace is used in this library
      *
      */
     boolean containsNamespace(String ns, Tag t);
@@ -45,6 +46,7 @@ public interface TagLibrary {
      *
      * @param ns namespace
      * @param localName local name
+     * @return whether handled by this library
      */
     boolean containsTagHandler(String ns, String localName);
 
@@ -55,7 +57,7 @@ public interface TagLibrary {
      * @param localName local name
      * @param tag configuration information
      * @return a new TagHandler instance
-     * @throws FacesException
+     * @throws FacesException when a Faces exception occurs
      */
     TagHandler createTagHandler(String ns, String localName, TagConfig tag) throws FacesException;
 
@@ -73,6 +75,7 @@ public interface TagLibrary {
      *
      * @param ns namespace
      * @param name function name
+     * @return a Method instance for the passed namespace and name
      */
     Method createFunction(String ns, String name);
 }

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/core/AjaxHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/core/AjaxHandler.java
@@ -77,9 +77,7 @@ import jakarta.faces.view.facelets.TagHandler;
  * <li>Add the {@link AjaxBehavior} instance to the {@link ClientBehaviorHolder} component by calling
  * {@link ClientBehaviorHolder#addClientBehavior} passing <code>event</code> and the {@link AjaxBehavior} instance.</li>
  * </ul>
- * <br/>
- * <br/>
- * 
+ * <p>
  * Check for the existence of the Ajax resource by calling <code>UIViewRoot.getComponentResources()</code>. If the Ajax
  * resource does not exist, create a <code>UIOutput</code> component instance and set the renderer type to
  * <code>jakarta.faces.resource.Script</code>. Set the the following attributes in the component's attribute
@@ -87,7 +85,7 @@ import jakarta.faces.view.facelets.TagHandler;
  * <code>name</code> with the value {@value ResourceHandler#FACES_SCRIPT_RESOURCE_NAME}. Install the component resource
  * using <code>UIViewRoot.addComponentResource()</code> and specifying <code>head</code> as the <code>target</code>
  * argument.
- *
+ * <p>
  * If this tag has component children, add the {@link AjaxBehavior} to {@link AjaxBehaviors} by calling
  * {@link AjaxBehaviors#pushBehavior}. As subsequent child components that implement the {@link ClientBehaviorHolder}
  * interface are evaluated this {@link AjaxBehavior} instance must be added as a behavior to the component.

--- a/util/src/main/java/com/sun/faces/test/util/HttpUtils.java
+++ b/util/src/main/java/com/sun/faces/test/util/HttpUtils.java
@@ -27,13 +27,20 @@ public class HttpUtils {
     /**
      * <p>Create an HTTP request line from the following parameters.</p>
      * 
-     * <code><pre>&lt;methodName&gt; + " /" + &lt;path&gt; + " HTTP/1.1\r\n"</pre></code>
+     * <pre><code>&lt;methodName&gt; + " /" + &lt;path&gt; + " HTTP/1.1\r\n"</code></pre>
      * 
      * <p>Open a socket to the specified host and port, and issue the request. 
      * Read the result into a buffer and return it as the result.  Save aside the
      * HTTP response code into the outbound argument rc, which must have 
      * at least one element.</p>
      * 
+     * @param methodName the desired http method
+     * @param rc the mutable holder for the response code
+     * @param host the target host
+     * @param port the target port
+     * @param path the target path
+     * @return the response
+     * @throws Exception when an exception occurs
      */ 
 
     public static String issueHttpRequest(String methodName, int [] rc, String host, String port, String path) throws Exception {


### PR DESCRIPTION
Maven javadoc plugin was updated during https://github.com/eclipse-ee4j/mojarra/pull/5008 and was more restrictive.

This PR fixes javadoc errors in such way that `mvn javadoc:javadoc` completes successfully on `java -version` of 11.