### PR TITLE
Fix container ID of development stage messages

### DIFF
--- a/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
@@ -150,6 +150,8 @@ public class RenderKitUtils {
 
     protected static final Logger LOGGER = FacesLogger.RENDERKIT.getLogger();
 
+    public static final String DEVELOPMENT_STAGE_MESSAGES_ID = "jakarta_faces_developmentstage_messages";
+
     /**
      * @see UIViewRoot#encodeChildren(FacesContext)
      */
@@ -1048,7 +1050,7 @@ public class RenderKitUtils {
         if (ctx.isProjectStage(ProjectStage.Development)) {
             Application app = ctx.getApplication();
             HtmlMessages messages = (HtmlMessages) app.createComponent(HtmlMessages.COMPONENT_TYPE);
-            messages.setId("javax_faces_developmentstage_messages");
+            messages.setId(DEVELOPMENT_STAGE_MESSAGES_ID);
             Renderer messagesRenderer = ctx.getRenderKit().getRenderer(HtmlMessages.COMPONENT_FAMILY, "jakarta.faces.Messages");
             messages.setErrorStyle("Color: red");
             messages.setWarnStyle("Color: orange");

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/MessagesRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/MessagesRenderer.java
@@ -88,7 +88,7 @@ public class MessagesRenderer extends HtmlBasicRenderer {
                 // no message to render, but must render anyway
                 // but if we're writing the dev stage messages,
                 // only write it if messages exist
-                if ("jakarta_faces_developmentstage_messages".equals(component.getId())) {
+                if (RenderKitUtils.DEVELOPMENT_STAGE_MESSAGES_ID.equals(component.getId())) {
                     return;
                 }
                 writer.startElement("div", component);


### PR DESCRIPTION
Old one was hardcoded in 2 places and one of them still had javax.