### PR TITLE
Analyzed and fixed failing testSpec790WithNamespacedViewAjaxNavigation

### DIFF
--- a/test2/faces23/namespacedView/src/test/java/com/sun/faces/test/javaee8/namespacedView/Spec790WithNamespacedViewIT.java
+++ b/test2/faces23/namespacedView/src/test/java/com/sun/faces/test/javaee8/namespacedView/Spec790WithNamespacedViewIT.java
@@ -122,7 +122,6 @@ public class Spec790WithNamespacedViewIT {
     }
 
     @Test
-    @Ignore // Fails due to yet unknown cause -- TODO: investigate
     public void testSpec790WithNamespacedViewAjaxNavigation() throws Exception {
         webClient.setIncorrectnessListener((o, i) -> {});
 
@@ -137,8 +136,6 @@ public class Spec790WithNamespacedViewIT {
         page = button.click();
         webClient.waitForBackgroundJavaScript(60000);
         
-        System.out.println(page.asXml()); // Ajax button doesn't seem to be executed at all. Probably JS error?
-
         namingContainerPrefix = page.getHead().getId().split("(?<=:)", 2)[0];
         HtmlForm form1 = (HtmlForm) page.getHtmlElementById(namingContainerPrefix + "form1");
         HtmlInput form1ViewState = (HtmlInput) form1.getInputByName(namingContainerPrefix + "jakarta.faces.ViewState");


### PR DESCRIPTION
It ultimately boiled down to that the `<html>` element didn't have an ID and also couldn't have one on a servlet
based environment (on a portlet based one it could have) but the test itself runs on a servlet based environment, so a kind of work around was introduced to `faces.js` to infer `render="@all"` in case the to-be-updated element was a `UIViewRoot` as well as a `NamingContainer` and the ID did not exist (previous impl threw error "During update: j_id1 not found").

FYI: entire /test2 was executed on this PR and all tests passed.