### PR TITLE
Issue #5059: FACELETS_REFRESH_PERIOD > 0 triggers incorrect rendering

### DIFF
--- a/impl/src/main/java/jakarta/faces/component/ComponentStateHelper.java
+++ b/impl/src/main/java/jakarta/faces/component/ComponentStateHelper.java
@@ -233,13 +233,13 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
     }
 
     private void initList(Serializable key) {
-        if (component.initialStateMarked()) {
-            deltaMap.computeIfAbsent(key, e -> new ArrayList<>(4));
-        }
-
         if (get(key) == null) {
             List<Object> items = new ArrayList<>(4);
             defaultMap.put(key, items);
+        }
+
+        if (component.initialStateMarked()) {
+            deltaMap.computeIfAbsent(key, e -> new ArrayList<>((List<Object>) get(key)));
         }
     }
 

--- a/impl/src/test/java/jakarta/faces/component/UIComponentBaseTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIComponentBaseTestCase.java
@@ -18,13 +18,12 @@ package jakarta.faces.component;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
-import com.sun.faces.mock.MockExternalContext;
 
 import jakarta.faces.FacesException;
 import jakarta.faces.context.FacesContext;
@@ -360,6 +359,21 @@ public class UIComponentBaseTestCase extends UIComponentTestCase {
         c.popComponentFromEL(facesContext);
         assertTrue(c.getListenersForEventClass(PostAddToViewEvent.class).size() == 1);
 
+    }
+
+    public void testAttributesThatAreSetStateHolder() throws Exception {
+        ComponentTestImpl c = new ComponentTestImpl();
+        c.getAttributes().put("attr1", "value1");
+        c.markInitialState();
+        c.getAttributes().put("attr2", "value2");
+        assertEquals(Arrays.asList("attr1", "attr2"), c.getAttributes().get("jakarta.faces.component.UIComponentBase.attributesThatAreSet"));
+
+        Object state = c.saveState(facesContext);
+        c = new ComponentTestImpl();
+        c.pushComponentToEL(facesContext, c);
+        c.restoreState(facesContext, state);
+        c.popComponentFromEL(facesContext);
+        assertEquals(Arrays.asList("attr1", "attr2"), c.getAttributes().get("jakarta.faces.component.UIComponentBase.attributesThatAreSet"));
     }
 
     public void testValueExpressions() throws Exception {


### PR DESCRIPTION
Issue: #5059 

Now the `initList` initializes the `deltaMap` with the values in the `defaultMap`. That way, when restoring, attributes are not lost. Little test added to check that `attributesThatAreSet` are restored OK when there were initial values before marking initial state.