### PR TITLE
Remove checks for Servlet < 3.0

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceCache.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceCache.java
@@ -174,13 +174,7 @@ public class ResourceCache {
 
 
     private static String getServletContextIdentifier(ServletContext context) {
-
-        if (context.getMajorVersion() == 2 && context.getMinorVersion() < 5) {
-            return context.getServletContextName();
-        } else {
-            return context.getContextPath();
-        }
-
+        return context.getContextPath();
     }
 
 

--- a/impl/src/main/java/com/sun/faces/config/ConfigureListener.java
+++ b/impl/src/main/java/com/sun/faces/config/ConfigureListener.java
@@ -632,14 +632,10 @@ public class ConfigureListener implements ServletRequestListener, HttpSessionLis
 
 
     private static String getServletContextIdentifier(ServletContext context) {
-        if (context.getMajorVersion() == 2 && context.getMinorVersion() < 5) {
+        try {
+            return context.getContextPath();
+        } catch(AbstractMethodError error){
             return context.getServletContextName();
-        } else {
-            try {
-                return context.getContextPath();
-            } catch(AbstractMethodError error){
-                return context.getServletContextName();
-            }
         }
     }
 
@@ -856,11 +852,6 @@ public class ConfigureListener implements ServletRequestListener, HttpSessionLis
          */
         private void scanForFacesServlet(ServletContext context) {
             InputStream in = context.getResourceAsStream(WEB_XML_PATH);
-            if (in == null) {
-                if (context.getMajorVersion() < 3) {
-                    throw new ConfigurationException("no web.xml present");
-                }
-            }
             SAXParserFactory factory = getConfiguredFactory();
             if (in != null) {
                 try {
@@ -882,7 +873,7 @@ public class ConfigureListener implements ServletRequestListener, HttpSessionLis
                     }
                 }
             }
-            if (!facesServletPresent && context.getMajorVersion() >= 3) {
+            if (!facesServletPresent) {
                 ClassLoader cl = Util.getCurrentLoader(this);
                 Enumeration<URL> urls;
                 try {

--- a/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
+++ b/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
@@ -332,11 +332,6 @@ public class WebConfiguration {
      * @return the name of this application
      */
     public String getServletContextName() {
-
-        if (servletContext.getMajorVersion() == 2 && servletContext.getMinorVersion() <= 4) {
-            return servletContext.getServletContextName();
-        }
-
         return servletContext.getContextPath();
     }
 

--- a/impl/src/main/java/com/sun/faces/context/ExternalContextImpl.java
+++ b/impl/src/main/java/com/sun/faces/context/ExternalContextImpl.java
@@ -182,16 +182,7 @@ public class ExternalContextImpl extends ExternalContext {
      */
     @Override
     public String getContextName() {
-
-        if (servletContext.getMajorVersion() >= 3
-            || (servletContext.getMajorVersion() == 2
-                && servletContext.getMinorVersion() == 5)) {
-            return this.servletContext.getServletContextName();
-        } else {
-            // for servlet 2.4 support
-            return servletContext.getServletContextName();
-        }
-
+        return this.servletContext.getServletContextName();
     }
 
 


### PR DESCRIPTION
For JSF 2.3 the Servlet API version should always be at least 3.0 or newer, so all these checks are redundant.

see https://github.com/eclipse-ee4j/mojarra/issues/5061#issuecomment-1061277845