### PR TITLE
Do not log ClientAbortException

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
@@ -325,7 +325,11 @@ public class ResourceHandlerImpl extends ResourceHandler {
                     }
 
                 } catch (IOException ioe) {
-                    send404(context, resourceName, libraryName, ioe, true);
+                    if (isClientAbortException(ioe)) {
+                        send404(context, resourceName, libraryName, false);
+                    } else {
+                        send404(context, resourceName, libraryName, ioe, true);
+                    }
                 } finally {
                     if (out != null) {
                         try {
@@ -347,6 +351,10 @@ public class ResourceHandlerImpl extends ResourceHandler {
             send404(context, resourceName, libraryName, true);
         }
 
+    }
+
+    private static boolean isClientAbortException(IOException ioe) {
+        return ioe.getClass().getCanonicalName().equals("org.apache.catalina.connector.ClientAbortException");
     }
     
     private boolean libraryNameIsSafe(String libraryName) {

--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
@@ -325,7 +325,7 @@ public class ResourceHandlerImpl extends ResourceHandler {
                     }
 
                 } catch (IOException ioe) {
-                    if (isClientAbortException(ioe)) {
+                    if (isConnectionAbort(ioe)) { // to be removed, when the exception is standardised in servlet.
                         send404(context, resourceName, libraryName, false);
                     } else {
                         send404(context, resourceName, libraryName, ioe, true);
@@ -353,8 +353,9 @@ public class ResourceHandlerImpl extends ResourceHandler {
 
     }
 
-    private static boolean isClientAbortException(IOException ioe) {
-        return ioe.getClass().getCanonicalName().equals("org.apache.catalina.connector.ClientAbortException");
+    private static boolean isConnectionAbort(IOException ioe) {
+        return ioe.getClass().getCanonicalName().equals("org.apache.catalina.connector.ClientAbortException") ||
+               ioe.getClass().getCanonicalName().equals("org.eclipse.jetty.io.EofException");
     }
     
     private boolean libraryNameIsSafe(String libraryName) {


### PR DESCRIPTION
## Description

This is a horribly flaky issue and usually only happens when using in Firefox.
Reproducing this consistently is next to impossible.

The issue has been listed multiple times for Mojarra already, namely [#547](https://github.com/eclipse-ee4j/mojarra/issues/547) and [#4280](https://github.com/eclipse-ee4j/mojarra/issues/4280)

This occurs due to Firefox's behaviour, when sending requests for resources, but canceling/dropping the connection midway through, because the cache was faster. There are 4 possible behaviours as described on the [Mozilla support-page](https://support.mozilla.org/en-US/questions/1267945). Of the 4 cases, the ClientAbortException only happens in case 4.

## Current Behaviour

The ClientAbortConnection is logged as IOException in the method call to `send404(context, resourceName, libraryName, ioe, true);`

It is logged on level `Warning` and prints the whole stacktrace into the log.

## This Change

The ClientAbortException is no longer logged, as there is no action that can be taken by the server.

## Further Details / Questions

- MyFaces handles it already like this. [Their implementation.](https://github.com/apache/myfaces/blob/ca18e438dd959de904bf5390906e9d6132ee4219/impl/src/main/java/org/apache/myfaces/application/ResourceHandlerImpl.java#L610)
- How should I handle the translation of the error messages?
- My current change does not abstract away sending the 404 status. I currently opted for the shortest possible fix. Is another approach suited better e.g. handling it inside `send404`?