### PR TITLE
Fix #4260: AttachedObjectListHolder IndexOutOfBounds fix 3.0

### DIFF
--- a/impl/src/main/java/jakarta/faces/component/AttachedObjectListHolder.java
+++ b/impl/src/main/java/jakarta/faces/component/AttachedObjectListHolder.java
@@ -139,7 +139,7 @@ class AttachedObjectListHolder<T> implements PartialStateHolder {
                     add(restored);
                 }
             }
-        } else {
+        } else if (this.attachedObjects != null) {
             // Assume 1:1 relation between existing attachedObjects and state
             for (int i = 0, len = attachedObjects.length; i < len; i++) {
                 T attachedObject = this.attachedObjects.get(i);


### PR DESCRIPTION
Signed-off-by: melloware <mellowaredev@gmail.com>