### PR TITLE
Fix #5120: no need to doublecheck if view exists when invoked via ViewHandler#deriveLogicalViewId() instead of deriveViewId()

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/MultiViewHandler.java
+++ b/impl/src/main/java/com/sun/faces/application/view/MultiViewHandler.java
@@ -503,9 +503,7 @@ public class MultiViewHandler extends ViewHandler {
 
             appendOrReplaceExtension(viewId, ext, length, extIdx, buffer);
 
-            String convertedViewId = buffer.toString();
-
-            return convertedViewId;
+            return buffer.toString();
         }
 
         return viewId;

--- a/impl/src/main/java/com/sun/faces/application/view/MultiViewHandler.java
+++ b/impl/src/main/java/com/sun/faces/application/view/MultiViewHandler.java
@@ -505,12 +505,7 @@ public class MultiViewHandler extends ViewHandler {
 
             String convertedViewId = buffer.toString();
 
-            ViewDeclarationLanguage vdl = getViewDeclarationLanguage(context, convertedViewId);
-
-            if (vdl.viewExists(context, convertedViewId)) {
-                // RELEASE_PENDING (rlubke,driscoll) cache the lookup
-                return convertedViewId;
-            }
+            return convertedViewId;
         }
 
         return viewId;


### PR DESCRIPTION
https://github.com/eclipse-ee4j/mojarra/issues/5120