### PR TITLE
Various fixes of warnings in tests

### DIFF
--- a/impl/src/test/java/com/sun/faces/mock/MockApplication.java
+++ b/impl/src/test/java/com/sun/faces/mock/MockApplication.java
@@ -258,7 +258,7 @@ public class MockApplication extends Application {
     }
 
     @Override
-    public Converter createConverter(Class targetClass) {
+    public Converter createConverter(Class<?> targetClass) {
         throw new UnsupportedOperationException();
     }
 
@@ -941,15 +941,15 @@ public class MockApplication extends Application {
             try {
                 return systemEvent.getDeclaredConstructor(source);
             } catch (NoSuchMethodException ignored) {
-                Constructor[] ctors = systemEvent.getConstructors();
+                Constructor<?>[] ctors = systemEvent.getConstructors();
                 if (ctors != null) {
-                    for (Constructor c : ctors) {
+                    for (Constructor<?> c : ctors) {
                         Class<?>[] params = c.getParameterTypes();
                         if (params.length != 1) {
                             continue;
                         }
                         if (params[0].isAssignableFrom(source)) {
-                            return c;
+                            return (Constructor<? extends SystemEvent>) c;
                         }
                     }
                 }

--- a/impl/src/test/java/com/sun/faces/mock/MockApplicationMap.java
+++ b/impl/src/test/java/com/sun/faces/mock/MockApplicationMap.java
@@ -115,7 +115,7 @@ final class MockApplicationMap implements Map<String, Object> {
     }
 
     @Override
-    public void putAll(Map map) {
+    public void putAll(Map<? extends String, ? extends Object> map) {
         Iterator<?> keys = map.keySet().iterator();
         while (keys.hasNext()) {
             String key = (String) keys.next();

--- a/impl/src/test/java/com/sun/faces/mock/MockFacesContextFactory.java
+++ b/impl/src/test/java/com/sun/faces/mock/MockFacesContextFactory.java
@@ -32,30 +32,31 @@ import jakarta.faces.lifecycle.Lifecycle;
 
 public class MockFacesContextFactory extends FacesContextFactory {
     public MockFacesContextFactory(FacesContextFactory oldImpl) {
-	System.setProperty(FactoryFinder.FACES_CONTEXT_FACTORY, 
-			   this.getClass().getName());
+        super(oldImpl);
+        System.setProperty(FactoryFinder.FACES_CONTEXT_FACTORY, this.getClass().getName());
     }
     public MockFacesContextFactory() {}
     
+
     @Override
     public FacesContext getFacesContext(Object context, Object request,
-					Object response, 
+					Object response,
 					Lifecycle lifecycle) throws FacesException {
 	MockFacesContext result = new MockFacesContext();
-        
+
         ExternalContext externalContext =
-                new MockExternalContext((ServletContext) context, 
+                new MockExternalContext((ServletContext) context,
                 (ServletRequest) request, (ServletResponse) response);
         result.setExternalContext(externalContext);
         ApplicationFactory applicationFactory = (ApplicationFactory)
                 FactoryFinder.getFactory(FactoryFinder.APPLICATION_FACTORY);
-        Application application = (MockApplication) applicationFactory.getApplication();
+        Application application = applicationFactory.getApplication();
         result.setApplication(application);
-        
+
 	ELContext elContext = new MockELContext(new MockELResolver());
 	elContext.putContext(FacesContext.class, result);
         result.setELContext(elContext);
-        
+
         return result;
     }
 }

--- a/impl/src/test/java/com/sun/faces/mock/MockHttpServletRequest.java
+++ b/impl/src/test/java/com/sun/faces/mock/MockHttpServletRequest.java
@@ -68,7 +68,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
         setHttpSession(session);
     }
 
-    protected HashMap attributes = new HashMap();
+    protected HashMap<String, Object> attributes = new HashMap<>();
     protected String contextPath = null;
     protected Locale locale = null;
     protected HashMap<String, String[]> parameters = new HashMap<>();
@@ -271,8 +271,8 @@ public class MockHttpServletRequest implements HttpServletRequest {
     }
 
     @Override
-    public Enumeration getAttributeNames() {
-        return (new MockEnumeration(attributes.keySet().iterator()));
+    public Enumeration<String> getAttributeNames() {
+        return (new MockEnumeration<>(attributes.keySet().iterator()));
     }
 
     @Override
@@ -324,7 +324,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
     }
 
     @Override
-    public Enumeration getLocales() {
+    public Enumeration<Locale> getLocales() {
         throw new UnsupportedOperationException();
     }
 
@@ -339,13 +339,13 @@ public class MockHttpServletRequest implements HttpServletRequest {
     }
 
     @Override
-    public Map getParameterMap() {
+    public Map<String, String[]> getParameterMap() {
         return (parameters);
     }
 
     @Override
-    public Enumeration getParameterNames() {
-        return (new MockEnumeration(parameters.keySet().iterator()));
+    public Enumeration<String> getParameterNames() {
+        return (new MockEnumeration<>(parameters.keySet().iterator()));
     }
 
     @Override

--- a/impl/src/test/java/com/sun/faces/mock/MockRenderKit.java
+++ b/impl/src/test/java/com/sun/faces/mock/MockRenderKit.java
@@ -16,6 +16,9 @@
 
 package com.sun.faces.mock;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,15 +34,11 @@ import jakarta.faces.render.RenderKit;
 import jakarta.faces.render.Renderer;
 import jakarta.faces.render.ResponseStateManager;
 
-import java.io.Writer;
-import java.io.OutputStream;
-import java.io.IOException;
-
 public class MockRenderKit extends RenderKit {
 
     public MockRenderKit() {
         addRenderer(UIData.COMPONENT_FAMILY,
-                "jakarta.faces.Table", new TestRenderer(true));
+                "jakarta.faces.Table", new TestRenderer());
         addRenderer(UIInput.COMPONENT_FAMILY,
                 "TestRenderer", new TestRenderer());
         addRenderer(UIInput.COMPONENT_FAMILY,
@@ -49,11 +48,11 @@ public class MockRenderKit extends RenderKit {
         addRenderer(UIOutput.COMPONENT_FAMILY,
                 "jakarta.faces.Text", new TestRenderer());
         addRenderer(UIPanel.COMPONENT_FAMILY,
-                "jakarta.faces.Grid", new TestRenderer(true));
+                "jakarta.faces.Grid", new TestRenderer());
         responseStateManager = new MockResponseStateManager();
     }
 
-    private Map renderers = new HashMap();
+    private Map<String, Renderer> renderers = new HashMap<>();
     private ResponseStateManager responseStateManager = null;
 
     @Override
@@ -70,7 +69,7 @@ public class MockRenderKit extends RenderKit {
         if ((family == null) || (rendererType == null)) {
             throw new NullPointerException();
         }
-        return ((Renderer) renderers.get(family + "|" + rendererType));
+        return (renderers.get(family + "|" + rendererType));
     }
 
     @Override
@@ -116,15 +115,9 @@ public class MockRenderKit extends RenderKit {
         return responseStateManager;
     }
 
-    class TestRenderer extends Renderer {
-
-        private boolean rendersChildren = false;
+    class TestRenderer extends Renderer<UIComponent> {
 
         public TestRenderer() {
-        }
-
-        public TestRenderer(boolean rendersChildren) {
-            this.rendersChildren = rendersChildren;
         }
 
         @Override
@@ -142,7 +135,7 @@ public class MockRenderKit extends RenderKit {
             // System.err.println("decode(" + clientId + ")");
 
             // Decode incoming request parameters
-            Map params = context.getExternalContext().getRequestParameterMap();
+            Map<String, String> params = context.getExternalContext().getRequestParameterMap();
             if (params.containsKey(clientId)) {
                 // System.err.println("  '" + input.currentValue(context) +
                 //                    "' --> '" + params.get(clientId) + "'");

--- a/impl/src/test/java/com/sun/faces/mock/MockResultSet.java
+++ b/impl/src/test/java/com/sun/faces/mock/MockResultSet.java
@@ -18,27 +18,29 @@ package com.sun.faces.mock;
 
 import java.io.InputStream;
 import java.io.Reader;
-import java.sql.NClob;
-import java.sql.RowId;
-import java.sql.SQLXML;
-import java.util.Calendar;
-import java.util.Map;
 import java.math.BigDecimal;
 import java.net.URL;
 import java.sql.Array;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Date;
+import java.sql.NClob;
 import java.sql.Ref;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
+import java.sql.RowId;
 import java.sql.SQLException;
 import java.sql.SQLWarning;
+import java.sql.SQLXML;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
-import com.sun.faces.mock.model.BeanTestImpl;
+import java.util.Calendar;
+import java.util.Map;
+
 import org.apache.commons.beanutils.PropertyUtils;
+
+import com.sun.faces.mock.model.BeanTestImpl;
 
 /**
  * <p>
@@ -241,6 +243,7 @@ public class MockResultSet implements ResultSet {
     /**
      * @deprecated
      */
+    @Deprecated
     @Override
     public BigDecimal getBigDecimal(int columnIndex, int scale)
             throws SQLException {
@@ -256,6 +259,7 @@ public class MockResultSet implements ResultSet {
      * @param columnName
      * @deprecated
      */
+    @Deprecated
     @Override
     public BigDecimal getBigDecimal(String columnName, int scale)
             throws SQLException {
@@ -409,12 +413,12 @@ public class MockResultSet implements ResultSet {
     }
 
     @Override
-    public Object getObject(int columnIndex, Map map) throws SQLException {
+    public Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Object getObject(String columnName, Map map) throws SQLException {
+    public Object getObject(String columnName, Map<String, Class<?>> map) throws SQLException {
         throw new UnsupportedOperationException();
     }
 
@@ -498,6 +502,7 @@ public class MockResultSet implements ResultSet {
     /**
      * @deprecated
      */
+    @Deprecated
     @Override
     public InputStream getUnicodeStream(int columnIndex) throws SQLException {
         throw new UnsupportedOperationException();
@@ -507,6 +512,7 @@ public class MockResultSet implements ResultSet {
      * @param columnName
      * @deprecated
      */
+    @Deprecated
     @Override
     public InputStream getUnicodeStream(String columnName) throws SQLException {
         throw new UnsupportedOperationException();
@@ -1131,11 +1137,13 @@ public class MockResultSet implements ResultSet {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
+    @Override
     public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
+    @Override
     public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
-        throw new UnsupportedOperationException("Not supported yet."); 
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 }

--- a/impl/src/test/java/com/sun/faces/mock/MockSessionMap.java
+++ b/impl/src/test/java/com/sun/faces/mock/MockSessionMap.java
@@ -65,10 +65,10 @@ final class MockSessionMap implements Map<String, Object> {
 
     @Override
     public Set entrySet() {
-        Set set = new HashSet();
-        Enumeration keys = session.getAttributeNames();
+        Set<Object> set = new HashSet<>();
+        Enumeration<String> keys = session.getAttributeNames();
         while (keys.hasMoreElements()) {
-            set.add(session.getAttribute((String) keys.nextElement()));
+            set.add(session.getAttribute(keys.nextElement()));
         }
         return set;
     }

--- a/impl/src/test/java/com/sun/faces/renderkit/html_basic/HtmlResponseWriterTest.java
+++ b/impl/src/test/java/com/sun/faces/renderkit/html_basic/HtmlResponseWriterTest.java
@@ -107,6 +107,7 @@ public class HtmlResponseWriterTest {
         responseWriter.endElement("script");
         responseWriter.flush();
         assertEquals(expected, stringWriter.toString());
+        responseWriter.close();
 
         // Case 2 start is // end is /* */
         stringWriter = new StringWriter();
@@ -116,6 +117,7 @@ public class HtmlResponseWriterTest {
         responseWriter.endElement("script");
         responseWriter.flush();
         assertEquals(expected, stringWriter.toString());
+        responseWriter.close();
 
         // Case 3 start is /* */  end is /* */
         stringWriter = new StringWriter();
@@ -125,6 +127,7 @@ public class HtmlResponseWriterTest {
         responseWriter.endElement("script");
         responseWriter.flush();
         assertEquals(expected, stringWriter.toString());
+        responseWriter.close();
 
         // Case 4 start is /* */  end is //
         stringWriter = new StringWriter();
@@ -134,6 +137,7 @@ public class HtmlResponseWriterTest {
         responseWriter.endElement("script");
         responseWriter.flush();
         assertEquals(expected, stringWriter.toString());
+        responseWriter.close();
 
         // Case 5 start is /* */  end is //
         stringWriter = new StringWriter();
@@ -143,6 +147,7 @@ public class HtmlResponseWriterTest {
         responseWriter.endElement("script");
         responseWriter.flush();
         assertEquals(expected, stringWriter.toString());
+        responseWriter.close();
     }
 
     /**
@@ -163,6 +168,7 @@ public class HtmlResponseWriterTest {
         responseWriter.endElement("style");
         responseWriter.flush();
         assertEquals(expectedStart + "]]]><![CDATA[" + expectedEnd, stringWriter.toString());
+        responseWriter.close();
 
         // two chars
         stringWriter = new StringWriter();
@@ -174,6 +180,7 @@ public class HtmlResponseWriterTest {
         responseWriter.endElement("style");
         responseWriter.flush();
         assertEquals(expectedStart + "]]]><![CDATA[]]]><![CDATA[" + expectedEnd, stringWriter.toString());
+        responseWriter.close();
 
         // long string
         stringWriter = new StringWriter();
@@ -185,6 +192,7 @@ public class HtmlResponseWriterTest {
         responseWriter.endElement("style");
         responseWriter.flush();
         assertEquals(expectedStart + "abc]]]><![CDATA[]>abc" + expectedEnd, stringWriter.toString());
+        responseWriter.close();
     }
 
     /**
@@ -206,6 +214,6 @@ public class HtmlResponseWriterTest {
         responseWriter.endElement("style");
         responseWriter.flush();
         assertEquals(expectedStart + expectedEnd, stringWriter.toString());
-
+        responseWriter.close();
     }
 }

--- a/impl/src/test/java/jakarta/faces/component/InputValidatorTestImpl.java
+++ b/impl/src/test/java/jakarta/faces/component/InputValidatorTestImpl.java
@@ -24,7 +24,7 @@ import jakarta.faces.validator.Validator;
  * Test implementation of {@link Validator}.
  * </p>
  */
-public class InputValidatorTestImpl implements Validator {
+public class InputValidatorTestImpl implements Validator<Object> {
 
     protected String validatorId = null;
 

--- a/impl/src/test/java/jakarta/faces/component/SearchExpressionHandlerTest.java
+++ b/impl/src/test/java/jakarta/faces/component/SearchExpressionHandlerTest.java
@@ -153,17 +153,6 @@ public class SearchExpressionHandlerTest extends JUnitFacesTestCaseBase {
         }
     }
 
-    private String resolveClientIds(UIComponent source, String expressions, SearchExpressionHint... hints) {
-
-        SearchExpressionContext searchContext = SearchExpressionContext.createSearchExpressionContext(facesContext, source, new HashSet<>(Arrays.asList(hints)),
-                null);
-        SearchExpressionHandler handler = FacesContext.getCurrentInstance().getApplication().getSearchExpressionHandler();
-
-        List<String> clientIds = handler.resolveClientIds(searchContext, expressions);
-
-        return String.join(" ", clientIds);
-    }
-
     public void test_ResolveComponent_Parent() {
 
         UIComponent root = new UIPanel();

--- a/impl/src/test/java/jakarta/faces/component/StateHolderSaverTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/StateHolderSaverTestCase.java
@@ -79,6 +79,6 @@ public class StateHolderSaverTestCase extends UIComponentBaseTestCase {
 
         saver = new StateHolderSaver(facesContext, preSave);
         postSave = (IntegerConverter) saver.restore(facesContext);
-        assertTrue(true); // lack of ClassCastException
+        assertTrue(postSave != null); // lack of ClassCastException
     }
 }

--- a/impl/src/test/java/jakarta/faces/component/UIColumnTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIColumnTestCase.java
@@ -59,37 +59,9 @@ public class UIColumnTestCase extends UIComponentBaseTestCase {
     }
 
     // ------------------------------------------------- Individual Test Methods
-    // Test attribute-property transparency
-    @Override
-    public void testAttributesTransparency() {
-        super.testAttributesTransparency();
-        UIColumn column = (UIColumn) component;
-    }
-
     // Suppress lifecycle tests since we do not have a renderer
     @Override
     public void testLifecycleManagement() {
-    }
-
-    // Test a pristine UIColumn instance
-    @Override
-    public void testPristine() {
-        super.testPristine();
-        UIColumn column = (UIColumn) component;
-    }
-
-    // Test setting properties to invalid values
-    @Override
-    public void testPropertiesInvalid() throws Exception {
-        super.testPropertiesInvalid();
-        UIColumn column = (UIColumn) component;
-    }
-
-    // Test setting properties to valid values
-    @Override
-    public void testPropertiesValid() throws Exception {
-        super.testPropertiesValid();
-        UIColumn column = (UIColumn) component;
     }
 
     // --------------------------------------------------------- Support Methods

--- a/impl/src/test/java/jakarta/faces/component/UICommandTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UICommandTestCase.java
@@ -85,7 +85,7 @@ public class UICommandTestCase extends UIComponentBaseTestCase {
         // Override the default action listener to test ordering
         ActionListener oldDefaultActionListener = facesContext.getApplication().getActionListener();
         facesContext.getApplication().setActionListener(new CommandActionListenerTestImpl("14"));
-        Map map = new HashMap();
+        Map<String, String> map = new HashMap<>();
         map.put(command.getClientId(facesContext), "");
         MockExternalContext econtext = (MockExternalContext) facesContext.getExternalContext();
         econtext.setRequestParameterMap(map);
@@ -292,7 +292,7 @@ public class UICommandTestCase extends UIComponentBaseTestCase {
                 return;
             }
             String clientId = component.getClientId(context);
-            Map params = context.getExternalContext().getRequestParameterMap();
+            Map<String, String> params = context.getExternalContext().getRequestParameterMap();
             if (params.containsKey(clientId)) {
                 component.queueEvent(new ActionEvent(component));
             }

--- a/impl/src/test/java/jakarta/faces/component/UICommandTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UICommandTestCase.java
@@ -206,13 +206,6 @@ public class UICommandTestCase extends UIComponentBaseTestCase {
     public void testLifecycleManagement() {
     }
 
-    // Test setting properties to invalid values
-    @Override
-    public void testPropertiesInvalid() throws Exception {
-        super.testPropertiesInvalid();
-        UICommand command = (UICommand) component;
-    }
-
     public void testNestedCommands() {
         UIViewRoot root = new UIViewRoot();
         UICommand c1 = new UICommand();

--- a/impl/src/test/java/jakarta/faces/component/UIComponentBaseAttachedStateTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIComponentBaseAttachedStateTestCase.java
@@ -80,8 +80,9 @@ public class UIComponentBaseAttachedStateTestCase extends TestCase {
         reInitializeFactoryManager.invoke(null, (Object[]) null);
     }
 
+
     public void testAttachedObjectsSet() throws Exception {
-        Set<ValueChangeListener> returnedAttachedObjects = null, attachedObjects = new HashSet<>();
+        Set<ValueChangeListener> attachedObjects = new HashSet<>();
         ValueChangeListener toAdd = new ValueChangeListenerTestImpl();
         attachedObjects.add(toAdd);
         toAdd = new ValueChangeListenerTestImpl();
@@ -89,11 +90,14 @@ public class UIComponentBaseAttachedStateTestCase extends TestCase {
         toAdd = new ValueChangeListenerTestImpl();
         attachedObjects.add(toAdd);
         Object result = UIComponentBase.saveAttachedState(facesContext, attachedObjects);
-        returnedAttachedObjects = (Set<ValueChangeListener>) UIComponentBase.restoreAttachedState(facesContext, result);
+        @SuppressWarnings("unchecked")
+        Set<ValueChangeListener> returnedAttachedObjects = (Set<ValueChangeListener>) UIComponentBase
+                .restoreAttachedState(facesContext, result);
+        assertNotNull(returnedAttachedObjects);
     }
 
     public void testAttachedObjectsStack() throws Exception {
-        Stack<ValueChangeListener> returnedAttachedObjects = null, attachedObjects = new Stack<>();
+        Stack<ValueChangeListener> attachedObjects = new Stack<>();
         ValueChangeListener toAdd = new ValueChangeListenerTestImpl();
         attachedObjects.add(toAdd);
         toAdd = new ValueChangeListenerTestImpl();
@@ -101,11 +105,14 @@ public class UIComponentBaseAttachedStateTestCase extends TestCase {
         toAdd = new ValueChangeListenerTestImpl();
         attachedObjects.add(toAdd);
         Object result = UIComponentBase.saveAttachedState(facesContext, attachedObjects);
-        returnedAttachedObjects = (Stack<ValueChangeListener>) UIComponentBase.restoreAttachedState(facesContext, result);
+        @SuppressWarnings("unchecked")
+        Stack<ValueChangeListener> returnedAttachedObjects = (Stack<ValueChangeListener>) UIComponentBase
+                .restoreAttachedState(facesContext, result);
+        assertNotNull(returnedAttachedObjects);
     }
 
     public void testAttachedObjectsMap() throws Exception {
-        Map<String, ValueChangeListener> returnedAttachedObjects = null, attachedObjects = new HashMap<>();
+        Map<String, ValueChangeListener> attachedObjects = new HashMap<>();
         ValueChangeListener toAdd = new ValueChangeListenerTestImpl();
         attachedObjects.put("one", toAdd);
         toAdd = new ValueChangeListenerTestImpl();
@@ -113,10 +120,14 @@ public class UIComponentBaseAttachedStateTestCase extends TestCase {
         toAdd = new ValueChangeListenerTestImpl();
         attachedObjects.put("three", toAdd);
         Object result = UIComponentBase.saveAttachedState(facesContext, attachedObjects);
-        returnedAttachedObjects = (Map<String, ValueChangeListener>) UIComponentBase.restoreAttachedState(facesContext, result);
+        @SuppressWarnings("unchecked")
+        Map<String, ValueChangeListener> returnedAttachedObjects = (Map<String, ValueChangeListener>) UIComponentBase
+                .restoreAttachedState(facesContext, result);
+        assertNotNull(returnedAttachedObjects);
     }
 
     // Regression test for bug #907
+    @SuppressWarnings("unchecked")
     public void testAttachedObjectsCount() throws Exception {
         Set<ValueChangeListener> returnedAttachedObjects = null, attachedObjects = new HashSet<>();
         ValueChangeListener toAdd = new ValueChangeListenerTestImpl();

--- a/impl/src/test/java/jakarta/faces/component/UIInputTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIInputTestCase.java
@@ -229,9 +229,9 @@ public class UIInputTestCase extends UIOutputTestCase {
         checkMessages(1);
         assertTrue(!input.isValid());
 
-        Iterator messages = facesContext.getMessages();
+        Iterator<FacesMessage> messages = facesContext.getMessages();
         while (messages.hasNext()) {
-            FacesMessage message = (FacesMessage) messages.next();
+            FacesMessage message = messages.next();
             assertTrue(message.getSummary().indexOf("mylabel") >= 0);
         }
 
@@ -257,6 +257,7 @@ public class UIInputTestCase extends UIOutputTestCase {
         ValueChangeListener[] listeners = command.getValueChangeListeners();
         assertEquals(2, listeners.length);
         ValueChangeListenerTestImpl[] taListeners = (ValueChangeListenerTestImpl[]) command.getFacesListeners(ValueChangeListenerTestImpl.class);
+        assertTrue(taListeners != null);
     }
 
     // --------------------------------------------------------- Support Methods
@@ -265,9 +266,9 @@ public class UIInputTestCase extends UIOutputTestCase {
     protected void checkMessages(int expected) {
         facesContext.getExceptionHandler().handle();
         int n = 0;
-        Iterator messages = facesContext.getMessages();
+        Iterator<FacesMessage> messages = facesContext.getMessages();
         while (messages.hasNext()) {
-            FacesMessage message = (FacesMessage) messages.next();
+            FacesMessage message = messages.next();
             assertEquals("Severity == ERROR", FacesMessage.SEVERITY_ERROR, message.getSeverity());
             n++;
             // System.err.println(message.getSummary());

--- a/impl/src/test/java/jakarta/faces/component/UIOutputTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIOutputTestCase.java
@@ -53,45 +53,9 @@ public class UIOutputTestCase extends ValueHolderTestCaseBase {
     }
 
     // ------------------------------------------------- Individual Test Methods
-    // Test attribute-property transparency
-    @Override
-    public void testAttributesTransparency() {
-
-        super.testAttributesTransparency();
-        UIOutput output = (UIOutput) component;
-
-    }
-
     // Suppress lifecycle tests since we do not have a renderer
     @Override
     public void testLifecycleManagement() {
-    }
-
-    // Test a pristine UIOutput instance
-    @Override
-    public void testPristine() {
-
-        super.testPristine();
-        UIOutput output = (UIOutput) component;
-
-    }
-
-    // Test setting properties to invalid values
-    @Override
-    public void testPropertiesInvalid() throws Exception {
-
-        super.testPropertiesInvalid();
-        UIOutput output = (UIOutput) component;
-
-    }
-
-    // Test setting properties to valid values
-    @Override
-    public void testPropertiesValid() throws Exception {
-
-        super.testPropertiesValid();
-        UIOutput output = (UIOutput) component;
-
     }
 
     // --------------------------------------------------------- Support Methods

--- a/impl/src/test/java/jakarta/faces/component/UIPanelTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIPanelTestCase.java
@@ -59,27 +59,6 @@ public class UIPanelTestCase extends UIComponentBaseTestCase {
     public void testLifecycleManagement() {
     }
 
-    // Test a pristine UIPanel instance
-    @Override
-    public void testPristine() {
-        super.testPristine();
-        UIPanel panel = (UIPanel) component;
-    }
-
-    // Test setting properties to invalid values
-    @Override
-    public void testPropertiesInvalid() throws Exception {
-        super.testPropertiesInvalid();
-        UIPanel panel = (UIPanel) component;
-    }
-
-    // Test setting properties to valid values
-    @Override
-    public void testPropertiesValid() throws Exception {
-        super.testPropertiesValid();
-        UIPanel panel = (UIPanel) component;
-    }
-
     // --------------------------------------------------------- Support Methods
     // Create a pristine component of the type to be used in state holder tests
     @Override

--- a/impl/src/test/java/jakarta/faces/component/UIParameterTest.java
+++ b/impl/src/test/java/jakarta/faces/component/UIParameterTest.java
@@ -38,7 +38,6 @@ public class UIParameterTest {
     @Test
     public void testIsDisable() throws Exception {
         FacesContext facesContext = PowerMock.createNicePartialMockForAllMethodsExcept(FacesContext.class, "getCurrentInstance", "setCurrentInstance");
-        ValueExpression valueExpression = PowerMock.createMock(ValueExpression.class);
         Method method = FacesContext.class.getDeclaredMethod("setCurrentInstance", FacesContext.class);
         method.setAccessible(true);
         method.invoke(null, facesContext);

--- a/impl/src/test/java/jakarta/faces/component/UIParameterTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIParameterTestCase.java
@@ -95,13 +95,6 @@ public class UIParameterTestCase extends UIComponentBaseTestCase {
         assertNull("no name", parameter.getName());
     }
 
-    // Test setting properties to invalid values
-    @Override
-    public void testPropertiesInvalid() throws Exception {
-        super.testPropertiesInvalid();
-        UIParameter parameter = (UIParameter) component;
-    }
-
     // Test setting properties to valid values
     @Override
     public void testPropertiesValid() throws Exception {

--- a/impl/src/test/java/jakarta/faces/component/UISelectBooleanTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UISelectBooleanTestCase.java
@@ -76,13 +76,6 @@ public class UISelectBooleanTestCase extends UIInputTestCase {
         assertTrue("not selected", !selectBoolean.isSelected());
     }
 
-    // Test setting properties to invalid values
-    @Override
-    public void testPropertiesInvalid() throws Exception {
-        super.testPropertiesInvalid();
-        UISelectBoolean selectBoolean = (UISelectBoolean) component;
-    }
-
     // --------------------------------------------------------- Support Methods
     // Create a pristine component of the type to be used in state holder tests
     @Override

--- a/impl/src/test/java/jakarta/faces/component/UISelectItemTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UISelectItemTestCase.java
@@ -131,13 +131,6 @@ public class UISelectItemTestCase extends UIComponentBaseTestCase {
         assertNull("no itemValue", selectItem.getItemValue());
     }
 
-    // Test setting properties to invalid values
-    @Override
-    public void testPropertiesInvalid() throws Exception {
-        super.testPropertiesInvalid();
-        UISelectItem selectItem = (UISelectItem) component;
-    }
-
     // Test setting properties to valid values
     @Override
     public void testPropertiesValid() throws Exception {

--- a/impl/src/test/java/jakarta/faces/component/UISelectItemsTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UISelectItemsTestCase.java
@@ -85,13 +85,6 @@ public class UISelectItemsTestCase extends UIComponentBaseTestCase {
         assertNull("no value", selectItems.getValue());
     }
 
-    // Test setting properties to invalid values
-    @Override
-    public void testPropertiesInvalid() throws Exception {
-        super.testPropertiesInvalid();
-        UISelectItems selectItems = (UISelectItems) component;
-    }
-
     // Test setting properties to valid values
     @Override
     public void testPropertiesValid() throws Exception {

--- a/impl/src/test/java/jakarta/faces/component/UISelectManyTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UISelectManyTestCase.java
@@ -370,7 +370,7 @@ public class UISelectManyTestCase extends UIInputTestCase {
         param.setValue("paramValue");
         selectMany.getChildren().add(param);
         selectMany.getChildren().add(new UISelectItemSub("esposito", null, null));
-        Iterator<SelectItem> iter = new SelectItemsIterator(facesContext, selectMany);
+        Iterator<SelectItem> iter = new SelectItemsIterator<>(facesContext, selectMany);
         while (iter.hasNext()) {
             Object object = iter.next();
             assertTrue(object instanceof jakarta.faces.model.SelectItem);
@@ -382,7 +382,7 @@ public class UISelectManyTestCase extends UIInputTestCase {
         selectMany.getChildren().add(new UISelectItemSub("gretsky", null, null));
         selectMany.getChildren().add(param);
         selectMany.getChildren().add(new UISelectItemSub("howe", null, null));
-        iter = new SelectItemsIterator(facesContext, selectMany);
+        iter = new SelectItemsIterator<>(facesContext, selectMany);
         while (iter.hasNext()) {
             Object object = iter.next();
             assertTrue(object instanceof jakarta.faces.model.SelectItem);
@@ -394,7 +394,7 @@ public class UISelectManyTestCase extends UIInputTestCase {
         UISelectItems items = new UISelectItems();
         items.setValue(Collections.emptyList());
         selectMany.getChildren().add(items);
-        iter = new SelectItemsIterator(facesContext, selectMany);
+        iter = new SelectItemsIterator<>(facesContext, selectMany);
         assertTrue(!iter.hasNext());
         try {
             iter.next();
@@ -411,7 +411,7 @@ public class UISelectManyTestCase extends UIInputTestCase {
         items = new UISelectItems();
         items.setValue(cItems);
         selectMany.getChildren().add(items);
-        iter = new SelectItemsIterator(facesContext, selectMany);
+        iter = new SelectItemsIterator<>(facesContext, selectMany);
         SelectItem previous = null;
         for (int i = 0, len = cItems.size(); i < len; i++) {
             assertTrue(iter.hasNext());
@@ -443,7 +443,7 @@ public class UISelectManyTestCase extends UIInputTestCase {
         items = new UISelectItems();
         items.setValue(new ListDataModel<>((List<Integer>) cItems));
         selectMany.getChildren().add(items);
-        iter = new SelectItemsIterator(facesContext, selectMany);
+        iter = new SelectItemsIterator<>(facesContext, selectMany);
         previous = null;
         for (int i = 0, len = cItems.size(); i < len; i++) {
             assertTrue(iter.hasNext());

--- a/impl/src/test/java/jakarta/faces/component/UISelectOneTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UISelectOneTestCase.java
@@ -64,27 +64,6 @@ public class UISelectOneTestCase extends UIInputTestCase {
     }
 
     // ------------------------------------------------- Individual Test Methods
-    // Test a pristine UISelectOne instance
-    @Override
-    public void testPristine() {
-        super.testPristine();
-        UISelectOne selectOne = (UISelectOne) component;
-    }
-
-    // Test setting properties to invalid values
-    @Override
-    public void testPropertiesInvalid() throws Exception {
-        super.testPropertiesInvalid();
-        UISelectOne selectOne = (UISelectOne) component;
-    }
-
-    // Test setting properties to valid values
-    @Override
-    public void testPropertiesValid() throws Exception {
-        super.testPropertiesValid();
-        UISelectOne selectOne = (UISelectOne) component;
-    }
-
     // Test validation of value against the valid list
     public void testValidation() throws Exception {
         // Put our component under test in a tree under a UIViewRoot

--- a/impl/src/test/java/jakarta/faces/component/UISelectOneTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UISelectOneTestCase.java
@@ -89,9 +89,9 @@ public class UISelectOneTestCase extends UIInputTestCase {
         selectOne.setSubmittedValue("bop");
         selectOne.validate(facesContext);
         assertTrue(!selectOne.isValid());
-        Iterator messages = facesContext.getMessages();
+        Iterator<FacesMessage> messages = facesContext.getMessages();
         while (messages.hasNext()) {
-            FacesMessage message = (FacesMessage) messages.next();
+            FacesMessage message = messages.next();
             assertTrue(message.getSummary().indexOf("mylabel") >= 0);
         }
     }
@@ -103,7 +103,7 @@ public class UISelectOneTestCase extends UIInputTestCase {
         root.getChildren().add(component);
 
         // Add valid options to the component under test
-        Map map = new HashMap();
+        Map<String, String> map = new HashMap<>();
         map.put("key_foo", "foo");
         map.put("key_bar", "bar");
         map.put("key_baz", "baz");
@@ -269,11 +269,10 @@ public class UISelectOneTestCase extends UIInputTestCase {
         param.setName("param");
         param.setValue("paramValue");
         selectOne.getChildren().add(param);
-        Iterator iter = new SelectItemsIterator(facesContext, selectOne);
+        Iterator<SelectItem> iter = new SelectItemsIterator(facesContext, selectOne);
         while (iter.hasNext()) {
-            Object object = iter.next();
-            assertTrue(object instanceof jakarta.faces.model.SelectItem);
-            assertTrue(((SelectItem) object).getValue().equals("orr") || ((SelectItem) object).getValue().equals("esposito"));
+            SelectItem selectItem = iter.next();
+            assertTrue(selectItem.getValue().equals("orr") || selectItem.getValue().equals("esposito"));
         }
 
         // sub test 2: non-selectitem in middle
@@ -283,9 +282,8 @@ public class UISelectOneTestCase extends UIInputTestCase {
         selectOne.getChildren().add(new UISelectItemSub("howe", null, null));
         iter = new SelectItemsIterator(facesContext, selectOne);
         while (iter.hasNext()) {
-            Object object = iter.next();
-            assertTrue(object instanceof jakarta.faces.model.SelectItem);
-            assertTrue(((SelectItem) object).getValue().equals("gretsky") || ((SelectItem) object).getValue().equals("howe"));
+            SelectItem selectItem = iter.next();
+            assertTrue(selectItem.getValue().equals("gretsky") || selectItem.getValue().equals("howe"));
         }
     }
 
@@ -308,11 +306,11 @@ public class UISelectOneTestCase extends UIInputTestCase {
     }
 
     // Create an options list with nested groups
-    protected List setupOptions() {
+    protected List<SelectItem> setupOptions() {
         SelectItemGroup group, subgroup;
         subgroup = new SelectItemGroup("Group C");
         subgroup.setSelectItems(new SelectItem[] { new SelectItem("C1"), new SelectItem("C2"), new SelectItem("C3") });
-        List options = new ArrayList();
+        List<SelectItem> options = new ArrayList<>();
         options.add(new SelectItem("A1"));
         group = new SelectItemGroup("Group B");
         group.setSelectItems(new SelectItem[] { new SelectItem("B1"), subgroup, new SelectItem("B2"), new SelectItem("B3") });

--- a/impl/src/test/java/jakarta/faces/component/UIViewRootTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIViewRootTestCase.java
@@ -515,14 +515,15 @@ public class UIViewRootTestCase extends UIComponentBaseTestCase {
         assertTrue(phaseListener.isAfterPhaseCalled());
     }
 
-    private void checkEventQueuesSizes(List<List> events, int applyEventsSize, int valEventsSize, int updateEventsSize, int appEventsSize) {
-        List applyEvents = events.get(PhaseId.APPLY_REQUEST_VALUES.getOrdinal());
+    private void checkEventQueuesSizes(List<List> events, int applyEventsSize, int valEventsSize, int updateEventsSize,
+            int appEventsSize) {
+        List<?> applyEvents = events.get(PhaseId.APPLY_REQUEST_VALUES.getOrdinal());
         assertEquals("Apply-Request-Values Event Count", applyEventsSize, applyEvents.size());
-        List valEvents = events.get(PhaseId.PROCESS_VALIDATIONS.getOrdinal());
+        List<?> valEvents = events.get(PhaseId.PROCESS_VALIDATIONS.getOrdinal());
         assertEquals("Process-Validations Event Count", valEventsSize, valEvents.size());
-        List updateEvents = events.get(PhaseId.UPDATE_MODEL_VALUES.getOrdinal());
+        List<?> updateEvents = events.get(PhaseId.UPDATE_MODEL_VALUES.getOrdinal());
         assertEquals("Update-Model Event Count", updateEventsSize, updateEvents.size());
-        List appEvents = events.get(PhaseId.INVOKE_APPLICATION.getOrdinal());
+        List<?> appEvents = events.get(PhaseId.INVOKE_APPLICATION.getOrdinal());
         assertEquals("Invoke-Application Event Count", appEventsSize, appEvents.size());
     }
 
@@ -551,7 +552,7 @@ public class UIViewRootTestCase extends UIComponentBaseTestCase {
                 field = fields[i];
                 field.setAccessible(true);
                 try {
-                    events = TypedCollections.dynamicallyCastList((List) field.get(root), List.class);
+                    events = TypedCollections.dynamicallyCastList((List<?>) field.get(root), List.class);
                 } catch (Exception e) {
                     assertTrue(false);
                 }
@@ -584,7 +585,7 @@ public class UIViewRootTestCase extends UIComponentBaseTestCase {
         root.queueEvent(event3);
         root.queueEvent(event4);
         try {
-            events = TypedCollections.dynamicallyCastList((List) field.get(root), List.class);
+            events = TypedCollections.dynamicallyCastList((List<?>) field.get(root), List.class);
         } catch (Exception e) {
             assertTrue(false);
         }
@@ -605,7 +606,7 @@ public class UIViewRootTestCase extends UIComponentBaseTestCase {
         root.queueEvent(event3);
         root.queueEvent(event4);
         try {
-            events = TypedCollections.dynamicallyCastList((List) field.get(root), List.class);
+            events = TypedCollections.dynamicallyCastList((List<?>) field.get(root), List.class);
         } catch (Exception e) {
             assertTrue(false);
         }
@@ -626,7 +627,7 @@ public class UIViewRootTestCase extends UIComponentBaseTestCase {
         root.queueEvent(event3);
         root.queueEvent(event4);
         try {
-            events = TypedCollections.dynamicallyCastList((List) field.get(root), List.class);
+            events = TypedCollections.dynamicallyCastList((List<?>) field.get(root), List.class);
         } catch (Exception e) {
             assertTrue(false);
         }
@@ -641,7 +642,7 @@ public class UIViewRootTestCase extends UIComponentBaseTestCase {
         // finally, get the internal events list one more time
         // to make sure it is null
         try {
-            events = TypedCollections.dynamicallyCastList((List) field.get(root), List.class);
+            events = TypedCollections.dynamicallyCastList((List<?>) field.get(root), List.class);
         } catch (Exception e) {
             assertTrue(false);
         }

--- a/impl/src/test/java/jakarta/faces/component/ValueHolderTestCaseBase.java
+++ b/impl/src/test/java/jakarta/faces/component/ValueHolderTestCaseBase.java
@@ -180,13 +180,6 @@ public abstract class ValueHolderTestCaseBase extends UIComponentBaseTestCase {
         assertNull("no converter", vh.getConverter());
     }
 
-    // Test setting properties to invalid values
-    @Override
-    public void testPropertiesInvalid() throws Exception {
-        super.testPropertiesInvalid();
-        ValueHolder vh = (ValueHolder) component;
-    }
-
     // Test setting properties to valid values
     @Override
     public void testPropertiesValid() throws Exception {


### PR DESCRIPTION
* Fixed warnings in mocks - collective change for all warnings without changes in public interfaces
* Fixed warnings in component tests - as above
* HtmlResponseWriterTest: close writer - I know those are tests, but still, warnings easy to fix. I think this way is better than try-with-resources because any exception will break tests (and this is good)
* Remove unused code
* Remove empty UIComponent test overrides -  they don't do anything. Tests are run anyway, because of the base class. This looks like generated code waiting to be filled.
