### PR TITLE
Fix #5155: NPE in BeanValidator when the ValueReference has no base class

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -182,6 +182,13 @@
             <version>2.1</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>8.0.0.Final</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
    <build>

--- a/impl/src/main/java/jakarta/faces/validator/BeanValidator.java
+++ b/impl/src/main/java/jakarta/faces/validator/BeanValidator.java
@@ -303,7 +303,7 @@ public class BeanValidator implements Validator, PartialStateHolder {
 
         ValueReference valueReference = getValueReference(context, component, valueExpression);
 
-        if (valueReference == null) {
+        if (valueReference == null || valueReference.getBase() == null) {
             return;
         }
 

--- a/impl/src/test/java/jakarta/faces/validator/BeanValidatorTestCase.java
+++ b/impl/src/test/java/jakarta/faces/validator/BeanValidatorTestCase.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2022, 2022 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.validator;
+
+import jakarta.faces.component.UIInput;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.Locale;
+import junit.framework.Test;
+import junit.framework.TestSuite;
+import org.junit.Assert;
+
+/**
+ * <p>Unit tests for {@link BeanValidator}.</p>
+ *
+ * @author rmartinc
+ */
+public class BeanValidatorTestCase extends ValidatorTestCase {
+
+    /**
+     * Test class for the bean validator.
+     */
+    public static class TestBean {
+
+        @NotNull
+        @Size(min = 1, max = 64)
+        private String message;
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+    }
+
+    // ------------------------------------------------------------ Constructors
+    /**
+     * Construct a new instance of this test case.
+     *
+     * @param name Name of the test case
+     */
+    public BeanValidatorTestCase(String name) {
+        super(name);
+    }
+
+    // ---------------------------------------------------- Overall Test Methods
+    // Return the tests included in this test case.
+    public static Test suite() {
+        return (new TestSuite(BeanValidatorTestCase.class));
+    }
+
+    // ------------------------------------------------- Individual Test Methods
+    public void testMessageOK() {
+        BeanValidator validator = new BeanValidator();
+        Locale.setDefault(Locale.US);
+        facesContext.getViewRoot().setLocale(Locale.US);
+        UIInput component = new UIInput();
+        request.setAttribute("test", new TestBean());
+        component.setValueExpression("value", application.getExpressionFactory().createValueExpression(facesContext.getELContext(), "#{test.message}", String.class));
+
+        validator.validate(facesContext, component, "something");
+    }
+
+    public void testMessageKO() {
+        BeanValidator validator = new BeanValidator();
+        Locale.setDefault(Locale.US);
+        facesContext.getViewRoot().setLocale(Locale.US);
+        UIInput component = new UIInput();
+        request.setAttribute("test", new TestBean());
+        component.setValueExpression("value", application.getExpressionFactory().createValueExpression(facesContext.getELContext(), "#{test.message}", String.class));
+
+        try {
+            validator.validate(facesContext, component, "");
+            Assert.fail("ValidatorException expected");
+        } catch (ValidatorException e) {
+            Assert.assertEquals("size must be between 1 and 64", e.getMessage());
+        }
+    }
+
+    public void testNoBase() {
+        BeanValidator validator = new BeanValidator();
+        Locale.setDefault(Locale.US);
+        facesContext.getViewRoot().setLocale(Locale.US);
+        UIInput component = new UIInput();
+        component.setValueExpression("value", application.getExpressionFactory().createValueExpression(facesContext.getELContext(), "#{something}", String.class));
+
+        validator.validate(facesContext, component, "something");
+    }
+}


### PR DESCRIPTION
Fixes #5155 

Just adding the condition to skip the validation if there is no base class. With jakarta validation the value reference can be returned with the attribute but no base class. Test was added adding the hibernate-validator dependency for testing. If you see any problem or improvement just let me know.