### PR TITLE
Update HtmlLibrary.java

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/html/HtmlLibrary.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/html/HtmlLibrary.java
@@ -27,6 +27,7 @@ import jakarta.faces.component.html.HtmlCommandButton;
 import jakarta.faces.component.html.HtmlCommandLink;
 import jakarta.faces.component.html.HtmlCommandScript;
 import jakarta.faces.component.html.HtmlDataTable;
+import jakarta.faces.component.html.HtmlDoctype;
 import jakarta.faces.component.html.HtmlForm;
 import jakarta.faces.component.html.HtmlGraphicImage;
 import jakarta.faces.component.html.HtmlInputFile;
@@ -89,7 +90,7 @@ public final class HtmlLibrary extends AbstractHtmlLibrary {
 
         addHtmlComponent("html", UIOutput.COMPONENT_TYPE, "jakarta.faces.Html");
 
-        addHtmlComponent("doctype", UIOutput.COMPONENT_TYPE, "jakarta.faces.Doctype");
+        addHtmlComponent("doctype", HtmlDoctype.COMPONENT_TYPE, "jakarta.faces.Doctype");
 
         addHtmlComponent("inputFile", HtmlInputFile.COMPONENT_TYPE, "jakarta.faces.File");
 


### PR DESCRIPTION
Fix for issue https://github.com/eclipse-ee4j/mojarra/issues/5182. Doctype if of type HtmlDoctype.COMPONENT_TYPE in JSF 4.0.