### PR TITLE
Add back id attribute to VDL of h:head and h:body

### DIFF
--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/BodyRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/BodyRenderer.java
@@ -54,7 +54,9 @@ public class BodyRenderer extends HtmlBasicRenderer {
     public void encodeBegin(FacesContext context, UIComponent component) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         writer.startElement("body", component);
-        writeIdAttributeIfNecessary(context, writer, component);
+        if (RenderKitUtils.isOutputHtml5Doctype(context)) {
+            writeIdAttributeIfNecessary(context, writer, component);
+        }
         String styleClass = (String) component.getAttributes().get("styleClass");
         if (styleClass != null && styleClass.length() != 0) {
             writer.writeAttribute("class", styleClass, "styleClass");

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/HeadRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/HeadRenderer.java
@@ -26,7 +26,6 @@ import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
-import jakarta.faces.render.Renderer;
 
 /**
  * /**
@@ -35,7 +34,7 @@ import jakarta.faces.render.Renderer;
  * resources that should be output before the <code>head</code> tag is closed.
  * </p>
  */
-public class HeadRenderer extends Renderer {
+public class HeadRenderer extends HtmlBasicRenderer {
 
     private static final Attribute[] HEAD_ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.OUTPUTHEAD);
 
@@ -48,12 +47,10 @@ public class HeadRenderer extends Renderer {
     public void encodeBegin(FacesContext context, UIComponent component) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         writer.startElement("head", component);
-        RenderKitUtils.renderPassThruAttributes(context, writer, component, HEAD_ATTRIBUTES);
-
         if (RenderKitUtils.isOutputHtml5Doctype(context)) {
-            String clientId = component.getClientId(context);
-            writer.writeAttribute("id", clientId, "clientId");
+            writeIdAttributeIfNecessary(context, writer, component);
         }
+        RenderKitUtils.renderPassThruAttributes(context, writer, component, HEAD_ATTRIBUTES);
     }
 
     @Override
@@ -66,6 +63,16 @@ public class HeadRenderer extends Renderer {
         ResponseWriter writer = context.getResponseWriter();
         encodeHeadResources(context);
         writer.endElement("head");
+    }
+
+    /**
+     * Do we render our children.
+     *
+     * @return false.
+     */
+    @Override
+    public boolean getRendersChildren() {
+        return false;
     }
 
     // --------------------------------------------------------- Private Methods

--- a/impl/src/main/resources/com/sun/faces/metadata/taglib/faces.html.taglib.xml
+++ b/impl/src/main/resources/com/sun/faces/metadata/taglib/faces.html.taglib.xml
@@ -1190,6 +1190,20 @@
         </component>
         <attribute>
             <description>
+                <![CDATA[
+                    <span class="changed_added_4_1">
+                        The component identifier for this component.
+                        This value must be unique within the closest parent component that is a naming container.
+                        The attribute is only rendered when the current doctype is a HTML5 doctype.
+                    </span>
+                ]]>
+            </description>
+            <name>id</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Direction indication for text that does not inherit directionality.
               Valid values are "LTR" (left-to-right) and "RTL" (right-to-left).]]>
             </description>
@@ -1278,6 +1292,20 @@
             <component-type>jakarta.faces.Output</component-type>
             <renderer-type>jakarta.faces.Body</renderer-type>
         </component>
+        <attribute>
+            <description>
+                <![CDATA[
+                    <span class="changed_added_4_1">
+                        The component identifier for this component.
+                        This value must be unique within the closest parent component that is a naming container.
+                        The attribute is only rendered when the current doctype is a HTML5 doctype.
+                    </span>
+                ]]>
+            </description>
+            <name>id</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
         <attribute>
             <description>
                 <![CDATA[Direction indication for text that does not inherit directionality.

--- a/impl/src/test/java/com/sun/faces/renderkit/html_basic/BodyRendererTest.java
+++ b/impl/src/test/java/com/sun/faces/renderkit/html_basic/BodyRendererTest.java
@@ -16,17 +16,19 @@
 
 package com.sun.faces.renderkit.html_basic;
 
+import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.StringWriter;
 import java.util.Collections;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.easymock.EasyMock.expect;
 import org.junit.Test;
 import org.powermock.api.easymock.PowerMock;
 
 import jakarta.faces.application.Application;
 import jakarta.faces.application.ProjectStage;
+import jakarta.faces.component.Doctype;
 import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.component.html.HtmlBody;
 import jakarta.faces.context.FacesContext;
@@ -56,11 +58,18 @@ public class BodyRendererTest {
         StringWriter writer = new StringWriter();
         ResponseWriter testResponseWriter = new TestResponseWriter(writer);
         FacesContext facesContext = PowerMock.createPartialMock(FacesContext.class, "getResponseWriter");
+        UIViewRoot viewRoot = PowerMock.createMock(UIViewRoot.class);
+        Doctype doctype = PowerMock.createMock(Doctype.class);
         BodyRenderer bodyRenderer = new BodyRenderer();
         HtmlBody htmlBody = new HtmlBody();
         htmlBody.getAttributes().put("styleClass", "myclass");
         
         expect(facesContext.getResponseWriter()).andReturn(testResponseWriter).anyTimes();
+        expect(facesContext.getViewRoot()).andReturn(viewRoot).anyTimes();
+        expect(viewRoot.getDoctype()).andReturn(doctype).anyTimes();
+        expect(doctype.getRootElement()).andReturn("html").anyTimes();
+        expect(doctype.getPublic()).andReturn(null).anyTimes();
+        expect(doctype.getSystem()).andReturn(null).anyTimes();
         
         PowerMock.replay(facesContext);
         bodyRenderer.encodeBegin(facesContext, htmlBody);

--- a/impl/src/test/java/com/sun/faces/renderkit/html_basic/HeadRendererTest.java
+++ b/impl/src/test/java/com/sun/faces/renderkit/html_basic/HeadRendererTest.java
@@ -16,14 +16,16 @@
 
 package com.sun.faces.renderkit.html_basic;
 
+import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertTrue;
+
 import java.io.StringWriter;
 import java.util.Collections;
 
-import static org.junit.Assert.assertTrue;
-import static org.easymock.EasyMock.expect;
 import org.junit.Test;
 import org.powermock.api.easymock.PowerMock;
 
+import jakarta.faces.component.Doctype;
 import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.component.html.HtmlHead;
 import jakarta.faces.context.FacesContext;
@@ -50,13 +52,26 @@ public class HeadRendererTest {
      */
     @Test
     public void testEncodeBegin() throws Exception {
-        //
-        // TODO: Note we are not testing this method as its complexity is too 
-        // high, because it uses WebConfiguration.getInstance to get
-        // configuration information that should be readily available to the
-        // renderer through either the FacesContext or the component being
-        // rendered.
-        //
+        StringWriter writer = new StringWriter();
+        ResponseWriter testResponseWriter = new TestResponseWriter(writer);
+        FacesContext facesContext = PowerMock.createPartialMock(FacesContext.class, "getResponseWriter");
+        UIViewRoot viewRoot = PowerMock.createMock(UIViewRoot.class);
+        Doctype doctype = PowerMock.createMock(Doctype.class);
+        HeadRenderer headRenderer = new HeadRenderer();
+        HtmlHead htmlHead = new HtmlHead();
+        
+        expect(facesContext.getResponseWriter()).andReturn(testResponseWriter).anyTimes();
+        expect(facesContext.getViewRoot()).andReturn(viewRoot).anyTimes();
+        expect(viewRoot.getDoctype()).andReturn(doctype).anyTimes();
+        expect(doctype.getRootElement()).andReturn("html").anyTimes();
+        expect(doctype.getPublic()).andReturn(null).anyTimes();
+        expect(doctype.getSystem()).andReturn(null).anyTimes();
+        
+        PowerMock.replay(facesContext);
+        headRenderer.encodeBegin(facesContext, htmlHead);
+        PowerMock.verify(facesContext);
+        String html = writer.toString();
+        assertTrue(html.contains("<head"));
     }
 
     /**


### PR DESCRIPTION
https://github.com/jakartaee/faces/issues/1760
- Add back id attribute to VDL of h:head and h:body
- fix HeadRenderer to only output it when actually specified
- fix BodyRenderer to only output it when HTML5 doctype is used""
