### PR TITLE
fix NPE if getResourcePaths return null

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/resource/ResourcePathsIterator.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourcePathsIterator.java
@@ -64,7 +64,10 @@ public class ResourcePathsIterator implements Iterator<String> {
     }
 
     private void visit(String resourcePath) {
-        stack.addAll(externalContext.getResourcePaths(resourcePath));
+        java.util.Set<String> set = externalContext.getResourcePaths(resourcePath);
+        if(set != null) {
+            stack.addAll(set);
+        }
     }
 
     private void tryTake() {


### PR DESCRIPTION
 java.lang.NullPointerException: Cannot invoke "java.util.Collection.size()" because "c" is null
                at java.base/java.util.ArrayDeque.addAll(ArrayDeque.java:322)
                at com.sun.faces.application.resource.ResourcePathsIterator.visit(ResourcePathsIterator.java:67)
                at com.sun.faces.application.resource.ResourcePathsIterator.tryTake(ResourcePathsIterator.java:79)
                at com.sun.faces.application.resource.ResourcePathsIterator.hasNext(ResourcePathsIterator.java:51)