### PR TITLE
The service file parsing is incomplete

### DIFF
--- a/impl/src/test/java/com/sun/faces/spi/ConfigurationResourceProviderFactoryTest.java
+++ b/impl/src/test/java/com/sun/faces/spi/ConfigurationResourceProviderFactoryTest.java
@@ -1,0 +1,100 @@
+package com.sun.faces.spi;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
+
+import com.sun.faces.spi.ConfigurationResourceProviderFactory.ProviderType;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests {@link ConfigurationResourceProviderFactory}.
+ */
+public class ConfigurationResourceProviderFactoryTest {
+
+    /**
+     * Test creating configuration resource providers from a service file.
+     * <p>
+     * It tests the correct parsing of the service file with empty lines and comments.
+     *
+     * @throws FileNotFoundException
+     *         Thrown when the test service file can't be written.
+     */
+    @Test
+    public void testCreateProvidersSuccessful() throws FileNotFoundException {
+        ProviderType facesConfig = ProviderType.FacesConfig;
+
+        File servicesFile = prepareServiceFile(facesConfig);
+
+        try (PrintWriter writer = new PrintWriter(servicesFile)) {
+            writer.println("");
+            writer.println("# Notices for Eclipse Mojarra");
+            writer.println("com.sun.faces.spi.MockFacesConfigResourceProvider");
+            writer.println("com.sun.faces.spi.MockFacesConfigResourceProvider   # This is a comment.");
+            writer.flush();
+        }
+
+        ConfigurationResourceProvider[] providers = ConfigurationResourceProviderFactory.createProviders(facesConfig);
+        assertNotNull(providers);
+        assertEquals(2, providers.length);
+
+        servicesFile.delete();
+    }
+
+    /**
+     * Test creating configuration resource providers from a service file.
+     * <p>
+     * It tests the correct parsing of the service file with a comment and if it correctly denies the attempt to load
+     * the wrong class ({@link MockConfigurationResourceProvider}) for the given {@link ProviderType}.
+     *
+     * @throws FileNotFoundException
+     *         Thrown when the test service file can't be written.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void testCreateProvidersWrongService() throws FileNotFoundException {
+        ProviderType facesConfig = ProviderType.FacesConfig;
+
+        File servicesFile = prepareServiceFile(facesConfig);
+
+        try (PrintWriter writer = new PrintWriter(servicesFile)) {
+            writer.println("com.sun.faces.spi.MockConfigurationResourceProvider"
+                    + "   # This should fail, since this is the wrong class for this ProviderType");
+            writer.flush();
+        }
+
+        try {
+            ConfigurationResourceProviderFactory.createProviders(facesConfig);
+        } finally {
+            servicesFile.delete();
+        }
+    }
+
+    /**
+     * Test case when no service file exists.
+     */
+    @Test
+    public void testNoServiceFile() {
+        ProviderType facesConfig = ProviderType.FacesConfig;
+
+        prepareServiceFile(facesConfig);
+
+        ConfigurationResourceProvider[] providers = ConfigurationResourceProviderFactory.createProviders(facesConfig);
+        assertNotNull(providers);
+        assertEquals(0, providers.length);
+    }
+
+    private static File prepareServiceFile(ProviderType facesConfig) {
+        // Write services file to test with.
+        File servicesDir = new File(System.getProperty("basedir"), "target/classes/META-INF/services");
+        servicesDir.mkdirs();
+
+        File servicesFile = new File(servicesDir, facesConfig.servicesKey);
+
+        if (servicesFile.exists()) {
+            servicesFile.delete();
+        }
+        return servicesFile;
+    }
+}

--- a/impl/src/test/java/com/sun/faces/spi/MockConfigurationResourceProvider.java
+++ b/impl/src/test/java/com/sun/faces/spi/MockConfigurationResourceProvider.java
@@ -1,0 +1,18 @@
+package com.sun.faces.spi;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import jakarta.servlet.ServletContext;
+
+/**
+ * Mock class for unit testing {@link ConfigurationResourceProvider} instantiating via service file.
+ */
+public class MockConfigurationResourceProvider implements ConfigurationResourceProvider {
+
+    @Override
+    public Collection<URI> getResources(ServletContext context) {
+        return new ArrayList<>();
+    }
+}

--- a/impl/src/test/java/com/sun/faces/spi/MockFacesConfigResourceProvider.java
+++ b/impl/src/test/java/com/sun/faces/spi/MockFacesConfigResourceProvider.java
@@ -1,0 +1,18 @@
+package com.sun.faces.spi;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import jakarta.servlet.ServletContext;
+
+/**
+ * Mock class for unit testing {@link FacesConfigResourceProvider} instantiating via service file.
+ */
+class MockFacesConfigResourceProvider implements FacesConfigResourceProvider {
+
+    @Override
+    public Collection<URI> getResources(ServletContext context) {
+        return new ArrayList<>();
+    }
+}


### PR DESCRIPTION
Issue https://github.com/eclipse-ee4j/mojarra/issues/5204.

According to the official documentation of Javas Service Loader it may contain comments. Everything which comes after the '#' is considered a comment. Reference: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html.
But Mojarras own Service Loader implementation doesn't support comments. It even doesn't skip blank lines. This leads to unexpected behaviour when using Mojarras Service Loader. When files under META-INF/services are loaded from Mojarras Service Loader it may lead to exceptions, while these service files under any other META-INF/services directory may perform perfect when they're loaded by the JDK Service Loader.

Therefore I implemented a Pull-Request which fixes that, so comments and blank lines don't lead to crashes when loading service files.

I also added unit tests to test the new functionality. To an area which had previously no test coverage at all.

I also replaced the magic string `"UTF-8"` with `StandardCharsets.UTF_8` in the method I updated. It was introduced with Java 7 and can therefore also be used in a project where downwards compability is important.

P.S.: I read, understood and accepted the ECA.