### PR TITLE
Fix various warnings in tests

### DIFF
--- a/action/src/main/java/org/eclipse/mojarra/action/DefaultActionMappingMatcher.java
+++ b/action/src/main/java/org/eclipse/mojarra/action/DefaultActionMappingMatcher.java
@@ -39,10 +39,12 @@ public class DefaultActionMappingMatcher implements ActionMappingMatcher {
      * @param bean the bean.
      * @return the action mapping match, or null if not found.
      */
+    @SuppressWarnings("rawtypes")
     private ActionMappingMatch determineActionMappingMatch(FacesContext facesContext, Bean<?> bean) {
         ActionMappingMatch result = null;
         Class<?> clazz = bean.getBeanClass();
         AnnotatedType annotatedType = CDI.current().getBeanManager().createAnnotatedType(clazz);
+        @SuppressWarnings("unchecked")
         Set<AnnotatedMethod> annotatedMethodSet = annotatedType.getMethods();
         for (AnnotatedMethod method : annotatedMethodSet) {
             if (method.isAnnotationPresent(ActionMapping.class)) {

--- a/action/src/main/java/org/eclipse/mojarra/action/DefaultActionMethodExecutor.java
+++ b/action/src/main/java/org/eclipse/mojarra/action/DefaultActionMethodExecutor.java
@@ -44,7 +44,7 @@ public class DefaultActionMethodExecutor implements ActionMethodExecutor {
      */
     @Override
     public void execute(FacesContext facesContext, ActionMappingMatch actionMappingMatch) {
-        Instance instance = CDI.current().select(
+        Instance<?> instance = CDI.current().select(
                 actionMappingMatch.getBean().getBeanClass(), Any.Literal.INSTANCE);
         String viewId;
         try {

--- a/impl/src/test/java/com/sun/faces/application/FacesMessageTest.java
+++ b/impl/src/test/java/com/sun/faces/application/FacesMessageTest.java
@@ -16,6 +16,8 @@
 
 package com.sun.faces.application;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -25,8 +27,6 @@ import java.io.ObjectOutputStream;
 import org.junit.Test;
 
 import jakarta.faces.application.FacesMessage;
-
-import static org.junit.Assert.*;
 
 public class FacesMessageTest {
 
@@ -69,7 +69,6 @@ public class FacesMessageTest {
         String mDetail, mDetail1 = null;
         String severity, severity1 = null;
         ByteArrayOutputStream bos = null;
-        ByteArrayInputStream bis = null;
 
         mSummary = message.getSummary();
         mDetail = message.getDetail();

--- a/impl/src/test/java/com/sun/faces/config/DigesterFactory.java
+++ b/impl/src/test/java/com/sun/faces/config/DigesterFactory.java
@@ -16,11 +16,13 @@
 
 package com.sun.faces.config;
 
-import javax.xml.parsers.ParserConfigurationException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import javax.xml.parsers.ParserConfigurationException;
+
 import org.apache.commons.digester.Digester;
 import org.apache.commons.logging.impl.NoOpLog;
 import org.xml.sax.ErrorHandler;
@@ -30,6 +32,7 @@ import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.helpers.DefaultHandler;
+
 import com.sun.faces.util.ToolsUtil;
 
 /**
@@ -88,9 +91,9 @@ public class DigesterFactory {
      * The <code>ThreadLocal</code> variable used to record the VersionListener
      * instance for each processing thread.</p>
      */
-    private static ThreadLocal versionListener = new ThreadLocal() {
+    private static ThreadLocal<VersionListener> versionListener = new ThreadLocal<>() {
         @Override
-        protected Object initialValue() {
+        protected VersionListener initialValue() {
             return (null);
         }
     };
@@ -165,7 +168,7 @@ public class DigesterFactory {
     } // END newInstance
 
     public static VersionListener getVersionListener() {
-        return ((VersionListener) versionListener.get());
+        return (versionListener.get());
     }
 
     public static void releaseDigester(Digester toRelease) {
@@ -200,7 +203,7 @@ public class DigesterFactory {
          * Called from the EntityResolver when we know one of the XML Grammar
          * elements to which this config file conforms.</p>
          * @param grammar       */
-        public void takeActionOnGrammar(String grammar);
+        void takeActionOnGrammar(String grammar);
 
         /**
          * <p>
@@ -209,7 +212,7 @@ public class DigesterFactory {
          * parsed.</p>
          * @param artifactName
          */
-        public void takeActionOnArtifact(String artifactName);
+        void takeActionOnArtifact(String artifactName);
     }
 
     // --------------------------------------------------------- Private Methods
@@ -337,7 +340,7 @@ public class DigesterFactory {
          * Contains mapping between grammar name and the local URL to the
          * physical resource.</p>
          */
-        private HashMap<String, String> entities = new HashMap<String, String>();
+        private HashMap<String, String> entities = new HashMap<>();
 
         // -------------------------------------------------------- Constructors
         public JsfEntityResolver() {

--- a/impl/src/test/java/com/sun/faces/context/ExternalContextImplTest.java
+++ b/impl/src/test/java/com/sun/faces/context/ExternalContextImplTest.java
@@ -16,24 +16,27 @@
 
 package com.sun.faces.context;
 
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+
+import org.junit.Test;
+import org.powermock.api.easymock.PowerMock;
+
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
-import org.junit.Test;
-import org.powermock.api.easymock.PowerMock;
 
 /**
  * The JUnit tests for the ExternalContextImpl class.
@@ -123,13 +126,6 @@ public class ExternalContextImplTest {
         valueIterator.next();
         try {
             valueIterator.remove();
-            fail();
-        } catch (Exception e) {
-            assertTrue(e instanceof UnsupportedOperationException);
-        }
-
-        try {
-            requestCookieMap.entrySet().remove("test");
             fail();
         } catch (Exception e) {
             assertTrue(e instanceof UnsupportedOperationException);

--- a/impl/src/test/java/com/sun/faces/el/CompositeComponentAttributesELResolverTest.java
+++ b/impl/src/test/java/com/sun/faces/el/CompositeComponentAttributesELResolverTest.java
@@ -16,23 +16,27 @@
 
 package com.sun.faces.el;
 
-import com.sun.faces.facelets.tag.composite.CompositeComponentBeanInfo;
-
-import jakarta.faces.application.Resource;
-import jakarta.faces.component.UIComponent;
-import jakarta.faces.component.UIPanel;
-import jakarta.faces.context.FacesContext;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.beans.BeanDescriptor;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
-import jakarta.el.ELContext;
 
 import org.easymock.EasyMock;
 import org.junit.Test;
-import static org.junit.Assert.*;
-import static org.easymock.EasyMock.*;
+
+import com.sun.faces.facelets.tag.composite.CompositeComponentBeanInfo;
+
+import jakarta.el.ELContext;
+import jakarta.faces.application.Resource;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIPanel;
+import jakarta.faces.context.FacesContext;
 
 /**
  * The JUnit tests for the CompositeComponentAttributesELResolver class.
@@ -50,8 +54,8 @@ public class CompositeComponentAttributesELResolverTest {
         FacesContext facesContext1 = EasyMock.createNiceMock(FacesContext.class);
         ELContext elContext2 = EasyMock.createNiceMock(ELContext.class);
         FacesContext facesContext2 = EasyMock.createNiceMock(FacesContext.class);
-        
-        HashMap<Object, Object> ctxAttributes1 = new HashMap<Object, Object>();
+
+        HashMap<Object, Object> ctxAttributes1 = new HashMap<>();
         UIPanel composite = new UIPanel();
         CompositeComponentBeanInfo compositeBeanInfo = new CompositeComponentBeanInfo();
         BeanDescriptor beanDescriptor = new BeanDescriptor(composite.getClass());
@@ -65,15 +69,17 @@ public class CompositeComponentAttributesELResolverTest {
         expect(elContext2.getContext(FacesContext.class)).andReturn(facesContext2);
         expect(facesContext2.getAttributes()).andReturn(ctxAttributes1);
         replay(elContext1, facesContext1, elContext2, facesContext2);
-        
+
         CompositeComponentAttributesELResolver elResolver = new CompositeComponentAttributesELResolver();
+        @SuppressWarnings("unchecked")
         Map<String, Object> evalMap1 = (Map<String, Object>) elResolver.getValue(elContext1, composite, property);
         assertNotNull(evalMap1);
+        @SuppressWarnings("unchecked")
         Map<String, Object> evalMap2 = (Map<String, Object>) elResolver.getValue(elContext2, composite, property);
         assertNotNull(evalMap2);
-        
+
         Field ctxField1 = evalMap1.getClass().getDeclaredField("ctx");
-        ctxField1.setAccessible(true);       
+        ctxField1.setAccessible(true);
         Field ctxField2 = evalMap2.getClass().getDeclaredField("ctx");
         ctxField2.setAccessible(true);
 
@@ -82,7 +88,7 @@ public class CompositeComponentAttributesELResolverTest {
         assertTrue(facesContext2 == ctxField1.get(evalMap1));
         assertTrue(facesContext1 != ctxField2.get(evalMap2));
         assertTrue(facesContext2 == ctxField2.get(evalMap2));
-        
+
         verify(elContext1, facesContext1, elContext2, facesContext2);
     }
 }

--- a/impl/src/test/java/com/sun/faces/junit/JUnitFacesTestCaseBase.java
+++ b/impl/src/test/java/com/sun/faces/junit/JUnitFacesTestCaseBase.java
@@ -16,6 +16,10 @@
 
 package com.sun.faces.junit;
 
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
 import com.sun.faces.mock.MockApplication;
 import com.sun.faces.mock.MockExternalContext;
 import com.sun.faces.mock.MockFacesContext;
@@ -30,11 +34,6 @@ import jakarta.faces.FactoryFinder;
 import jakarta.faces.application.ApplicationFactory;
 import jakarta.faces.context.FacesContextFactory;
 import jakarta.faces.lifecycle.LifecycleFactory;
-
-import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.Map;
-
 import junit.framework.TestCase;
 
 public class JUnitFacesTestCaseBase extends TestCase {
@@ -91,7 +90,7 @@ public class JUnitFacesTestCaseBase extends TestCase {
         lifecycle = (MockLifecycle) lFactory.getLifecycle(LifecycleFactory.DEFAULT_LIFECYCLE);
         facesContext = (MockFacesContext) fcFactory.getFacesContext(servletContext, request, response, lifecycle);
         externalContext = (MockExternalContext) facesContext.getExternalContext();
-        Map map = new HashMap();
+        Map<String, String> map = new HashMap<>();
         externalContext.setRequestParameterMap(map);
 
         ApplicationFactory applicationFactory = (ApplicationFactory) FactoryFinder.getFactory(FactoryFinder.APPLICATION_FACTORY);

--- a/impl/src/test/java/com/sun/faces/mock/MockResultSetMetaData.java
+++ b/impl/src/test/java/com/sun/faces/mock/MockResultSetMetaData.java
@@ -36,7 +36,7 @@ public class MockResultSetMetaData implements ResultSetMetaData {
      *
      * @param clazz Class whose properties we treat like columns
      */
-    public MockResultSetMetaData(Class clazz) throws SQLException {
+    public MockResultSetMetaData(Class<?> clazz) throws SQLException {
         try {
             descriptors
                     = Introspector.getBeanInfo(clazz).getPropertyDescriptors();

--- a/impl/src/test/java/com/sun/faces/mock/MockServletConfig.java
+++ b/impl/src/test/java/com/sun/faces/mock/MockServletConfig.java
@@ -18,6 +18,7 @@ package com.sun.faces.mock;
 
 import java.util.Enumeration;
 import java.util.Hashtable;
+
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletContext;
 
@@ -31,7 +32,7 @@ public class MockServletConfig implements ServletConfig {
         setServletContext(context);
     }
 
-    private Hashtable parameters = new Hashtable();
+    private Hashtable<String, String> parameters = new Hashtable<>();
     private ServletContext context;
 
     // --------------------------------------------------------- Public Methods
@@ -46,11 +47,11 @@ public class MockServletConfig implements ServletConfig {
     // -------------------------------------------------- ServletConfig Methods
     @Override
     public String getInitParameter(String name) {
-        return ((String) parameters.get(name));
+        return (parameters.get(name));
     }
 
     @Override
-    public Enumeration getInitParameterNames() {
+    public Enumeration<String> getInitParameterNames() {
         return (parameters.keys());
     }
 

--- a/impl/src/test/java/com/sun/faces/renderkit/html_basic/BodyRendererTest.java
+++ b/impl/src/test/java/com/sun/faces/renderkit/html_basic/BodyRendererTest.java
@@ -16,12 +16,13 @@
 
 package com.sun.faces.renderkit.html_basic;
 
+import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.StringWriter;
 import java.util.Collections;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.easymock.EasyMock.expect;
 import org.junit.Test;
 import org.powermock.api.easymock.PowerMock;
 
@@ -59,9 +60,9 @@ public class BodyRendererTest {
         BodyRenderer bodyRenderer = new BodyRenderer();
         HtmlBody htmlBody = new HtmlBody();
         htmlBody.getAttributes().put("styleClass", "myclass");
-        
+
         expect(facesContext.getResponseWriter()).andReturn(testResponseWriter).anyTimes();
-        
+
         PowerMock.replay(facesContext);
         bodyRenderer.encodeBegin(facesContext, htmlBody);
         PowerMock.verify(facesContext);
@@ -101,14 +102,15 @@ public class BodyRendererTest {
         Application application = PowerMock.createMock(Application.class);
         BodyRenderer bodyRenderer = new BodyRenderer();
         HtmlBody htmlBody = new HtmlBody();
-        
+
         expect(facesContext.getApplication()).andReturn(application).anyTimes();
-        expect(facesContext.getClientIdsWithMessages()).andReturn(Collections.EMPTY_LIST.iterator()).anyTimes();
+        expect(facesContext.getClientIdsWithMessages()).andReturn(Collections.<String>emptyList().iterator())
+                .anyTimes();
         expect(facesContext.getResponseWriter()).andReturn(testResponseWriter).anyTimes();
         expect(facesContext.getViewRoot()).andReturn(viewRoot).anyTimes();
         expect(facesContext.isProjectStage(ProjectStage.Development)).andReturn(false).anyTimes();
-        expect(viewRoot.getComponentResources(facesContext, "body")).andReturn(Collections.EMPTY_LIST).anyTimes();
-       
+        expect(viewRoot.getComponentResources(facesContext, "body")).andReturn(Collections.emptyList()).anyTimes();
+
         PowerMock.replay(facesContext, viewRoot, application);
         bodyRenderer.encodeEnd(facesContext, htmlBody);
         PowerMock.verify(facesContext, viewRoot, application);

--- a/impl/src/test/java/com/sun/faces/renderkit/html_basic/HeadRendererTest.java
+++ b/impl/src/test/java/com/sun/faces/renderkit/html_basic/HeadRendererTest.java
@@ -16,11 +16,12 @@
 
 package com.sun.faces.renderkit.html_basic;
 
+import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertTrue;
+
 import java.io.StringWriter;
 import java.util.Collections;
 
-import static org.junit.Assert.assertTrue;
-import static org.easymock.EasyMock.expect;
 import org.junit.Test;
 import org.powermock.api.easymock.PowerMock;
 
@@ -51,7 +52,7 @@ public class HeadRendererTest {
     @Test
     public void testEncodeBegin() throws Exception {
         //
-        // TODO: Note we are not testing this method as its complexity is too 
+        // TODO: Note we are not testing this method as its complexity is too
         // high, because it uses WebConfiguration.getInstance to get
         // configuration information that should be readily available to the
         // renderer through either the FacesContext or the component being
@@ -89,11 +90,11 @@ public class HeadRendererTest {
         UIViewRoot viewRoot = PowerMock.createMock(UIViewRoot.class);
         HeadRenderer headRenderer = new HeadRenderer();
         HtmlHead htmlHead = new HtmlHead();
-        
+
         expect(facesContext.getResponseWriter()).andReturn(testResponseWriter).anyTimes();
         expect(facesContext.getViewRoot()).andReturn(viewRoot).anyTimes();
-        expect(viewRoot.getComponentResources(facesContext, "head")).andReturn(Collections.EMPTY_LIST).anyTimes();
-        
+        expect(viewRoot.getComponentResources(facesContext, "head")).andReturn(Collections.emptyList()).anyTimes();
+
         PowerMock.replay(facesContext, viewRoot);
         headRenderer.encodeEnd(facesContext, htmlHead);
         PowerMock.verify(facesContext, viewRoot);

--- a/impl/src/test/java/jakarta/faces/FactoryFinderTestCase.java
+++ b/impl/src/test/java/jakarta/faces/FactoryFinderTestCase.java
@@ -16,6 +16,10 @@
 
 package jakarta.faces;
 
+import java.io.File;
+import java.io.PrintWriter;
+import java.lang.reflect.Method;
+
 import com.sun.faces.mock.MockHttpServletRequest;
 import com.sun.faces.mock.MockHttpServletResponse;
 import com.sun.faces.mock.MockServletContext;
@@ -26,13 +30,8 @@ import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.FacesContextFactory;
 import jakarta.faces.lifecycle.Lifecycle;
 import jakarta.faces.lifecycle.LifecycleFactory;
-
-import java.io.File;
-import java.io.PrintWriter;
-import java.lang.reflect.Method;
-
-import junit.framework.TestCase;
 import junit.framework.Test;
+import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
 public class FactoryFinderTestCase extends TestCase {
@@ -122,7 +121,7 @@ public class FactoryFinderTestCase extends TestCase {
         servicesDir.mkdirs();
 
         File servicesFile = new File(servicesDir, "jakarta.faces.context.FacesContextFactory");
-        
+
         if (servicesFile.exists()) {
             servicesFile.delete();
         }
@@ -130,12 +129,12 @@ public class FactoryFinderTestCase extends TestCase {
         writer.println("jakarta.faces.mock.MockFacesContextFactoryExtender");
         writer.flush();
         writer.close();
-        
+
         File cServicesDir = new File(System.getProperty("basedir"), "target/generated-classes/cobertura/META-INF/services");
         cServicesDir.mkdirs();
 
         File cServicesFile = new File(cServicesDir, "jakarta.faces.context.FacesContextFactory");
-        
+
         if (cServicesFile.exists()) {
             cServicesFile.delete();
         }
@@ -163,7 +162,7 @@ public class FactoryFinderTestCase extends TestCase {
         assertTrue(System.getProperty(FACTORIES[2][0]).equals("jakarta.faces.mock.MockFacesContextFactoryExtender2"));
         assertTrue(System.getProperty("oldImpl").equals("jakarta.faces.mock.MockFacesContextFactoryExtender"));
 
-        // Verify IllegalStateException when factory not found 
+        // Verify IllegalStateException when factory not found
         FactoryFinder.releaseFactories();
         FactoryFinder.setFactory(FACTORIES[0][0], FACTORIES[0][1]);
         FactoryFinder.setFactory(FACTORIES[1][0], FACTORIES[1][1]);
@@ -215,25 +214,25 @@ public class FactoryFinderTestCase extends TestCase {
         servicesDir.mkdirs();
 
         File servicesFile = new File(servicesDir, "jakarta.faces.context.FacesContextFactory");
-        
+
         if (servicesFile.exists()) {
             servicesFile.delete();
         }
-        
+
         PrintWriter writer = new PrintWriter(servicesFile);
         writer.println("jakarta.faces.mock.MockFacesContextFactoryExtender");
         writer.flush();
         writer.close();
-        
+
         File cServicesDir = new File(System.getProperty("basedir"), "target/generated-classes/cobertura/META-INF/services");
         cServicesDir.mkdirs();
 
         File cServicesFile = new File(cServicesDir, "jakarta.faces.context.FacesContextFactory");
-        
+
         if (cServicesFile.exists()) {
             cServicesFile.delete();
         }
-        
+
         PrintWriter cWriter = new PrintWriter(cServicesFile);
         cWriter.println("jakarta.faces.mock.MockFacesContextFactoryExtender");
         cWriter.flush();
@@ -275,9 +274,11 @@ public class FactoryFinderTestCase extends TestCase {
         Object response = new MockHttpServletResponse();
         Object containerContext = new MockServletContext();
         Lifecycle l = lFactory.getLifecycle(LifecycleFactory.DEFAULT_LIFECYCLE);
+        @SuppressWarnings("unused")
         FacesContext context = fcFactory.getFacesContext(containerContext, request, response, l);
 
         ApplicationFactory aFactory = (ApplicationFactory) FactoryFinder.getFactory(FactoryFinder.APPLICATION_FACTORY);
+        @SuppressWarnings("unused")
         Application app = aFactory.getApplication();
         FactoryFinder.releaseFactories();
     }

--- a/impl/src/test/java/jakarta/faces/event/PhaseIdTest.java
+++ b/impl/src/test/java/jakarta/faces/event/PhaseIdTest.java
@@ -16,8 +16,9 @@
 
 package jakarta.faces.event;
 
-import junit.framework.TestCase;
 import java.util.Iterator;
+
+import junit.framework.TestCase;
 
 public class PhaseIdTest extends TestCase {
 //
@@ -33,7 +34,7 @@ public class PhaseIdTest extends TestCase {
 // Attribute Instance Variables
 // Relationship Instance Variables
 //
-// Constructors and Initializers    
+// Constructors and Initializers
 //
     public PhaseIdTest() {
         super();
@@ -46,10 +47,10 @@ public class PhaseIdTest extends TestCase {
 // General Methods
 //
     public void testToString() {
-        Iterator valueIter = PhaseId.VALUES.iterator();
+        Iterator<PhaseId> valueIter = PhaseId.VALUES.iterator();
         String cur = null;
         while (valueIter.hasNext()) {
-            cur = (String) valueIter.next().toString();
+            cur = valueIter.next().toString();
             System.out.println(cur);
             assertTrue(cur.length() > 3);
         }

--- a/impl/src/test/java/jakarta/faces/model/CollectionDataModelTest.java
+++ b/impl/src/test/java/jakarta/faces/model/CollectionDataModelTest.java
@@ -16,14 +16,16 @@
 
 package jakarta.faces.model;
 
-import java.util.ArrayList;
-import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
-import static org.junit.Assert.*;
+import java.util.ArrayList;
+
+import org.junit.Test;
 
 /**
  * The JUnit tests for CollectionDataModel.
- * 
+ *
  * @author Manfred Riem
  */
 public class CollectionDataModelTest {
@@ -33,9 +35,9 @@ public class CollectionDataModelTest {
      */
     @Test
     public void testGetWrappedData() {
-        CollectionDataModel model = new CollectionDataModel();
+        CollectionDataModel<Object> model = new CollectionDataModel<>();
         assertNull(model.getWrappedData());
-        ArrayList<String> list = new ArrayList<String>();
+        ArrayList<String> list = new ArrayList<>();
         model.setWrappedData(list);
         assertNotNull(model.getWrappedData());
         model.setWrappedData(null);

--- a/impl/src/test/java/jakarta/faces/model/DataModelTestCaseBase.java
+++ b/impl/src/test/java/jakarta/faces/model/DataModelTestCaseBase.java
@@ -16,11 +16,11 @@
 
 package jakarta.faces.model;
 
+import java.lang.reflect.Method;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-import java.lang.reflect.Method;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
@@ -48,7 +48,7 @@ public abstract class DataModelTestCaseBase extends TestCase {
     protected BeanTestImpl beans[] = new BeanTestImpl[0];
 
     // The DataModel we are testing
-    protected DataModel model = null;
+    protected DataModel<?> model = null;
 
     // ---------------------------------------------------- Overall Test Methods
     // Configure the properties of the beans we will be wrapping
@@ -58,8 +58,8 @@ public abstract class DataModelTestCaseBase extends TestCase {
             bean.setBooleanProperty((i % 2) == 0);
             bean.setBooleanSecond(!bean.getBooleanProperty());
             bean.setByteProperty((byte) i);
-            bean.setDoubleProperty(((double) i) * 100.0);
-            bean.setFloatProperty(((float) i) * ((float) 10.0));
+            bean.setDoubleProperty(i * 100.0);
+            bean.setFloatProperty(i * ((float) 10.0));
             bean.setIntProperty(1000 * i);
             bean.setLongProperty((long) 10000 * (long) i);
             bean.setStringProperty("This is string " + i);
@@ -79,6 +79,7 @@ public abstract class DataModelTestCaseBase extends TestCase {
     }
 
     // Tear down instance variables required by ths test case
+    @Override
     public void tearDown() throws Exception {
         super.tearDown();
         beans = null;
@@ -192,6 +193,7 @@ public abstract class DataModelTestCaseBase extends TestCase {
     }
 
     // Test the ability to update through the Map returned by getRowData()
+    @SuppressWarnings("unchecked")
     public void testRowData() throws Exception {
         // Retrieve the row data for row zero
         model.setRowIndex(0);
@@ -202,7 +204,7 @@ public abstract class DataModelTestCaseBase extends TestCase {
         BeanTestImpl bean = beans[0];
         bean.setBooleanProperty(!bean.getBooleanProperty());
         if (data instanceof Map) {
-            ((Map) data).put("booleanProperty",
+            ((Map<String, Boolean>) data).put("booleanProperty",
                     bean.getBooleanProperty()
                     ? Boolean.TRUE : Boolean.FALSE);
         } else {
@@ -211,7 +213,7 @@ public abstract class DataModelTestCaseBase extends TestCase {
         }
         bean.setIntProperty(bean.getIntProperty() + 5);
         if (data instanceof Map) {
-            ((Map) data).put("intProperty",
+            ((Map<String, Integer>) data).put("intProperty",
                     bean.getIntProperty());
         } else {
             Method m = data.getClass().getMethod("setIntProperty", Integer.TYPE);
@@ -219,7 +221,7 @@ public abstract class DataModelTestCaseBase extends TestCase {
         }
         bean.setStringProperty(bean.getStringProperty() + "XYZ");
         if (data instanceof Map) {
-            ((Map) data).put("stringProperty",
+            ((Map<String, String>) data).put("stringProperty",
                     bean.getStringProperty() + "XYZ");
         } else {
             Method m = data.getClass().getMethod("setStringProperty", String.class);
@@ -263,7 +265,7 @@ public abstract class DataModelTestCaseBase extends TestCase {
     }
 
     public void testIterator() {
-        Iterator iterator = model.iterator();
+        Iterator<?> iterator = model.iterator();
         if (!(model instanceof ScalarDataModel)) {
             for (int i = 0; i < 5; i++) {
                 System.out.println("Index: " + i);

--- a/impl/src/test/java/jakarta/faces/validator/CastingValidatorTestCase.java
+++ b/impl/src/test/java/jakarta/faces/validator/CastingValidatorTestCase.java
@@ -43,10 +43,10 @@ public class CastingValidatorTestCase extends ValidatorTestCase {
 
     // ------------------------------------------------- Individual Test Methods
     public void testWithGenericCanCastToRaw() {
-    	
-    	Validator<?> validatorWithGeneric = (context, component, value) -> {};
-    	
-    	Validator validatorRaw = validatorWithGeneric;
+        Validator<?> validatorWithGeneric = (context, component, value) -> {
+        };
+        Validator<?> validatorRaw = validatorWithGeneric;
+        assertNotNull(validatorRaw);
     }
-    
+
 }

--- a/impl/src/test/java/jakarta/faces/webapp/ConfigFileTestCase.java
+++ b/impl/src/test/java/jakarta/faces/webapp/ConfigFileTestCase.java
@@ -93,7 +93,7 @@ public class ConfigFileTestCase extends TestCase {
         assertEquals("com.mycompany.MyNavigationHandler", base.getNavigationHandler());
 
         // <component>
-        Map components = base.getComponents();
+        Map<?, ?> components = base.getComponents();
         assertNotNull(components);
         ConfigComponent ccomp1 = (ConfigComponent) components.get("Command");
         assertNotNull(ccomp1);
@@ -107,7 +107,7 @@ public class ConfigFileTestCase extends TestCase {
         assertEquals(0, ccomp1.getProperties().size());
 
         // <converter>
-        Map converters = base.getConverters();
+        Map<?, ?> converters = base.getConverters();
         assertNotNull(converters);
         ConfigConverter cc1 = (ConfigConverter) converters.get("First");
         assertNotNull(cc1);
@@ -147,7 +147,7 @@ public class ConfigFileTestCase extends TestCase {
         assertEquals("java.lang.String", cc2p1.getPropertyClass());
 
         // <validator>
-        Map validators = base.getValidators();
+        Map<?, ?> validators = base.getValidators();
         assertNotNull(validators);
         ConfigValidator cv1 = (ConfigValidator) validators.get("First");
         assertNotNull(cv1);
@@ -293,6 +293,6 @@ public class ConfigFileTestCase extends TestCase {
     // Return the URL of the specified path, relative to our base directory
     protected URL relativeURL(String relativePath) throws Exception {
         File file = new File(System.getProperty("base.dir"), relativePath);
-        return (file.toURL());
+        return (file.toURI().toURL());
     }
 }

--- a/rest/src/main/java/org/eclipse/mojarra/rest/DefaultRestMappingMatcher.java
+++ b/rest/src/main/java/org/eclipse/mojarra/rest/DefaultRestMappingMatcher.java
@@ -18,6 +18,7 @@ package org.eclipse.mojarra.rest;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.regex.Pattern;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.spi.AnnotatedMethod;
@@ -39,10 +40,12 @@ public class DefaultRestMappingMatcher implements RestMappingMatcher {
      * @param bean the bean.
      * @return the REST mapping match, or null if not found.
      */
+    @SuppressWarnings("rawtypes")
     private RestMappingMatch determineRestMappingMatch(FacesContext facesContext, Bean<?> bean) {
         RestMappingMatch result = null;
         Class<?> clazz = bean.getBeanClass();
         AnnotatedType annotatedType = CDI.current().getBeanManager().createAnnotatedType(clazz);
+        @SuppressWarnings("unchecked")
         Set<AnnotatedMethod> annotatedMethodSet = annotatedType.getMethods();
         for (AnnotatedMethod method : annotatedMethodSet) {
             if (method.isAnnotationPresent(RestPath.class)) {

--- a/rest/src/main/java/org/eclipse/mojarra/rest/DefaultRestMethodExecutor.java
+++ b/rest/src/main/java/org/eclipse/mojarra/rest/DefaultRestMethodExecutor.java
@@ -37,7 +37,7 @@ public class DefaultRestMethodExecutor implements RestMethodExecutor {
 
     @Override
     public Object execute(FacesContext facesContext, RestMappingMatch restMappingMatch) {
-        Instance instance = CDI.current().select(
+        Instance<?> instance = CDI.current().select(
                 restMappingMatch.getBean().getBeanClass(), Any.Literal.INSTANCE);
         Object result;
         try {


### PR DESCRIPTION
Hello again,
I've got many leftover from my work in last year with fixing warnings in project. Here are 4 of them.

* Remove various warnings from jakarta/faces tests (like you can see I had no inspiration to name these changes)
* Remove various warnings from com.sun.faces tests
* Fix compilation warnings in Action project (all warnings in subproject)
* Fix compilation warnings in Rest project (all warnings in subproject)

Since I wanted to play safe most of my work focus on test classes, so there are no worries about introducing bugs in the main code :-)

Any feedback will be appreciated. I can marge, split or delete anything from this changes.