### PR TITLE
FacesContext EL variable incorrectly references previous instance after sendError() to a Facelet

### DIFF
--- a/impl/src/main/java/com/sun/faces/context/FacesContextImpl.java
+++ b/impl/src/main/java/com/sun/faces/context/FacesContextImpl.java
@@ -36,6 +36,9 @@ import com.sun.faces.util.Util;
 import jakarta.el.ELContext;
 import jakarta.el.ELContextEvent;
 import jakarta.el.ELContextListener;
+import jakarta.enterprise.context.spi.AlterableContext;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.FactoryFinder;
 import jakarta.faces.application.Application;
 import jakarta.faces.application.ApplicationFactory;
@@ -506,6 +509,7 @@ public class FacesContextImpl extends FacesContext {
      */
     @Override
     public void release() {
+        BeanManager beanManager = Util.getCdiBeanManager(this);
 
         released = true;
         if (externalContext != null) {
@@ -551,6 +555,9 @@ public class FacesContextImpl extends FacesContext {
         // remove our private ThreadLocal instance.
         DEFAULT_FACES_CONTEXT.remove();
 
+        // Destroy our instance produced by FacesContextProducer.
+        Bean<?> bean = beanManager.resolve(beanManager.getBeans(FacesContext.class));
+        ((AlterableContext) beanManager.getContext(bean.getScope())).destroy(bean);
     }
 
     /**


### PR DESCRIPTION
https://github.com/eclipse-ee4j/mojarra/issues/5183 Quick work around for now. Cleanest solution would have been a custom scope like `@FacesContextScoped`. I'll look at it next.