### PR TITLE
View maps entries are not restored in "finally" block

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/ViewMetadataImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/view/ViewMetadataImpl.java
@@ -97,8 +97,9 @@ public class ViewMetadataImpl extends ViewMetadata {
                 Map<String, Object> currentViewMap = currentViewRoot.getViewMap(false);
 
                 if (!isEmpty(currentViewMap)) {
+                    currentViewMapShallowCopy = new HashMap<>(currentViewMap);
                     metadataView.getViewMap(true)
-                                .putAll(new HashMap<>(currentViewMap));
+                                .putAll(currentViewMapShallowCopy);
                 }
             }
 


### PR DESCRIPTION
View maps entries are not restored in "finally" block of method "ViewMetadataImpl.createMetadataView" because "currentViewMapShallowCopy" is always empty