### PR TITLE
StringBuffer -> StringBuilder

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -930,7 +930,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
         // Always log
         if (LOGGER.isLoggable(SEVERE)) {
             UIViewRoot root = context.getViewRoot();
-            StringBuffer sb = new StringBuffer(64);
+            StringBuilder sb = new StringBuilder(64);
             sb.append("Error Rendering View");
             if (root != null) {
                 sb.append('[');

--- a/impl/src/main/java/com/sun/faces/ext/component/MessageFactory.java
+++ b/impl/src/main/java/com/sun/faces/ext/component/MessageFactory.java
@@ -255,7 +255,7 @@ public class MessageFactory {
             if (params == null || msgtext == null) {
                 return msgtext;
             }
-            StringBuffer b = new StringBuffer(100);
+            StringBuilder b = new StringBuilder(100);
             MessageFormat mf = new MessageFormat(msgtext);
             if (locale != null) {
                 mf.setLocale(locale);

--- a/impl/src/main/java/com/sun/faces/facelets/compiler/SAXCompiler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/compiler/SAXCompiler.java
@@ -251,9 +251,7 @@ public final class SAXCompiler extends Compiler {
                 boolean processAsXhtml = unit.getWebConfiguration().getFaceletsConfiguration().isProcessCurrentDocumentAsFaceletsXhtml(alias);
 
                 if (processAsXhtml) {
-                    StringBuffer sb = new StringBuffer(64);
-                    sb.append("<?").append(target).append(' ').append(data).append("?>\n");
-                    unit.writeInstruction(sb.toString());
+                    unit.writeInstruction("<?" + target + ' ' + data + "?>\n");
                 }
             }
         }

--- a/impl/src/main/java/com/sun/faces/facelets/compiler/TextUnit.java
+++ b/impl/src/main/java/com/sun/faces/facelets/compiler/TextUnit.java
@@ -141,7 +141,7 @@ final class TextUnit extends CompilationUnit {
             addInstruction(new CommentInstruction(el));
         }
 
-        buffer.append("<!--" + text + "-->");
+        buffer.append("<!--").append(text).append("-->");
     }
 
     public void startTag(Tag tag) {
@@ -182,7 +182,7 @@ final class TextUnit extends CompilationUnit {
 
     private void finishStartTag() {
         if (tags.size() > 0 && startTagOpen) {
-            buffer.append(">");
+            buffer.append('>');
             startTagOpen = false;
         }
     }
@@ -285,7 +285,7 @@ final class TextUnit extends CompilationUnit {
             if (Character.isWhitespace(s.charAt(i))) {
                 i--;
             } else {
-                return s;
+                return s.substring(0,i+1);
             }
         }
         return "";
@@ -295,4 +295,6 @@ final class TextUnit extends CompilationUnit {
     public String toString() {
         return "TextUnit[" + children.size() + "]";
     }
+
+
 }

--- a/impl/src/main/java/com/sun/faces/facelets/el/DefaultFunctionMapper.java
+++ b/impl/src/main/java/com/sun/faces/facelets/el/DefaultFunctionMapper.java
@@ -51,7 +51,7 @@ public final class DefaultFunctionMapper extends FunctionMapper implements Exter
     @Override
     public Method resolveFunction(String prefix, String localName) {
         if (functions != null) {
-            Function f = (Function) functions.get(prefix + ":" + localName);
+            Function f = (Function) functions.get(prefix + ':' + localName);
             return f.getMethod();
         }
         return null;
@@ -63,7 +63,7 @@ public final class DefaultFunctionMapper extends FunctionMapper implements Exter
         }
         Function f = new Function(prefix, localName, m);
         synchronized (this) {
-            functions.put(prefix + ":" + localName, f);
+            functions.put(prefix + ':' + localName, f);
         }
     }
 
@@ -89,7 +89,7 @@ public final class DefaultFunctionMapper extends FunctionMapper implements Exter
 
     @Override
     public String toString() {
-        StringBuffer sb = new StringBuffer(128);
+        StringBuilder sb = new StringBuilder(128);
         sb.append("FunctionMapper[\n");
         for (Iterator itr = functions.values().iterator(); itr.hasNext();) {
             sb.append(itr.next()).append('\n');
@@ -215,7 +215,7 @@ public final class DefaultFunctionMapper extends FunctionMapper implements Exter
 
         @Override
         public String toString() {
-            StringBuffer sb = new StringBuffer(32);
+            StringBuilder sb = new StringBuilder(32);
             sb.append("Function[");
             if (prefix != null) {
                 sb.append(prefix).append(':');

--- a/impl/src/main/java/com/sun/faces/facelets/el/ELText.java
+++ b/impl/src/main/java/com/sun/faces/facelets/el/ELText.java
@@ -122,9 +122,9 @@ public class ELText {
 
         @Override
         public String toString(ELContext ctx) {
-            StringBuffer sb = new StringBuffer();
-            for (int i = 0; i < txt.length; i++) {
-                sb.append(txt[i].toString(ctx));
+            StringBuilder sb = new StringBuilder();
+            for (ELText elText : txt) {
+                sb.append(elText.toString(ctx));
             }
             return sb.toString();
         }
@@ -136,9 +136,9 @@ public class ELText {
 
         @Override
         public String toString() {
-            StringBuffer sb = new StringBuffer();
-            for (int i = 0; i < txt.length; i++) {
-                sb.append(txt[i].toString());
+            StringBuilder sb = new StringBuilder();
+            for (ELText elText : txt) {
+                sb.append(elText.toString());
             }
             return sb.toString();
         }
@@ -324,7 +324,7 @@ public class ELText {
         boolean esc = false;
         int vlen = 0;
 
-        StringBuffer buff = new StringBuffer(128);
+        StringBuilder buff = new StringBuilder(128);
         List<ELText> text = new ArrayList<>();
         ELText t = null;
         ValueExpression ve = null;

--- a/impl/src/main/java/com/sun/faces/facelets/tag/TagAttributesImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/TagAttributesImpl.java
@@ -170,9 +170,9 @@ public final class TagAttributesImpl extends TagAttributes {
      */
     @Override
     public String toString() {
-        StringBuffer sb = new StringBuffer();
-        for (int i = 0; i < attrs.length; i++) {
-            sb.append(attrs[i]);
+        StringBuilder sb = new StringBuilder();
+        for (TagAttribute attr : attrs) {
+            sb.append(attr);
             sb.append(' ');
         }
         if (sb.length() > 1) {

--- a/impl/src/main/java/com/sun/faces/facelets/tag/composite/InterfaceHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/composite/InterfaceHandler.java
@@ -90,7 +90,7 @@ public class InterfaceHandler extends TagHandlerImpl {
         String key;
         Object requiredValue;
         boolean found = false, required = false;
-        StringBuffer buf = null;
+        StringBuilder buf = null;
         String attrMessage = "", facetMessage = "";
 
         // Traverse the attributes of this component
@@ -121,10 +121,10 @@ public class InterfaceHandler extends TagHandlerImpl {
                 }
                 if (!found) {
                     if (null == buf) {
-                        buf = new StringBuffer();
+                        buf = new StringBuilder();
                         buf.append(key);
                     } else {
-                        buf.append(", " + key);
+                        buf.append(", ").append(key);
                     }
                 }
             }
@@ -152,10 +152,10 @@ public class InterfaceHandler extends TagHandlerImpl {
                     key = cur.getName();
                     if (!cc.getFacets().containsKey(key)) {
                         if (null == buf) {
-                            buf = new StringBuffer();
+                            buf = new StringBuilder();
                             buf.append(key);
                         } else {
-                            buf.append(", " + key);
+                            buf.append(", ").append(key);
                         }
                     }
                 }

--- a/impl/src/main/java/com/sun/faces/facelets/tag/ui/UIDebug.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/ui/UIDebug.java
@@ -80,7 +80,7 @@ public final class UIDebug extends UIComponentBase {
             pushComponentToEL(facesContext, this);
             String actionId = facesContext.getApplication().getViewHandler().getActionURL(facesContext, facesContext.getViewRoot().getViewId());
 
-            StringBuffer sb = new StringBuffer(512);
+            StringBuilder sb = new StringBuilder(512);
             sb.append("//<![CDATA[\n");
             sb.append("function faceletsDebugWindow(URL) {");
             sb.append("day = new Date();");
@@ -89,8 +89,9 @@ public final class UIDebug extends UIComponentBase {
                     "eval(\"page\" + id + \" = window.open(URL, '\" + id + \"', 'toolbar=0,scrollbars=1,location=0,statusbar=0,menubar=0,resizable=1,width=800,height=600,left = 240,top = 212');\"); };");
             sb.append("(function() { if (typeof faceletsDebug === 'undefined') { var faceletsDebug = false; } if (!faceletsDebug) {");
             sb.append("var faceletsOrigKeyup = document.onkeyup;");
-            sb.append("document.onkeyup = function(e) { if (window.event) e = window.event; if (String.fromCharCode(e.keyCode) == '" + getHotkey()
-                    + "' & e.shiftKey & e.ctrlKey) faceletsDebugWindow('");
+            sb.append("document.onkeyup = function(e) { if (window.event) e = window.event; if (String.fromCharCode(e.keyCode) == '")
+              .append(getHotkey())
+              .append("' & e.shiftKey & e.ctrlKey) faceletsDebugWindow('");
             sb.append(actionId);
             sb.append(actionId.indexOf('?') == -1 ? '?' : '&');
             sb.append(KEY);
@@ -133,7 +134,7 @@ public final class UIDebug extends UIComponentBase {
             };
         }
         session.put(KEY, debugs);
-        String id = "" + nextId++;
+        String id = String.valueOf(nextId++);
         debugs.put(id, fw.toString());
         return id;
     }

--- a/impl/src/main/java/com/sun/faces/facelets/util/Classpath.java
+++ b/impl/src/main/java/com/sun/faces/facelets/util/Classpath.java
@@ -23,6 +23,7 @@ import java.net.JarURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -65,20 +66,20 @@ public final class Classpath {
     }
 
     public static URL[] search(ClassLoader cl, String prefix, String suffix, SearchAdvice advice) throws IOException {
-        Enumeration[] e = new Enumeration[] { cl.getResources(prefix), cl.getResources(prefix + "MANIFEST.MF") };
-        Set all = new LinkedHashSet();
+        Enumeration<URL>[] e = new Enumeration[] { cl.getResources(prefix), cl.getResources(prefix + "MANIFEST.MF") };
+        Set<URL> all = new LinkedHashSet<>();
         URL url;
         URLConnection conn;
         JarFile jarFile;
-        for (int i = 0, s = e.length; i < s; ++i) {
-            while (e[i].hasMoreElements()) {
-                url = (URL) e[i].nextElement();
+        for (Enumeration<URL> enumeration : e) {
+            while (enumeration.hasMoreElements()) {
+                url = enumeration.nextElement();
                 // Defensive programming. Due to issue 13045 this collection
                 // can contain URLs that have their spaces incorrectly escaped
                 // by having %20 replaced with %2520. This quick conditional
                 // check catches this particular case and averts it.
                 String str = url.getPath();
-                if (-1 != str.indexOf("%2520")) {
+                if (str.contains("%2520")) {
                     str = url.toExternalForm();
                     str = str.replace("%2520", "%20");
                     url = new URL(str);
@@ -93,18 +94,18 @@ public final class Classpath {
                 if (jarFile != null) {
                     searchJar(cl, all, jarFile, prefix, suffix, advice);
                 } else {
-                    boolean searchDone = searchDir(all, new File(URLDecoder.decode(url.getFile(), "UTF-8")), suffix);
+                    boolean searchDone = searchDir(all, new File(URLDecoder.decode(url.getFile(), StandardCharsets.UTF_8)), suffix);
                     if (!searchDone) {
                         searchFromURL(all, prefix, suffix, url);
                     }
                 }
             }
         }
-        URL[] urlArray = (URL[]) all.toArray(new URL[all.size()]);
+        URL[] urlArray = all.toArray(new URL[0]);
         return urlArray;
     }
 
-    private static boolean searchDir(Set result, File file, String suffix) throws IOException {
+    private static boolean searchDir(Set<URL> result, File file, String suffix) throws IOException {
         if (file.exists() && file.isDirectory()) {
             File[] fc = file.listFiles();
             String path;
@@ -115,13 +116,13 @@ public final class Classpath {
                 return false;
             }
 
-            for (int i = 0; i < fc.length; i++) {
-                path = fc[i].getAbsolutePath();
-                if (fc[i].isDirectory()) {
-                    searchDir(result, fc[i], suffix);
+            for (File value : fc) {
+                path = value.getAbsolutePath();
+                if (value.isDirectory()) {
+                    searchDir(result, value, suffix);
                 } else if (path.endsWith(suffix)) {
                     // result.add(new URL("file:/" + path));
-                    result.add(fc[i].toURL());
+                    result.add(value.toURL());
                 }
             }
             return true;
@@ -139,7 +140,7 @@ public final class Classpath {
      *
      * @throws IOException for any error
      */
-    private static void searchFromURL(Set result, String prefix, String suffix, URL url) throws IOException {
+    private static void searchFromURL(Set<URL> result, String prefix, String suffix, URL url) throws IOException {
         boolean done = false;
         InputStream is = getInputStream(url);
         if (is != null) {
@@ -190,9 +191,9 @@ public final class Classpath {
      * @return joined tokens
      */
     private static String join(String[] tokens, boolean excludeLast) {
-        StringBuffer join = new StringBuffer();
+        StringBuilder join = new StringBuilder();
         for (int i = 0; i < tokens.length - (excludeLast ? 1 : 0); i++) {
-            join.append(tokens[i]).append("/");
+            join.append(tokens[i]).append('/');
         }
         return join.toString();
     }
@@ -244,7 +245,7 @@ public final class Classpath {
             // And trim off any "file:" prefix.
             if (jarFileUrl.startsWith("file:")) {
                 jarFileUrl = jarFileUrl.substring("file:".length());
-                jarFileUrl = URLDecoder.decode(jarFileUrl, "UTF-8");
+                jarFileUrl = URLDecoder.decode(jarFileUrl, StandardCharsets.UTF_8);
             }
             boolean foundExclusion = false;
             for (int i = 0; i < PREFIXES_TO_EXCLUDE.length; i++) {
@@ -266,19 +267,19 @@ public final class Classpath {
         return null;
     }
 
-    private static void searchJar(ClassLoader cl, Set result, JarFile file, String prefix, String suffix, SearchAdvice advice) throws IOException {
-        Enumeration e = file.entries();
+    private static void searchJar(ClassLoader cl, Set<URL> result, JarFile file, String prefix, String suffix, SearchAdvice advice) throws IOException {
+        Enumeration<JarEntry> e = file.entries();
         JarEntry entry;
         String name;
         while (e.hasMoreElements()) {
             try {
-                entry = (JarEntry) e.nextElement();
+                entry = e.nextElement();
             } catch (Throwable t) {
                 continue;
             }
             name = entry.getName();
             if (name.startsWith(prefix) && name.endsWith(suffix)) {
-                Enumeration e2 = cl.getResources(name);
+                Enumeration<URL> e2 = cl.getResources(name);
                 while (e2.hasMoreElements()) {
                     result.add(e2.nextElement());
                     if (advice == SearchAdvice.FirstMatchOnly) {

--- a/impl/src/main/java/com/sun/faces/facelets/util/Classpath.java
+++ b/impl/src/main/java/com/sun/faces/facelets/util/Classpath.java
@@ -101,7 +101,7 @@ public final class Classpath {
                 }
             }
         }
-        URL[] urlArray = all.toArray(new URL[0]);
+        URL[] urlArray = all.toArray(new URL[all.size()]);
         return urlArray;
     }
 

--- a/impl/src/main/java/com/sun/faces/facelets/util/ReflectionUtil.java
+++ b/impl/src/main/java/com/sun/faces/facelets/util/ReflectionUtil.java
@@ -146,11 +146,11 @@ public class ReflectionUtil {
 //        return null;
 //    }
 
-    protected static final String paramString(Class[] types) {
+    protected static String paramString(Class<?>[] types) {
         if (types != null) {
-            StringBuffer sb = new StringBuffer();
-            for (int i = 0; i < types.length; i++) {
-                sb.append(types[i].getName()).append(", ");
+            StringBuilder sb = new StringBuilder();
+            for (Class<?> type : types) {
+                sb.append(type.getName()).append(", ");
             }
             if (sb.length() > 2) {
                 sb.setLength(sb.length() - 2);

--- a/impl/src/main/java/com/sun/faces/renderkit/RenderKitImpl.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/RenderKitImpl.java
@@ -198,7 +198,7 @@ public class RenderKitImpl extends RenderKit {
         if (null == desiredContentTypeList || contentTypeNullFromResponse) {
             String[] typeArray = context.getExternalContext().getRequestHeaderValuesMap().get("Accept");
             if (typeArray.length > 0) {
-                StringBuffer buff = new StringBuffer();
+                StringBuilder buff = new StringBuilder();
                 buff.append(typeArray[0]);
                 for (int i = 1, len = typeArray.length; i < len; i++) {
                     buff.append(',');
@@ -279,15 +279,13 @@ public class RenderKitImpl extends RenderKit {
 
         // For each entry in the desiredTypes array, look for a match in
         // the supportedTypes array
-        for (int i = 0, ilen = desiredTypes.length; i < ilen; i++) {
-            String curDesiredType = desiredTypes[i];
-            for (int j = 0, jlen = supportedTypes.length; j < jlen; j++) {
-                String curContentType = supportedTypes[j].trim();
+        for (String curDesiredType : desiredTypes) {
+            for (String supportedType : supportedTypes) {
+                String curContentType = supportedType.trim();
                 if (curDesiredType.contains(curContentType)) {
                     if (curContentType.contains(RIConstants.HTML_CONTENT_TYPE)) {
                         contentType = RIConstants.HTML_CONTENT_TYPE;
-                    } else if (curContentType.contains(RIConstants.XHTML_CONTENT_TYPE) || curContentType.contains(RIConstants.APPLICATION_XML_CONTENT_TYPE)
-                            || curContentType.contains(RIConstants.TEXT_XML_CONTENT_TYPE)) {
+                    } else if (curContentType.contains(RIConstants.XHTML_CONTENT_TYPE) || curContentType.contains(RIConstants.APPLICATION_XML_CONTENT_TYPE) || curContentType.contains(RIConstants.TEXT_XML_CONTENT_TYPE)) {
                         contentType = RIConstants.XHTML_CONTENT_TYPE;
                     }
                     break;
@@ -310,12 +308,12 @@ public class RenderKitImpl extends RenderKit {
             }
 
             @Override
-            public void write(byte b[]) throws IOException {
+            public void write(byte[] b) throws IOException {
                 output.write(b);
             }
 
             @Override
-            public void write(byte b[], int off, int len) throws IOException {
+            public void write(byte[] b, int off, int len) throws IOException {
                 output.write(b, off, len);
             }
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutputLinkRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutputLinkRenderer.java
@@ -23,6 +23,7 @@ import static java.util.logging.Level.FINE;
 
 import java.io.IOException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import com.sun.faces.renderkit.Attribute;
 import com.sun.faces.renderkit.AttributeManager;
@@ -166,20 +167,20 @@ public class OutputLinkRenderer extends LinkRenderer {
 
         // Write Anchor attributes
 
-        Param paramList[] = getParamList(component);
-        StringBuffer sb = new StringBuffer();
+        Param[] paramList = getParamList(component);
+        StringBuilder sb = new StringBuilder();
         sb.append(hrefVal);
         boolean paramWritten = hrefVal.indexOf('?') > 0;
 
-        for (int i = 0, len = paramList.length; i < len; i++) {
-            String pn = paramList[i].name;
+        for (Param param : paramList) {
+            String pn = param.name;
             if (pn != null && pn.length() != 0) {
-                String pv = paramList[i].value;
+                String pv = param.value;
                 sb.append(paramWritten ? '&' : '?');
-                sb.append(URLEncoder.encode(pn, "UTF-8"));
+                sb.append(URLEncoder.encode(pn, StandardCharsets.UTF_8));
                 sb.append('=');
                 if (pv != null && pv.length() != 0) {
-                    sb.append(URLEncoder.encode(pv, "UTF-8"));
+                    sb.append(URLEncoder.encode(pv, StandardCharsets.UTF_8));
                 }
                 paramWritten = true;
             }

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutputMessageRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutputMessageRenderer.java
@@ -54,7 +54,7 @@ public class OutputMessageRenderer extends HtmlBasicInputRenderer {
         }
 
         String currentValue = getCurrentValue(context, component);
-        // If null, do not putput anything - return.
+        // If null, do not output anything - return.
         if (null == currentValue) {
             return;
         }

--- a/impl/src/main/java/com/sun/faces/util/MessageFactory.java
+++ b/impl/src/main/java/com/sun/faces/util/MessageFactory.java
@@ -309,7 +309,7 @@ public class MessageFactory {
             if (params == null || msgtext == null) {
                 return msgtext;
             }
-            StringBuffer b = new StringBuffer(100);
+            StringBuilder b = new StringBuilder(100);
             MessageFormat mf = new MessageFormat(msgtext);
             if (locale != null) {
                 mf.setLocale(locale);

--- a/impl/src/main/java/com/sun/faces/util/Util.java
+++ b/impl/src/main/java/com/sun/faces/util/Util.java
@@ -897,7 +897,7 @@ public class Util {
         }
 
         StackTraceElement[] stacks = e.getStackTrace();
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (StackTraceElement stack : stacks) {
             sb.append(stack.toString()).append('\n');
         }

--- a/impl/src/main/java/jakarta/faces/component/MessageFactory.java
+++ b/impl/src/main/java/jakarta/faces/component/MessageFactory.java
@@ -307,7 +307,7 @@ class MessageFactory {
             if (params == null || msgtext == null) {
                 return msgtext;
             }
-            StringBuffer b = new StringBuffer(100);
+            StringBuilder b = new StringBuilder(100);
             MessageFormat mf = new MessageFormat(msgtext);
             if (locale != null) {
                 mf.setLocale(locale);

--- a/impl/src/main/java/jakarta/faces/component/UIComponent.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponent.java
@@ -2160,7 +2160,7 @@ public abstract class UIComponent implements PartialStateHolder, TransientStateH
 
             @Override
             public String toString() {
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 Iterator<Map.Entry<String, String>> entries = entrySet().iterator();
                 Map.Entry<String, String> cur;
                 while (entries.hasNext()) {

--- a/impl/src/main/java/jakarta/faces/convert/MessageFactory.java
+++ b/impl/src/main/java/jakarta/faces/convert/MessageFactory.java
@@ -309,7 +309,7 @@ class MessageFactory {
             if (params == null || msgtext == null) {
                 return msgtext;
             }
-            StringBuffer b = new StringBuffer(100);
+            StringBuilder b = new StringBuilder(100);
             MessageFormat mf = new MessageFormat(msgtext);
             if (locale != null) {
                 mf.setLocale(locale);

--- a/impl/src/main/java/jakarta/faces/validator/MessageFactory.java
+++ b/impl/src/main/java/jakarta/faces/validator/MessageFactory.java
@@ -309,7 +309,7 @@ class MessageFactory {
             if (params == null || msgtext == null) {
                 return msgtext;
             }
-            StringBuffer b = new StringBuffer(100);
+            StringBuilder b = new StringBuilder(100);
             MessageFormat mf = new MessageFormat(msgtext);
             if (locale != null) {
                 mf.setLocale(locale);

--- a/impl/src/main/java/jakarta/faces/webapp/MessageFactory.java
+++ b/impl/src/main/java/jakarta/faces/webapp/MessageFactory.java
@@ -303,13 +303,14 @@ class MessageFactory {
             }
         }
 
+        // fixme: if the locale is null, the output is null!! is it expected?
         private String getFormattedString(String msgtext, Object[] params) {
             String localizedStr = null;
 
             if (params == null || msgtext == null) {
                 return msgtext;
             }
-            StringBuffer b = new StringBuffer(100);
+            StringBuilder b = new StringBuilder(100);
             MessageFormat mf = new MessageFormat(msgtext);
             if (locale != null) {
                 mf.setLocale(locale);

--- a/impl/src/test/java/com/sun/faces/mock/MockHttpServletRequest.java
+++ b/impl/src/test/java/com/sun/faces/mock/MockHttpServletRequest.java
@@ -196,7 +196,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 
     @Override
     public String getRequestURI() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if (contextPath != null) {
             sb.append(contextPath);
         }
@@ -330,7 +330,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 
     @Override
     public String getParameter(String name) {
-        String values[] = parameters.get(name);
+        String[] values = parameters.get(name);
         if (values != null) {
             return (values[0]);
         } else {

--- a/impl/src/test/java/jakarta/faces/component/ActionListenerTestImpl.java
+++ b/impl/src/test/java/jakarta/faces/component/ActionListenerTestImpl.java
@@ -64,7 +64,7 @@ public class ActionListenerTestImpl implements ActionListener, StateHolder {
 
     // ---------------------------------------------------- Static Trace Methods
     // Accumulated trace log
-    private static StringBuffer trace = new StringBuffer();
+    private static final StringBuffer trace = new StringBuffer();
 
     // Append to the current trace log (or clear if null)
     public static void trace(String text) {

--- a/impl/src/test/java/jakarta/faces/component/UIComponentBaseTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIComponentBaseTestCase.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import jakarta.faces.FacesException;
 import jakarta.faces.context.FacesContext;
@@ -734,16 +735,16 @@ public class UIComponentBaseTestCase extends UIComponentTestCase {
      * @return
      */
     protected String lifecycleTrace(String lmethod, String cmethod) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         lifecycleTrace(lmethod, cmethod, component, sb);
         return sb.toString();
     }
 
-    protected void lifecycleTrace(String lmethod, String cmethod, UIComponent component, StringBuffer sb) {
+    protected void lifecycleTrace(String lmethod, String cmethod, UIComponent component, StringBuilder sb) {
 
         // Append the call for this lifecycle method
         String id = component.getId();
-        sb.append("/").append(lmethod).append("-").append(id);
+        sb.append('/').append(lmethod).append('-').append(id);
         if (!component.isRendered()) {
             return;
         }
@@ -752,9 +753,9 @@ public class UIComponentBaseTestCase extends UIComponentTestCase {
         Iterator<String> names = component.getFacets().keySet().iterator();
         while (names.hasNext()) {
             String name = names.next();
-            sb.append("/").append(lmethod).append("-").append(name);
+            sb.append('/').append(lmethod).append('-').append(name);
             if (cmethod != null && component.getFacets().get(name).isRendered()) {
-                sb.append("/").append(cmethod).append("-").append(name);
+                sb.append('/').append(cmethod).append('-').append(name);
             }
         }
 
@@ -767,7 +768,7 @@ public class UIComponentBaseTestCase extends UIComponentTestCase {
 
         // Append the call for this component's component method
         if (cmethod != null && component.isRendered()) {
-            sb.append("/").append(cmethod).append("-").append(id);
+            sb.append('/').append(cmethod).append('-').append(id);
         }
 
     }

--- a/impl/src/test/java/jakarta/faces/model/DataModelTestCaseBase.java
+++ b/impl/src/test/java/jakarta/faces/model/DataModelTestCaseBase.java
@@ -106,7 +106,7 @@ public abstract class DataModelTestCaseBase extends TestCase {
 
     // Test positioning to all rows in ascending order
     public void testPositionAscending() throws Exception {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         model.setRowIndex(-1);
         model.addDataModelListener(new ListenerTestImpl());
         ListenerTestImpl.trace(null);
@@ -114,14 +114,14 @@ public abstract class DataModelTestCaseBase extends TestCase {
         int n = model.getRowCount();
         for (int i = 0; i < n; i++) {
             checkRow(i);
-            sb.append("/").append(i);
+            sb.append('/').append(i);
         }
         assertEquals(sb.toString(), ListenerTestImpl.trace());
     }
 
     // Test positioning to all rows in descending order
     public void testPositionDescending() throws Exception {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         model.setRowIndex(-1);
         model.addDataModelListener(new ListenerTestImpl());
         ListenerTestImpl.trace(null);
@@ -129,7 +129,7 @@ public abstract class DataModelTestCaseBase extends TestCase {
         int n = model.getRowCount();
         for (int i = (n - 1); i >= 0; i--) {
             checkRow(i);
-            sb.append("/").append(i);
+            sb.append('/').append(i);
         }
         assertEquals(sb.toString(), ListenerTestImpl.trace());
     }

--- a/impl/src/test/java/jakarta/faces/model/ListenerTestImpl.java
+++ b/impl/src/test/java/jakarta/faces/model/ListenerTestImpl.java
@@ -27,7 +27,7 @@ public class ListenerTestImpl implements DataModelListener {
     public void rowSelected(DataModelEvent event) {
         Object rowData = event.getRowData();
         int rowIndex = event.getRowIndex();
-        trace("" + rowIndex);
+        trace(String.valueOf(rowIndex));
         if ((rowIndex >= 0) && (rowData == null)) {
             throw new IllegalArgumentException("rowIndex=" + rowIndex
                     + " but rowData is null");
@@ -51,7 +51,7 @@ public class ListenerTestImpl implements DataModelListener {
         if (value == null) {
             trace = new StringBuffer();
         } else {
-            trace.append("/");
+            trace.append('/');
             trace.append(value);
         }
     }


### PR DESCRIPTION
+ StringBuffer -> StringBuilder
+ fixed: `static trimRight(String s)` function inside `TextUnit` didn't trim anything

can I move this and other String util functions inside the Utils class?

for example inside the MessageFactory classes there is a function 
that should format a String with the passed parameters and it's copy/pasted
all over the place

also it returns `null` if the `locale` parameter is null... is it expected?
