### PR TITLE
maven JS compressor - transpiler level

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -244,7 +244,7 @@
                             </includes>
                             <outputFilename>#{path}/faces.js</outputFilename>
                             <skipMerge>true</skipMerge>
-                            <closureLanguageOut>ECMASCRIPT5_STRICT</closureLanguageOut>
+                            <closureLanguageOut>NO_TRANSPILE</closureLanguageOut>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
We don't need to transpile to ES5 anymore 
because Faces 4.1 will be released over 1 year after IE11 EOL.

[https://learn.microsoft.com/en-us/lifecycle/products/internet-explorer-11](https://learn.microsoft.com/en-us/lifecycle/products/internet-explorer-11)

> The Internet Explorer (IE) 11 desktop application ended support for Windows 10 semi-annual channel on June 15, 2022

This will reduce the size of the compressed file and unlock the potential of `const` and `let` optimization 