### PR TITLE
RowIndex/DataModel of UIData doesn't need to be reset when broadcasted row index is same as current row index; noticed same thing on UIRepeat as well so also improved over there

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/component/UIRepeat.java
+++ b/impl/src/main/java/com/sun/faces/facelets/component/UIRepeat.java
@@ -969,11 +969,12 @@ public class UIRepeat extends UINamingContainer {
             this.resetDataModel(ctx);
             int idx = idxEvent.getIndex();
             int prevIndex = this.index;
+            boolean needsToSetIndex = idx != -1 || prevIndex != -1; // #5213
             UIComponent source = target.getComponent();
             UIComponent compositeParent = null;
             try {
                 int rowCount = getDataModel().getRowCount();
-                if (idx != prevIndex) {
+                if (needsToSetIndex) {
                     this.setIndex(ctx, idx);
                 }
                 Integer begin = this.getBegin();
@@ -1007,7 +1008,7 @@ public class UIRepeat extends UINamingContainer {
                     compositeParent.popComponentFromEL(ctx);
                 }
                 this.updateIterationStatus(ctx, null);
-                if (idx != prevIndex) {
+                if (needsToSetIndex) {
                     this.setIndex(ctx, prevIndex);
                 }
             }

--- a/impl/src/main/java/com/sun/faces/facelets/component/UIRepeat.java
+++ b/impl/src/main/java/com/sun/faces/facelets/component/UIRepeat.java
@@ -967,13 +967,15 @@ public class UIRepeat extends UINamingContainer {
             FacesEvent target = idxEvent.getTarget();
             FacesContext ctx = target.getFacesContext();
             this.resetDataModel(ctx);
+            int idx = idxEvent.getIndex();
             int prevIndex = this.index;
             UIComponent source = target.getComponent();
             UIComponent compositeParent = null;
             try {
                 int rowCount = getDataModel().getRowCount();
-                int idx = idxEvent.getIndex();
-                this.setIndex(ctx, idx);
+                if (idx != prevIndex) {
+                    this.setIndex(ctx, idx);
+                }
                 Integer begin = this.getBegin();
                 Integer end = this.getEnd();
                 Integer step = this.getStep();
@@ -1005,7 +1007,9 @@ public class UIRepeat extends UINamingContainer {
                     compositeParent.popComponentFromEL(ctx);
                 }
                 this.updateIterationStatus(ctx, null);
-                this.setIndex(ctx, prevIndex);
+                if (idx != prevIndex) {
+                    this.setIndex(ctx, prevIndex);
+                }
             }
         } else {
             super.broadcast(event);

--- a/impl/src/main/java/javax/faces/component/UIData.java
+++ b/impl/src/main/java/javax/faces/component/UIData.java
@@ -1103,8 +1103,9 @@ public class UIData extends UIComponentBase
         }
         int currentRowIndex = getRowIndex();
         int broadcastedRowIndex = revent.getRowIndex();
+        boolean needsToSetIndex = currentRowIndex != -1 || broadcastedRowIndex != -1; // #5213
 
-        if (currentRowIndex != broadcastedRowIndex) {
+        if (needsToSetIndex) {
             setRowIndex(broadcastedRowIndex);
         }
 
@@ -1127,7 +1128,7 @@ public class UIData extends UIComponentBase
             }
         }
 
-        if (currentRowIndex != broadcastedRowIndex) {
+        if (needsToSetIndex) {
             setRowIndex(currentRowIndex);
         }
     }

--- a/impl/src/main/java/javax/faces/component/UIData.java
+++ b/impl/src/main/java/javax/faces/component/UIData.java
@@ -18,7 +18,6 @@ package javax.faces.component;
 
 import static com.sun.faces.util.Util.extractFirstNumericSegment;
 import static com.sun.faces.util.Util.isNestedInIterator;
-import static java.lang.Character.isDigit;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -1102,8 +1101,13 @@ public class UIData extends UIComponentBase
         if (isNestedWithinIterator(context)) {
             setDataModel(null);
         }
-        int oldRowIndex = getRowIndex();
-        setRowIndex(revent.getRowIndex());
+        int currentRowIndex = getRowIndex();
+        int broadcastedRowIndex = revent.getRowIndex();
+
+        if (currentRowIndex != broadcastedRowIndex) {
+            setRowIndex(broadcastedRowIndex);
+        }
+
         FacesEvent rowEvent = revent.getFacesEvent();
         UIComponent source = rowEvent.getComponent();
         UIComponent compositeParent = null;
@@ -1122,8 +1126,10 @@ public class UIData extends UIComponentBase
                 compositeParent.popComponentFromEL(context);
             }
         }
-        setRowIndex(oldRowIndex);
 
+        if (currentRowIndex != broadcastedRowIndex) {
+            setRowIndex(currentRowIndex);
+        }
     }
 
     /**


### PR DESCRIPTION
https://github.com/eclipse-ee4j/mojarra/issues/5213