### PR TITLE
Composite component can't find reparented child when it's in turn in another NamingContainer within the composite

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
@@ -462,10 +462,7 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
     protected UIComponent findReparentedComponent(FaceletContext ctx, UIComponent parent, String tagId) {
         UIComponent facet = parent.getFacets().get(UIComponent.COMPOSITE_FACET_NAME);
         if (facet != null) {
-            UIComponent newParent = facet.findComponent((String) parent.getAttributes().get(tagId));
-            if (newParent != null) {
-                return ComponentSupport.findChildByTagId(ctx.getFacesContext(), newParent, tagId);
-            }
+            return findChild(ctx, facet, tagId);
         }
         return null;
     }


### PR DESCRIPTION
https://github.com/eclipse-ee4j/mojarra/issues/5214

E.g.
```
<cc:implementation>
  <h:form> <!-- or h:dataTable -->
    <cc:insertChildren>
```
caused the composite to recreate all children for cc:insertChildren brand new during render response of postback instead of reusing the ones already created during restore view.