### PR TITLE
Faces 4.1: Spec 1739 - Require firing events for @Initialized, @BeforeDestroyed, and @Destroyed for build-in scopes

### DIFF
--- a/impl/src/main/java/jakarta/faces/flow/FlowScoped.java
+++ b/impl/src/main/java/jakarta/faces/flow/FlowScoped.java
@@ -41,6 +41,10 @@ import jakarta.enterprise.context.NormalScope;
  * is necessary to also replace the CDI extension that implements the specified behavior regarding
  * <code>FlowScoped</code> beans.
  * </p>
+ * 
+ * <p class="changed_added_4_1">
+ * Events with qualifiers  {@code @Initialized}, {@code @BeforeDestroyed}, and {@code @Destroyed} as defined by the CDI specification  must fire for this built-in scope. 
+ * </p>
  *
  * @since 2.2
  */

--- a/impl/src/main/java/jakarta/faces/view/ViewScoped.java
+++ b/impl/src/main/java/jakarta/faces/view/ViewScoped.java
@@ -92,6 +92,10 @@ import jakarta.enterprise.context.NormalScope;
  *
  *
  * </div>
+ * 
+ * <p class="changed_added_4_1">
+ * Events with qualifiers  {@code @Initialized}, {@code @BeforeDestroyed}, and {@code @Destroyed} as defined by the CDI specification  must fire for this built-in scope. 
+ * </p>
  *
  * @since 2.2
  */


### PR DESCRIPTION
https://github.com/jakartaee/faces/issues/1739

Both Mojarra and MyFaces should have this implemented. Now it's required via the faces spec.  

The tests should also be added back in the next TCK release for 4.1 / 5.0.  See  https://github.com/jakartaee/faces/pull/1741/files 