### PR TITLE
[2.3] Do not override application-specified "com.sun.faces.enableDistributable" value

### DIFF
--- a/impl/src/main/java/com/sun/faces/config/ConfigureListener.java
+++ b/impl/src/main/java/com/sun/faces/config/ConfigureListener.java
@@ -179,8 +179,11 @@ public class ConfigureListener implements ServletRequestListener, HttpSessionLis
             }
         }
         
-        if (webXmlProcessor.isDistributablePresent()) {
-            webConfig.setOptionEnabled(WebConfiguration.BooleanWebContextInitParameter.EnableDistributable, true);
+        // Do not override if already defined
+        if (!webConfig.isSet(WebConfiguration.BooleanWebContextInitParameter.EnableDistributable)) {
+            webConfig.setOptionEnabled(WebConfiguration.BooleanWebContextInitParameter.EnableDistributable, webXmlProcessor.isDistributablePresent());
+        }
+        if (webConfig.isOptionEnabled(WebConfiguration.BooleanWebContextInitParameter.EnableDistributable)) {
             context.setAttribute(WebConfiguration.BooleanWebContextInitParameter.EnableDistributable.getQualifiedName(), TRUE);
         }
 


### PR DESCRIPTION
Mojarra defines a number of initialization parameters. While "com.sun.faces.enableDistributable" is one of them, Mojarra automatically overrides any existing setting provided by the application.
If a web application wanted explicitly disable this for a distributable web application, it would normally add a servlet context parameter within web.xml.
e.g.

```
<web-app>
  <distributable/>
  <context-param>
    <param-name>com.sun.faces.enableDistributable</param-name>
    <param-value>false</param-value>
  </context-param>
</web-app>
```
However, the ConfigureListener auto-enables the com.sun.faces.enableDistributable configuration property whenever it see that the tag in web.xml, overriding any custom setting.
I would expect Mojarra to respect the setting defined by the application, and only provide a default value if no value was specified.