### PR TITLE
Make sure that ViewHandler#getViews() also returns programmatic facelets

### DIFF
--- a/impl/src/main/java/jakarta/faces/annotation/View.java
+++ b/impl/src/main/java/jakarta/faces/annotation/View.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.util.Nonbinding;
 import jakarta.faces.component.ActionSource2;
 import jakarta.inject.Qualifier;
 
@@ -61,6 +62,7 @@ public @interface View {
      *
      * @return the Faces View Id pattern
      */
+    @Nonbinding
     String value() default "";
 
     /**


### PR DESCRIPTION
https://github.com/eclipse-ee4j/mojarra/issues/5365

I only question the validity to add the missing `@Nonbinding` to the `@View` annotation value at this stage already, which was clearly an oversight. I checked spec and apidocs, this is *nowhere* explicitly mentioned for all other existing Faces annotations with a `@Nonbinding` field. So I felt it's kind of safe to fix it in Mojarra 4.0.6 already instead of in Faces 4.1 (which is not yet released!).

If you disagree, let me know then I'll adjust the approach to fetch all CDI beans and then manually filter them instead of fetching them by qualifier, though this might be less efficient. And in the meanwhile try to get that `@Nonbinding` into Faces 4.1 before it gets released.

cc: @tandraschko 