### PR TITLE
UIInput#getSubmittedValue() must also consider isLocalValueSet() when INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL=true

### DIFF
--- a/impl/src/main/java/jakarta/faces/component/UIInput.java
+++ b/impl/src/main/java/jakarta/faces/component/UIInput.java
@@ -252,7 +252,7 @@ public class UIInput extends UIOutput implements EditableValueHolder {
      */
     @Override
     public Object getSubmittedValue() {
-        if (submittedValue == null && !isValid() && considerEmptyStringNull(FacesContext.getCurrentInstance())) { // JAVASERVERFACES_SPEC_PUBLIC-671
+        if (submittedValue == null && !isValid() && !isLocalValueSet() && considerEmptyStringNull(FacesContext.getCurrentInstance())) { // JAVASERVERFACES_SPEC_PUBLIC-671
             return "";
         } else {
             return submittedValue;


### PR DESCRIPTION
https://github.com/eclipse-ee4j/mojarra/issues/5386