### PR TITLE
Revert "Remove deprecated bindings field"

### DIFF
--- a/impl/src/main/java/jakarta/faces/component/UIComponent.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to Eclipse Foundation.
+ * Copyright (c) 2022, 2024 Contributors to Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -2377,5 +2377,12 @@ public abstract class UIComponent implements PartialStateHolder, TransientStateH
 
         return resourceBundle != null ? result : null;
     }
+
+    // The set of ValueExpressions for this component, keyed by property
+    // name This collection is lazily instantiated
+    // The set of ValueExpressions for this component, keyed by property
+    // name This collection is lazily instantiated
+    @Deprecated
+    protected Map<String, ValueExpression> bindings = null;
 
 }

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to Eclipse Foundation.
+ * Copyright (c) 2022, 2024 Contributors to Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -1141,6 +1141,10 @@ public abstract class UIComponentBase extends UIComponent {
             Object savedBehaviors = saveBehaviorsState(context);
             Object savedBindings = null;
 
+            if (bindings != null) {
+                savedBindings = saveBindingsState(context);
+            }
+
             Object savedHelper = null;
             if (stateHelper != null) {
                 savedHelper = stateHelper.saveState(context);
@@ -1173,6 +1177,10 @@ public abstract class UIComponentBase extends UIComponent {
             values[0] = listeners != null ? listeners.saveState(context) : null;
             values[1] = saveSystemEventListeners(context);
             values[2] = saveBehaviorsState(context);
+
+            if (bindings != null) {
+                values[3] = saveBindingsState(context);
+            }
 
             if (stateHelper != null) {
                 values[4] = stateHelper.saveState(context);
@@ -1215,6 +1223,10 @@ public abstract class UIComponentBase extends UIComponent {
 
         if (values[2] != null) {
             behaviors = restoreBehaviorsState(context, values[2]);
+        }
+
+        if (values[3] != null) {
+            bindings = restoreBindingsState(context, values[3]);
         }
 
         if (values[4] != null) {
@@ -1431,6 +1443,26 @@ public abstract class UIComponentBase extends UIComponent {
             bindings.put(names[i], (ValueExpression) restoreAttachedState(context, states[i]));
         }
         return bindings;
+
+    }
+
+    private Object saveBindingsState(FacesContext context) {
+
+        if (bindings == null) {
+            return null;
+        }
+
+        Object values[] = new Object[2];
+        values[0] = bindings.keySet().toArray(new String[bindings.size()]);
+
+        Object[] bindingValues = bindings.values().toArray();
+        for (int i = 0; i < bindingValues.length; i++) {
+            bindingValues[i] = saveAttachedState(context, bindingValues[i]);
+        }
+
+        values[1] = bindingValues;
+
+        return values;
 
     }
 


### PR DESCRIPTION
This reverts commit d3aed2499c582c461676cece1a9f845fde77fe1b.

Spoke to Emily Jiang  and we cannot remove this field from 4.1 as it's a minor release.  If we do, it would need to be a 5.0 release and that's too much work at this point.


Linking to https://github.com/jakartaee/faces/issues/1725