### PR TITLE
Reduce logging level of exception which is already rethrown

### DIFF
--- a/impl/src/main/java/com/sun/faces/lifecycle/ApplyRequestValuesPhase.java
+++ b/impl/src/main/java/com/sun/faces/lifecycle/ApplyRequestValuesPhase.java
@@ -52,8 +52,8 @@ public class ApplyRequestValuesPhase extends Phase {
         } catch (RuntimeException re) {
             String exceptionMessage = re.getMessage();
             if (null != exceptionMessage) {
-                if (LOGGER.isLoggable(Level.WARNING)) {
-                    LOGGER.log(Level.WARNING, exceptionMessage, re);
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.log(Level.FINE, exceptionMessage, re);
                 }
             }
             throw new FacesException(exceptionMessage, re);

--- a/impl/src/main/java/com/sun/faces/lifecycle/InvokeApplicationPhase.java
+++ b/impl/src/main/java/com/sun/faces/lifecycle/InvokeApplicationPhase.java
@@ -57,8 +57,8 @@ public class InvokeApplicationPhase extends Phase {
         } catch (RuntimeException re) {
             String exceptionMessage = re.getMessage();
             if (null != exceptionMessage) {
-                if (LOGGER.isLoggable(Level.WARNING)) {
-                    LOGGER.log(Level.WARNING, exceptionMessage, re);
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.log(Level.FINE, exceptionMessage, re);
                 }
             }
             throw new FacesException(exceptionMessage, re);

--- a/impl/src/main/java/com/sun/faces/lifecycle/ProcessValidationsPhase.java
+++ b/impl/src/main/java/com/sun/faces/lifecycle/ProcessValidationsPhase.java
@@ -50,8 +50,8 @@ public class ProcessValidationsPhase extends Phase {
         } catch (RuntimeException re) {
             String exceptionMessage = re.getMessage();
             if (null != exceptionMessage) {
-                if (LOGGER.isLoggable(Level.WARNING)) {
-                    LOGGER.log(Level.WARNING, exceptionMessage, re);
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.log(Level.FINE, exceptionMessage, re);
                 }
             }
             throw new FacesException(exceptionMessage, re);

--- a/impl/src/main/java/com/sun/faces/lifecycle/UpdateModelValuesPhase.java
+++ b/impl/src/main/java/com/sun/faces/lifecycle/UpdateModelValuesPhase.java
@@ -51,8 +51,8 @@ public class UpdateModelValuesPhase extends Phase {
         } catch (RuntimeException re) {
             String exceptionMessage = re.getMessage();
             if (null != exceptionMessage) {
-                if (LOGGER.isLoggable(Level.WARNING)) {
-                    LOGGER.log(Level.WARNING, exceptionMessage, re);
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.log(Level.FINE, exceptionMessage, re);
                 }
             }
             throw new FacesException(exceptionMessage, re);


### PR DESCRIPTION
Reduce logging level of exception which is already rethrown during processing a lifecycle phase -- this only causes duplicate logs https://github.com/eclipse-ee4j/mojarra/issues/5404