### PR TITLE
Only http/2-push real faces resource urls

### DIFF
--- a/impl/src/main/java/com/sun/faces/context/ExternalContextImpl.java
+++ b/impl/src/main/java/com/sun/faces/context/ExternalContextImpl.java
@@ -42,16 +42,6 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.sun.faces.RIConstants;
-import com.sun.faces.config.WebConfiguration;
-import com.sun.faces.context.flash.ELFlash;
-import com.sun.faces.renderkit.html_basic.ScriptRenderer;
-import com.sun.faces.renderkit.html_basic.StylesheetRenderer;
-import com.sun.faces.util.FacesLogger;
-import com.sun.faces.util.MessageUtils;
-import com.sun.faces.util.TypedCollections;
-import com.sun.faces.util.Util;
-
 import jakarta.faces.FacesException;
 import jakarta.faces.FactoryFinder;
 import jakarta.faces.application.ProjectStage;
@@ -73,6 +63,16 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.servlet.http.PushBuilder;
+
+import com.sun.faces.RIConstants;
+import com.sun.faces.config.WebConfiguration;
+import com.sun.faces.context.flash.ELFlash;
+import com.sun.faces.renderkit.html_basic.ScriptRenderer;
+import com.sun.faces.renderkit.html_basic.StylesheetRenderer;
+import com.sun.faces.util.FacesLogger;
+import com.sun.faces.util.MessageUtils;
+import com.sun.faces.util.TypedCollections;
+import com.sun.faces.util.Util;
 
 /**
  * <p>
@@ -576,10 +576,10 @@ public class ExternalContextImpl extends ExternalContext {
             throw new NullPointerException(getExceptionMessageString(NULL_PARAMETERS_ERROR_MESSAGE_ID, "url"));
         }
 
-        String result = ((HttpServletResponse) response).encodeURL(url);
-        pushIfPossibleAndNecessary(result);
+        String encodedURL = ((HttpServletResponse) response).encodeURL(url);
+        pushIfPossibleAndNecessary(encodedURL);
 
-        return result;
+        return encodedURL;
     }
 
     /**
@@ -1032,26 +1032,25 @@ public class ExternalContextImpl extends ExternalContext {
         flash = null;
     }
 
-    private void pushIfPossibleAndNecessary(String result) {
+    @SuppressWarnings("unchecked")
+    private void pushIfPossibleAndNecessary(String encodedURL) {
         FacesContext context = FacesContext.getCurrentInstance();
 
-        // 1. Don't bother trying to push if we've already pushed this URL for this request
-        @SuppressWarnings("unchecked")
-        Set<String> resourceUrls = (Set<String>) context.getAttributes().computeIfAbsent(PUSH_RESOURCE_URLS_KEY_NAME,
-                k -> new HashSet<>());
-
-        if (resourceUrls.contains(result)) {
+        if (!context.getApplication().getResourceHandler().isResourceURL(encodedURL)) {
             return;
         }
-        resourceUrls.add(result);
 
-        // 2. At this point we know we haven't pushed this URL for this request before
-        PushBuilder pushBuilder = getPushBuilder(context);
-        if (pushBuilder != null) {
-            // and now we also know there was no If-Modified-Since header
-            pushBuilder.path(result).push();
+        Set<String> resourceUrls = (Set<String>) context.getAttributes().computeIfAbsent(PUSH_RESOURCE_URLS_KEY_NAME, k -> new HashSet<>());
+
+        if (!resourceUrls.add(encodedURL)) {
+            return;
         }
 
+        PushBuilder pushBuilder = getPushBuilder(context);
+
+        if (pushBuilder != null) {
+            pushBuilder.path(encodedURL).push();
+        }
     }
 
     private PushBuilder getPushBuilder(FacesContext context) {


### PR DESCRIPTION
Fix #5414 only http/2-push real faces resource urls coming from resource components/annotations and thus not just any url which happens to be passed through encodeResourceURL