### PR TITLE
Backport: Default encoding should be prechecked

### DIFF
--- a/impl/src/main/java/com/sun/faces/util/Util.java
+++ b/impl/src/main/java/com/sun/faces/util/Util.java
@@ -1677,7 +1677,9 @@ public class Util {
 
         if (encoding == null) {
             // 5. If still none found then fall back to specified default.
-            encoding = defaultEncoding.get();
+            if (defaultEncoding.isPresent()) {
+                encoding = defaultEncoding.get();
+            }
 
             if (encoding != null && !encoding.isBlank()) {
                 if (LOGGER.isLoggable(FINEST)) {


### PR DESCRIPTION
This backports https://github.com/eclipse-ee4j/mojarra/pull/5401 into the 4.0 branch. 

Resolves https://github.com/eclipse-ee4j/mojarra/issues/5429