### PR TITLE
show which viewId was not found in exception

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/ViewHandlingStrategyManager.java
+++ b/impl/src/main/java/com/sun/faces/application/view/ViewHandlingStrategyManager.java
@@ -54,7 +54,7 @@ public class ViewHandlingStrategyManager {
         return Arrays.stream(strategies)
                      .filter(strategy -> strategy.handlesViewId(viewId))
                      .findFirst()
-                     .orElseThrow(ViewHandlingStrategyNotFoundException::new);
+                     .orElseThrow(()-> new ViewHandlingStrategyNotFoundException(viewId));
     }
 
     /**

--- a/impl/src/main/java/com/sun/faces/application/view/ViewHandlingStrategyNotFoundException.java
+++ b/impl/src/main/java/com/sun/faces/application/view/ViewHandlingStrategyNotFoundException.java
@@ -20,7 +20,7 @@ import jakarta.faces.FacesException;
 
 /**
  * Indicates that no {@link com.sun.faces.application.view.ViewHandlingStrategy} instances were found appropriate to a
- * particulare view ID.
+ * particular view ID.
  */
 public class ViewHandlingStrategyNotFoundException extends FacesException {
 
@@ -31,9 +31,9 @@ public class ViewHandlingStrategyNotFoundException extends FacesException {
     /**
      * @see FacesException#FacesException()
      */
-    public ViewHandlingStrategyNotFoundException() {
+    public ViewHandlingStrategyNotFoundException(String viewId) {
 
-        super();
+        super("Strategy not found for viewId: " + viewId);
 
     }
 


### PR DESCRIPTION
when migrating to extensionless I had an issue in production where I was getting an exception

```
2024-04-01 14:04:46,373 SEVERE [jakarta.enterprise.resource.webcontainer.faces.application] (default task-347) Error Rendering View[/s/home.xhtml]: com.sun.faces.application.view.ViewHandlingStrategyNotFoundException
	at java.base/java.util.Optional.orElseThrow(Optional.java:403)
	at jakarta.faces.impl@4.0.5//com.sun.faces.application.view.ViewHandlingStrategyManager.getStrategy(ViewHandlingStrategyManager.java:57)
	at jakarta.faces.impl@4.0.5//com.sun.faces.application.view.ViewDeclarationLanguageFactoryImpl.getViewDeclarationLanguage(ViewDeclarationLanguageFactoryImpl.java:45)
	at jakarta.faces.impl@4.0.5//com.sun.faces.application.view.MultiViewHandler.getViewDeclarationLanguage(MultiViewHandler.java:408)
	at jakarta.faces.impl@4.0.5//com.sun.faces.application.view.MultiViewHandler.derivePhysicalViewId(MultiViewHandler.java:461)
	at jakarta.faces.impl@4.0.5//com.sun.faces.application.view.MultiViewHandler.deriveViewId(MultiViewHandler.java:423)
	at deployment.ROOT.war//org.ocpsoft.rewrite.faces.RewriteViewHandler.deriveViewId(RewriteViewHandler.java:155)
	at jakarta.faces.impl@4.0.5//jakarta.faces.application.ViewHandlerWrapper.deriveViewId(ViewHandlerWrapper.java:172)
	at jakarta.faces.impl@4.0.5//jakarta.faces.application.ViewHandlerWrapper.deriveViewId(ViewHandlerWrapper.java:172)
	at jakarta.faces.impl@4.0.5//com.sun.faces.application.NavigationHandlerImpl.findImplicitMatch(NavigationHandlerImpl.java:945)
```

This ended up being because I had an `h:link` with an outcome which had a trailing slash. 

```
<h:link outcome="/s/profile/two-step.xhtml/">Click here to get started</h:link>
```

This worked previously before enabling extensionless. This would have been much easier to track down if the viewId in question had been printed in the exception message.

This PR adds a useful message to the exception and fixes a doc typo in the same class

