### PR TITLE
Improve timing of firing PreRemoveFromViewEvent wrt children

### DIFF
--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -1830,9 +1830,8 @@ public abstract class UIComponentBase extends UIComponent {
 
     private static void disconnectFromView(FacesContext context, Application application, UIComponent component) {
 
-        application.publishEvent(context, PreRemoveFromViewEvent.class, component);
         component.setInView(false);
-        component.compositeParent = null;
+
         if (component.getChildCount() > 0) {
             List<UIComponent> children = component.getChildren();
             for (UIComponent c : children) {
@@ -1846,6 +1845,8 @@ public abstract class UIComponentBase extends UIComponent {
             }
         }
 
+        application.publishEvent(context, PreRemoveFromViewEvent.class, component);
+        component.compositeParent = null;
     }
 
     // --------------------------------------------------------- Private Classes


### PR DESCRIPTION
https://github.com/eclipse-ee4j/mojarra/issues/5445

Essentially, while removing children, they (naturally) don't expect the parent to already be removed at that point.

Wait with merging. I want to run entire TCK on this just to exclude this was done intentionally by the original developer.