### PR TITLE
Fix 5457: revert removal of getBeanClass on Faces artifact producers

### DIFF
--- a/impl/src/main/java/com/sun/faces/cdi/ApplicationMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ApplicationMapProducer.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.ApplicationMap;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -40,10 +41,13 @@ public class ApplicationMapProducer extends CdiProducer<Map<String, Object>> {
      */
     private static final long serialVersionUID = 1L;
 
-    public ApplicationMapProducer() {
-        super.name("applicationScope").scope(ApplicationScoped.class).qualifiers(ApplicationMap.Literal.INSTANCE)
-                .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
-                .create(e -> FacesContext.getCurrentInstance().getExternalContext().getApplicationMap());
+    public ApplicationMapProducer(BeanManager beanManager) {
+        super.name("applicationScope")
+    		.scope(ApplicationScoped.class)
+    		.qualifiers(ApplicationMap.Literal.INSTANCE)
+    		.beanClass(beanManager, Map.class)
+            .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
+            .create(e -> FacesContext.getCurrentInstance().getExternalContext().getApplicationMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/ApplicationMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ApplicationMapProducer.java
@@ -43,9 +43,9 @@ public class ApplicationMapProducer extends CdiProducer<Map<String, Object>> {
 
     public ApplicationMapProducer(BeanManager beanManager) {
         super.name("applicationScope")
-    		.scope(ApplicationScoped.class)
-    		.qualifiers(ApplicationMap.Literal.INSTANCE)
-    		.beanClass(beanManager, Map.class)
+            .scope(ApplicationScoped.class)
+            .qualifiers(ApplicationMap.Literal.INSTANCE)
+            .beanClass(beanManager, Map.class)
             .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
             .create(e -> FacesContext.getCurrentInstance().getExternalContext().getApplicationMap());
     }

--- a/impl/src/main/java/com/sun/faces/cdi/CdiExtension.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CdiExtension.java
@@ -180,27 +180,27 @@ public class CdiExtension implements Extension {
         // but this is not detectable as ServletContext is not necessarily available at this moment.
 
         afterBeanDiscovery.addBean(new ApplicationProducer());
-        afterBeanDiscovery.addBean(new ApplicationMapProducer());
-        afterBeanDiscovery.addBean(new CompositeComponentProducer());
-        afterBeanDiscovery.addBean(new ComponentProducer());
-        afterBeanDiscovery.addBean(new FlashProducer());
-        afterBeanDiscovery.addBean(new FlowMapProducer());
-        afterBeanDiscovery.addBean(new HeaderMapProducer());
-        afterBeanDiscovery.addBean(new HeaderValuesMapProducer());
-        afterBeanDiscovery.addBean(new InitParameterMapProducer());
-        afterBeanDiscovery.addBean(new RequestParameterMapProducer());
-        afterBeanDiscovery.addBean(new RequestParameterValuesMapProducer());
+        afterBeanDiscovery.addBean(new ApplicationMapProducer(beanManager));
+        afterBeanDiscovery.addBean(new CompositeComponentProducer(beanManager));
+        afterBeanDiscovery.addBean(new ComponentProducer(beanManager));
+        afterBeanDiscovery.addBean(new FlashProducer(beanManager));
+        afterBeanDiscovery.addBean(new FlowMapProducer(beanManager));
+        afterBeanDiscovery.addBean(new HeaderMapProducer(beanManager));
+        afterBeanDiscovery.addBean(new HeaderValuesMapProducer(beanManager));
+        afterBeanDiscovery.addBean(new InitParameterMapProducer(beanManager));
+        afterBeanDiscovery.addBean(new RequestParameterMapProducer(beanManager));
+        afterBeanDiscovery.addBean(new RequestParameterValuesMapProducer(beanManager));
         afterBeanDiscovery.addBean(new RequestProducer());
-        afterBeanDiscovery.addBean(new RequestMapProducer());
-        afterBeanDiscovery.addBean(new ResourceHandlerProducer());
-        afterBeanDiscovery.addBean(new ExternalContextProducer());
-        afterBeanDiscovery.addBean(new FacesContextProducer());
-        afterBeanDiscovery.addBean(new RequestCookieMapProducer());
+        afterBeanDiscovery.addBean(new RequestMapProducer(beanManager));
+        afterBeanDiscovery.addBean(new ResourceHandlerProducer(beanManager));
+        afterBeanDiscovery.addBean(new ExternalContextProducer(beanManager));
+        afterBeanDiscovery.addBean(new FacesContextProducer(beanManager));
+        afterBeanDiscovery.addBean(new RequestCookieMapProducer(beanManager));
         afterBeanDiscovery.addBean(new SessionProducer());
-        afterBeanDiscovery.addBean(new SessionMapProducer());
-        afterBeanDiscovery.addBean(new ViewMapProducer());
-        afterBeanDiscovery.addBean(new ViewProducer());
-        afterBeanDiscovery.addBean(new DataModelClassesMapProducer());
+        afterBeanDiscovery.addBean(new SessionMapProducer(beanManager));
+        afterBeanDiscovery.addBean(new ViewMapProducer(beanManager));
+        afterBeanDiscovery.addBean(new ViewProducer(beanManager));
+        afterBeanDiscovery.addBean(new DataModelClassesMapProducer(beanManager));
 
         for (Type type : managedPropertyTargetTypes) {
             afterBeanDiscovery.addBean(new ManagedPropertyProducer(type, beanManager));

--- a/impl/src/main/java/com/sun/faces/cdi/CdiProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CdiProducer.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.enterprise.inject.spi.PassivationCapable;
 import jakarta.faces.context.FacesContext;
@@ -49,8 +50,7 @@ abstract class CdiProducer<T> implements Bean<T>, PassivationCapable, Serializab
 
     private String id = this.getClass().getName();
     private String name;
-    // for synthetic beans, the beanClass defaults to the extension that registers them
-    private Class<?> beanClass = CdiExtension.class;
+    private Class<?> beanClass = Object.class;
     private Set<Type> types = singleton(Object.class);
     private Set<Annotation> qualifiers = unmodifiableSet(asSet(new DefaultAnnotationLiteral(), new AnyAnnotationLiteral()));
     private Class<? extends Annotation> scope = Dependent.class;
@@ -165,8 +165,19 @@ abstract class CdiProducer<T> implements Bean<T>, PassivationCapable, Serializab
         return this;
     }
 
+    protected CdiProducer<T> beanClass(BeanManager beanManager, Class<?> beanClass) {
+    	if (CdiUtils.isWeld(beanManager)) {
+    		this.beanClass = CdiExtension.class; // See #5457 and #5157
+    	} else {
+    		this.beanClass = beanClass;
+    	}
+
+    	return this;
+    }
+
     protected CdiProducer<T> types(Type... types) {
         this.types = asSet(types);
+        this.types.add(getClass()); // Add producer class as well so it can at least be filtered from BeanManager#getBeans().
         return this;
     }
 

--- a/impl/src/main/java/com/sun/faces/cdi/CdiProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CdiProducer.java
@@ -166,13 +166,13 @@ abstract class CdiProducer<T> implements Bean<T>, PassivationCapable, Serializab
     }
 
     protected CdiProducer<T> beanClass(BeanManager beanManager, Class<?> beanClass) {
-    	if (CdiUtils.isWeld(beanManager)) {
-    		this.beanClass = CdiExtension.class; // See #5457 and #5157
-    	} else {
-    		this.beanClass = beanClass;
-    	}
+        if (CdiUtils.isWeld(beanManager)) {
+            this.beanClass = CdiExtension.class; // See #5457 and #5157
+        } else {
+            this.beanClass = beanClass;
+        }
 
-    	return this;
+        return this;
     }
 
     protected CdiProducer<T> types(Type... types) {

--- a/impl/src/main/java/com/sun/faces/cdi/CdiUtils.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CdiUtils.java
@@ -421,4 +421,11 @@ public final class CdiUtils {
         }
     }
 
+    /**
+     * Returns true if Weld is used as CDI impl.
+     */
+    public static boolean isWeld(BeanManager beanManager) {
+        return beanManager.getClass().getPackageName().startsWith("org.jboss.weld.");
+    }
+
 }

--- a/impl/src/main/java/com/sun/faces/cdi/ComponentProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ComponentProducer.java
@@ -18,6 +18,7 @@ package com.sun.faces.cdi;
 
 import static jakarta.faces.component.UIComponent.getCurrentComponent;
 
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.context.FacesContext;
 
@@ -36,8 +37,11 @@ public class ComponentProducer extends CdiProducer<UIComponent> {
      */
     private static final long serialVersionUID = 1L;
 
-    public ComponentProducer() {
-        super.name("component").types(UIComponent.class).create(e -> getCurrentComponent(FacesContext.getCurrentInstance()));
+    public ComponentProducer(BeanManager beanManager) {
+        super.name("component")
+        	.beanClass(beanManager, UIComponent.class)
+        	.types(UIComponent.class)
+        	.create(e -> getCurrentComponent(FacesContext.getCurrentInstance()));
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/ComponentProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ComponentProducer.java
@@ -39,9 +39,9 @@ public class ComponentProducer extends CdiProducer<UIComponent> {
 
     public ComponentProducer(BeanManager beanManager) {
         super.name("component")
-        	.beanClass(beanManager, UIComponent.class)
-        	.types(UIComponent.class)
-        	.create(e -> getCurrentComponent(FacesContext.getCurrentInstance()));
+            .beanClass(beanManager, UIComponent.class)
+            .types(UIComponent.class)
+            .create(e -> getCurrentComponent(FacesContext.getCurrentInstance()));
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/CompositeComponentProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CompositeComponentProducer.java
@@ -40,9 +40,9 @@ public class CompositeComponentProducer extends CdiProducer<Object> {
 
     public CompositeComponentProducer(BeanManager beanManager) {
         super.name("cc")
-        	.beanClass(beanManager, UIComponent.class)
-        	.types(UIComponent.class)
-        	.create(e -> {
+            .beanClass(beanManager, UIComponent.class)
+            .types(UIComponent.class)
+            .create(e -> {
 
             FacesContext context = getCurrentInstance();
 

--- a/impl/src/main/java/com/sun/faces/cdi/CompositeComponentProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CompositeComponentProducer.java
@@ -20,6 +20,7 @@ import static com.sun.faces.component.CompositeComponentStackManager.getManager;
 import static jakarta.faces.component.UIComponent.getCurrentCompositeComponent;
 import static jakarta.faces.context.FacesContext.getCurrentInstance;
 
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.context.FacesContext;
 
@@ -37,8 +38,11 @@ public class CompositeComponentProducer extends CdiProducer<Object> {
      */
     private static final long serialVersionUID = 1L;
 
-    public CompositeComponentProducer() {
-        super.name("cc").types(UIComponent.class).create(e -> {
+    public CompositeComponentProducer(BeanManager beanManager) {
+        super.name("cc")
+        	.beanClass(beanManager, UIComponent.class)
+        	.types(UIComponent.class)
+        	.create(e -> {
 
             FacesContext context = getCurrentInstance();
 

--- a/impl/src/main/java/com/sun/faces/cdi/DataModelClassesMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/DataModelClassesMapProducer.java
@@ -19,6 +19,7 @@ package com.sun.faces.cdi;
 import java.util.Map;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.faces.model.DataModel;
 
@@ -43,9 +44,13 @@ public class DataModelClassesMapProducer extends CdiProducer<Map<Class<?>, Class
      */
     private static final long serialVersionUID = 1L;
 
-    public DataModelClassesMapProducer() {
-        super.name("comSunFacesDataModelClassesMap").scope(ApplicationScoped.class).qualifiers(new DataModelClassesAnnotationLiteral())
-                .types(Map.class, Object.class).create(e -> CDI.current().select(CdiExtension.class).get().getForClassToDataModelClass());
+    public DataModelClassesMapProducer(BeanManager beanManager) {
+		super.name("comSunFacesDataModelClassesMap")
+			.scope(ApplicationScoped.class)
+			.qualifiers(new DataModelClassesAnnotationLiteral())
+			.beanClass(beanManager, Map.class)
+			.types(Map.class, Object.class)
+			.create(e -> CDI.current().select(CdiExtension.class).get().getForClassToDataModelClass());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/DataModelClassesMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/DataModelClassesMapProducer.java
@@ -45,12 +45,12 @@ public class DataModelClassesMapProducer extends CdiProducer<Map<Class<?>, Class
     private static final long serialVersionUID = 1L;
 
     public DataModelClassesMapProducer(BeanManager beanManager) {
-		super.name("comSunFacesDataModelClassesMap")
-			.scope(ApplicationScoped.class)
-			.qualifiers(new DataModelClassesAnnotationLiteral())
-			.beanClass(beanManager, Map.class)
-			.types(Map.class, Object.class)
-			.create(e -> CDI.current().select(CdiExtension.class).get().getForClassToDataModelClass());
+        super.name("comSunFacesDataModelClassesMap")
+            .scope(ApplicationScoped.class)
+            .qualifiers(new DataModelClassesAnnotationLiteral())
+            .beanClass(beanManager, Map.class)
+            .types(Map.class, Object.class)
+            .create(e -> CDI.current().select(CdiExtension.class).get().getForClassToDataModelClass());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/ExternalContextProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ExternalContextProducer.java
@@ -17,6 +17,7 @@
 package com.sun.faces.cdi;
 
 import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
 
@@ -36,9 +37,12 @@ public class ExternalContextProducer extends CdiProducer<ExternalContext> {
      */
     private static final long serialVersionUID = 1L;
 
-    public ExternalContextProducer() {
-        super.name("externalContext").scope(RequestScoped.class).types(ExternalContext.class)
-                .create(e -> FacesContext.getCurrentInstance().getExternalContext());
+    public ExternalContextProducer(BeanManager beanManager) {
+        super.name("externalContext")
+        	.scope(RequestScoped.class)
+        	.beanClass(beanManager, ExternalContext.class)
+        	.types(ExternalContext.class)
+            .create(e -> FacesContext.getCurrentInstance().getExternalContext());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/ExternalContextProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ExternalContextProducer.java
@@ -39,9 +39,9 @@ public class ExternalContextProducer extends CdiProducer<ExternalContext> {
 
     public ExternalContextProducer(BeanManager beanManager) {
         super.name("externalContext")
-        	.scope(RequestScoped.class)
-        	.beanClass(beanManager, ExternalContext.class)
-        	.types(ExternalContext.class)
+            .scope(RequestScoped.class)
+            .beanClass(beanManager, ExternalContext.class)
+            .types(ExternalContext.class)
             .create(e -> FacesContext.getCurrentInstance().getExternalContext());
     }
 

--- a/impl/src/main/java/com/sun/faces/cdi/FacesContextProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/FacesContextProducer.java
@@ -17,6 +17,7 @@
 package com.sun.faces.cdi;
 
 import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.context.FacesContext;
 
 /**
@@ -35,9 +36,12 @@ public class FacesContextProducer extends CdiProducer<FacesContext> {
      */
     private static final long serialVersionUID = 1L;
 
-    public FacesContextProducer() {
-        super.name("facesContext").scope(RequestScoped.class).types(FacesContext.class)
-                .create(e -> FacesContext.getCurrentInstance());
+    public FacesContextProducer(BeanManager beanManager) {
+        super.name("facesContext")
+        	.scope(RequestScoped.class)
+        	.beanClass(beanManager, FacesContext.class)
+        	.types(FacesContext.class)
+            .create(e -> FacesContext.getCurrentInstance());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/FacesContextProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/FacesContextProducer.java
@@ -38,9 +38,9 @@ public class FacesContextProducer extends CdiProducer<FacesContext> {
 
     public FacesContextProducer(BeanManager beanManager) {
         super.name("facesContext")
-        	.scope(RequestScoped.class)
-        	.beanClass(beanManager, FacesContext.class)
-        	.types(FacesContext.class)
+            .scope(RequestScoped.class)
+            .beanClass(beanManager, FacesContext.class)
+            .types(FacesContext.class)
             .create(e -> FacesContext.getCurrentInstance());
     }
 

--- a/impl/src/main/java/com/sun/faces/cdi/FlashProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/FlashProducer.java
@@ -43,7 +43,7 @@ public class FlashProducer extends CdiProducer<Object> {
 
     public FlashProducer(BeanManager beanManager) {
         super.name("flash")
-        	.beanClass(beanManager, Flash.class)
+            .beanClass(beanManager, Flash.class)
             .types(Flash.class, new ParameterizedTypeImpl(Map.class, new Type[] { Dummy.class, Dummy.class }), Object.class)
             .scope(RequestScoped.class)
             .create(e -> FacesContext.getCurrentInstance().getExternalContext().getFlash());

--- a/impl/src/main/java/com/sun/faces/cdi/FlashProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/FlashProducer.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.Flash;
 
@@ -40,10 +41,12 @@ public class FlashProducer extends CdiProducer<Object> {
     private static class Dummy {
     }
 
-    public FlashProducer() {
+    public FlashProducer(BeanManager beanManager) {
         super.name("flash")
-                .types(Flash.class, new ParameterizedTypeImpl(Map.class, new Type[] { Dummy.class, Dummy.class }), Object.class).scope(RequestScoped.class)
-                .create(e -> FacesContext.getCurrentInstance().getExternalContext().getFlash());
+        	.beanClass(beanManager, Flash.class)
+            .types(Flash.class, new ParameterizedTypeImpl(Map.class, new Type[] { Dummy.class, Dummy.class }), Object.class)
+            .scope(RequestScoped.class)
+            .create(e -> FacesContext.getCurrentInstance().getExternalContext().getFlash());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/FlowMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/FlowMapProducer.java
@@ -44,9 +44,9 @@ public class FlowMapProducer extends CdiProducer<Map<Object, Object>> {
 
     public FlowMapProducer(BeanManager beanManager) {
         super.name("flowScope")
-        	.scope(FlowScoped.class)
-        	.qualifiers(FlowMap.Literal.INSTANCE)
-        	.beanClass(beanManager, Map.class)
+            .scope(FlowScoped.class)
+            .qualifiers(FlowMap.Literal.INSTANCE)
+            .beanClass(beanManager, Map.class)
             .types(new ParameterizedTypeImpl(Map.class, new Type[] { Object.class, Object.class }), Map.class, Object.class)
             .create(e -> FacesContext.getCurrentInstance().getApplication().getFlowHandler().getCurrentFlowScope());
     }

--- a/impl/src/main/java/com/sun/faces/cdi/FlowMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/FlowMapProducer.java
@@ -19,6 +19,7 @@ package com.sun.faces.cdi;
 import java.lang.reflect.Type;
 import java.util.Map;
 
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.FlowMap;
 import jakarta.faces.application.Application;
 import jakarta.faces.context.FacesContext;
@@ -41,10 +42,13 @@ public class FlowMapProducer extends CdiProducer<Map<Object, Object>> {
      */
     private static final long serialVersionUID = 1L;
 
-    public FlowMapProducer() {
-        super.name("flowScope").scope(FlowScoped.class).qualifiers(FlowMap.Literal.INSTANCE)
-                .types(new ParameterizedTypeImpl(Map.class, new Type[] { Object.class, Object.class }), Map.class, Object.class)
-                .create(e -> FacesContext.getCurrentInstance().getApplication().getFlowHandler().getCurrentFlowScope());
+    public FlowMapProducer(BeanManager beanManager) {
+        super.name("flowScope")
+        	.scope(FlowScoped.class)
+        	.qualifiers(FlowMap.Literal.INSTANCE)
+        	.beanClass(beanManager, Map.class)
+            .types(new ParameterizedTypeImpl(Map.class, new Type[] { Object.class, Object.class }), Map.class, Object.class)
+            .create(e -> FacesContext.getCurrentInstance().getApplication().getFlowHandler().getCurrentFlowScope());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/HeaderMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/HeaderMapProducer.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.HeaderMap;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -39,10 +40,13 @@ public class HeaderMapProducer extends CdiProducer<Map<String, String>> {
      */
     private static final long serialVersionUID = 1L;
 
-    public HeaderMapProducer() {
-        super.name("header").scope(RequestScoped.class).qualifiers(HeaderMap.Literal.INSTANCE)
-                .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String.class }), Map.class, Object.class)
-                .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestHeaderMap());
+    public HeaderMapProducer(BeanManager beanManager) {
+        super.name("header")
+        	.scope(RequestScoped.class)
+        	.qualifiers(HeaderMap.Literal.INSTANCE)
+        	.beanClass(beanManager, Map.class)
+            .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String.class }), Map.class, Object.class)
+            .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestHeaderMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/HeaderMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/HeaderMapProducer.java
@@ -42,9 +42,9 @@ public class HeaderMapProducer extends CdiProducer<Map<String, String>> {
 
     public HeaderMapProducer(BeanManager beanManager) {
         super.name("header")
-        	.scope(RequestScoped.class)
-        	.qualifiers(HeaderMap.Literal.INSTANCE)
-        	.beanClass(beanManager, Map.class)
+            .scope(RequestScoped.class)
+            .qualifiers(HeaderMap.Literal.INSTANCE)
+            .beanClass(beanManager, Map.class)
             .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String.class }), Map.class, Object.class)
             .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestHeaderMap());
     }

--- a/impl/src/main/java/com/sun/faces/cdi/HeaderValuesMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/HeaderValuesMapProducer.java
@@ -42,11 +42,11 @@ public class HeaderValuesMapProducer extends CdiProducer<Map<String, String[]>> 
 
     public HeaderValuesMapProducer(BeanManager beanManager) {
         super.name("headerValues")
-			.scope(RequestScoped.class)
-			.qualifiers(HeaderValuesMap.Literal.INSTANCE)
-			.beanClass(beanManager, Map.class)
+            .scope(RequestScoped.class)
+            .qualifiers(HeaderValuesMap.Literal.INSTANCE)
+            .beanClass(beanManager, Map.class)
             .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String[].class }), Map.class, Object.class)
-			.create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestHeaderValuesMap());
+            .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestHeaderValuesMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/HeaderValuesMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/HeaderValuesMapProducer.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.HeaderValuesMap;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -39,10 +40,13 @@ public class HeaderValuesMapProducer extends CdiProducer<Map<String, String[]>> 
      */
     private static final long serialVersionUID = 1L;
 
-    public HeaderValuesMapProducer() {
-        super.name("headerValues").scope(RequestScoped.class).qualifiers(HeaderValuesMap.Literal.INSTANCE)
-                .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String[].class }), Map.class, Object.class)
-                .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestHeaderValuesMap());
+    public HeaderValuesMapProducer(BeanManager beanManager) {
+        super.name("headerValues")
+			.scope(RequestScoped.class)
+			.qualifiers(HeaderValuesMap.Literal.INSTANCE)
+			.beanClass(beanManager, Map.class)
+            .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String[].class }), Map.class, Object.class)
+			.create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestHeaderValuesMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/InitParameterMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/InitParameterMapProducer.java
@@ -42,11 +42,11 @@ public class InitParameterMapProducer extends CdiProducer<Map<String, String>> {
 
     public InitParameterMapProducer(BeanManager beanManager) {
         super.name("initParam")
-	        .scope(RequestScoped.class)
-	        .qualifiers(InitParameterMap.Literal.INSTANCE)
-	        .beanClass(beanManager, Map.class)
-	        .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String.class }), Map.class, Object.class)
-	        .create(e -> FacesContext.getCurrentInstance().getExternalContext().getInitParameterMap());
+            .scope(RequestScoped.class)
+            .qualifiers(InitParameterMap.Literal.INSTANCE)
+            .beanClass(beanManager, Map.class)
+            .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String.class }), Map.class, Object.class)
+            .create(e -> FacesContext.getCurrentInstance().getExternalContext().getInitParameterMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/InitParameterMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/InitParameterMapProducer.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.InitParameterMap;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -39,10 +40,13 @@ public class InitParameterMapProducer extends CdiProducer<Map<String, String>> {
      */
     private static final long serialVersionUID = 1L;
 
-    public InitParameterMapProducer() {
-        super.name("initParam").scope(RequestScoped.class).qualifiers(InitParameterMap.Literal.INSTANCE)
-                .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String.class }), Map.class, Object.class)
-                .create(e -> FacesContext.getCurrentInstance().getExternalContext().getInitParameterMap());
+    public InitParameterMapProducer(BeanManager beanManager) {
+        super.name("initParam")
+	        .scope(RequestScoped.class)
+	        .qualifiers(InitParameterMap.Literal.INSTANCE)
+	        .beanClass(beanManager, Map.class)
+	        .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String.class }), Map.class, Object.class)
+	        .create(e -> FacesContext.getCurrentInstance().getExternalContext().getInitParameterMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/ManagedPropertyProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ManagedPropertyProducer.java
@@ -44,7 +44,11 @@ public class ManagedPropertyProducer extends CdiProducer<Object> {
     private Class<?> expectedClass;
 
     public ManagedPropertyProducer(Type type, BeanManager beanManager) {
-        super.types(type).qualifiers(ManagedProperty.Literal.INSTANCE).addToId(type).create(creationalContext -> {
+        super.qualifiers(ManagedProperty.Literal.INSTANCE)
+	        .beanClass(beanManager, ManagedPropertyProducer.class)
+	    	.types(type)
+	    	.addToId(type)
+        	.create(creationalContext -> {
 
             // TODO: handle no InjectionPoint available
             String expression = getCurrentInjectionPoint(beanManager, creationalContext).getAnnotated().getAnnotation(ManagedProperty.class).value();

--- a/impl/src/main/java/com/sun/faces/cdi/ManagedPropertyProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ManagedPropertyProducer.java
@@ -45,10 +45,10 @@ public class ManagedPropertyProducer extends CdiProducer<Object> {
 
     public ManagedPropertyProducer(Type type, BeanManager beanManager) {
         super.qualifiers(ManagedProperty.Literal.INSTANCE)
-	        .beanClass(beanManager, ManagedPropertyProducer.class)
-	    	.types(type)
-	    	.addToId(type)
-        	.create(creationalContext -> {
+            .beanClass(beanManager, ManagedPropertyProducer.class)
+            .types(type)
+            .addToId(type)
+            .create(creationalContext -> {
 
             // TODO: handle no InjectionPoint available
             String expression = getCurrentInjectionPoint(beanManager, creationalContext).getAnnotated().getAnnotation(ManagedProperty.class).value();

--- a/impl/src/main/java/com/sun/faces/cdi/RequestCookieMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/RequestCookieMapProducer.java
@@ -43,10 +43,10 @@ public class RequestCookieMapProducer extends CdiProducer<Map<String, Object>> {
 
     public RequestCookieMapProducer(BeanManager beanManager) {
         super.name("cookie")
-        	.scope(RequestScoped.class)
-        	.qualifiers(RequestCookieMap.Literal.INSTANCE)
-        	.beanClass(beanManager, Map.class)
-        	.types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
+            .scope(RequestScoped.class)
+            .qualifiers(RequestCookieMap.Literal.INSTANCE)
+            .beanClass(beanManager, Map.class)
+            .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
             .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestCookieMap());
     }
 

--- a/impl/src/main/java/com/sun/faces/cdi/RequestCookieMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/RequestCookieMapProducer.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.RequestCookieMap;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -40,10 +41,13 @@ public class RequestCookieMapProducer extends CdiProducer<Map<String, Object>> {
      */
     private static final long serialVersionUID = 1L;
 
-    public RequestCookieMapProducer() {
-        super.name("cookie").scope(RequestScoped.class).qualifiers(RequestCookieMap.Literal.INSTANCE)
-                .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
-                .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestCookieMap());
+    public RequestCookieMapProducer(BeanManager beanManager) {
+        super.name("cookie")
+        	.scope(RequestScoped.class)
+        	.qualifiers(RequestCookieMap.Literal.INSTANCE)
+        	.beanClass(beanManager, Map.class)
+        	.types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
+            .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestCookieMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/RequestMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/RequestMapProducer.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.RequestMap;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -39,10 +40,13 @@ public class RequestMapProducer extends CdiProducer<Map<String, Object>> {
      */
     private static final long serialVersionUID = 1L;
 
-    public RequestMapProducer() {
-        super.name("requestScope").scope(RequestScoped.class).qualifiers(RequestMap.Literal.INSTANCE)
-                .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
-                .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestMap());
+    public RequestMapProducer(BeanManager beanManager) {
+        super.name("requestScope")
+        	.scope(RequestScoped.class)
+        	.qualifiers(RequestMap.Literal.INSTANCE)
+        	.beanClass(beanManager, Map.class)
+            .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
+            .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/RequestMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/RequestMapProducer.java
@@ -42,9 +42,9 @@ public class RequestMapProducer extends CdiProducer<Map<String, Object>> {
 
     public RequestMapProducer(BeanManager beanManager) {
         super.name("requestScope")
-        	.scope(RequestScoped.class)
-        	.qualifiers(RequestMap.Literal.INSTANCE)
-        	.beanClass(beanManager, Map.class)
+            .scope(RequestScoped.class)
+            .qualifiers(RequestMap.Literal.INSTANCE)
+            .beanClass(beanManager, Map.class)
             .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
             .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestMap());
     }

--- a/impl/src/main/java/com/sun/faces/cdi/RequestParameterMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/RequestParameterMapProducer.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.RequestParameterMap;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -40,10 +41,13 @@ public class RequestParameterMapProducer extends CdiProducer<Map<String, String>
      */
     private static final long serialVersionUID = 1L;
 
-    public RequestParameterMapProducer() {
-        super.name("param").scope(RequestScoped.class).qualifiers(RequestParameterMap.Literal.INSTANCE)
-                .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String.class }), Map.class, Object.class)
-                .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap());
+    public RequestParameterMapProducer(BeanManager beanManager) {
+        super.name("param")
+        	.scope(RequestScoped.class)
+        	.qualifiers(RequestParameterMap.Literal.INSTANCE)
+        	.beanClass(beanManager, Map.class)
+            .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String.class }), Map.class, Object.class)
+            .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/RequestParameterMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/RequestParameterMapProducer.java
@@ -43,9 +43,9 @@ public class RequestParameterMapProducer extends CdiProducer<Map<String, String>
 
     public RequestParameterMapProducer(BeanManager beanManager) {
         super.name("param")
-        	.scope(RequestScoped.class)
-        	.qualifiers(RequestParameterMap.Literal.INSTANCE)
-        	.beanClass(beanManager, Map.class)
+            .scope(RequestScoped.class)
+            .qualifiers(RequestParameterMap.Literal.INSTANCE)
+            .beanClass(beanManager, Map.class)
             .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String.class }), Map.class, Object.class)
             .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap());
     }

--- a/impl/src/main/java/com/sun/faces/cdi/RequestParameterValuesMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/RequestParameterValuesMapProducer.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.RequestParameterValuesMap;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -40,10 +41,13 @@ public class RequestParameterValuesMapProducer extends CdiProducer<Map<String, S
      */
     private static final long serialVersionUID = 1L;
 
-    public RequestParameterValuesMapProducer() {
-        super.name("paramValues").scope(RequestScoped.class).qualifiers(RequestParameterValuesMap.Literal.INSTANCE)
-                .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String[].class }), Map.class, Object.class)
-                .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestParameterValuesMap());
+    public RequestParameterValuesMapProducer(BeanManager beanManager) {
+        super.name("paramValues")
+        	.scope(RequestScoped.class)
+        	.qualifiers(RequestParameterValuesMap.Literal.INSTANCE)
+        	.beanClass(beanManager, Map.class)
+        	.types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String[].class }), Map.class, Object.class)
+            .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestParameterValuesMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/RequestParameterValuesMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/RequestParameterValuesMapProducer.java
@@ -43,10 +43,10 @@ public class RequestParameterValuesMapProducer extends CdiProducer<Map<String, S
 
     public RequestParameterValuesMapProducer(BeanManager beanManager) {
         super.name("paramValues")
-        	.scope(RequestScoped.class)
-        	.qualifiers(RequestParameterValuesMap.Literal.INSTANCE)
-        	.beanClass(beanManager, Map.class)
-        	.types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String[].class }), Map.class, Object.class)
+            .scope(RequestScoped.class)
+            .qualifiers(RequestParameterValuesMap.Literal.INSTANCE)
+            .beanClass(beanManager, Map.class)
+            .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, String[].class }), Map.class, Object.class)
             .create(e -> FacesContext.getCurrentInstance().getExternalContext().getRequestParameterValuesMap());
     }
 

--- a/impl/src/main/java/com/sun/faces/cdi/ResourceHandlerProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ResourceHandlerProducer.java
@@ -16,7 +16,10 @@
 
 package com.sun.faces.cdi;
 
+import java.util.Map;
+
 import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.application.Application;
 import jakarta.faces.application.ResourceHandler;
 import jakarta.faces.context.FacesContext;
@@ -38,9 +41,12 @@ public class ResourceHandlerProducer extends CdiProducer<ResourceHandler> {
      */
     private static final long serialVersionUID = 1L;
 
-    public ResourceHandlerProducer() {
-        super.name("resource").scope(RequestScoped.class).types(ResourceHandler.class)
-                .create(e -> FacesContext.getCurrentInstance().getApplication().getResourceHandler());
+    public ResourceHandlerProducer(BeanManager beanManager) {
+        super.name("resource")
+        	.scope(RequestScoped.class)
+        	.beanClass(beanManager, ResourceHandler.class)
+        	.types(ResourceHandler.class)
+    		.create(e -> FacesContext.getCurrentInstance().getApplication().getResourceHandler());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/ResourceHandlerProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ResourceHandlerProducer.java
@@ -43,10 +43,10 @@ public class ResourceHandlerProducer extends CdiProducer<ResourceHandler> {
 
     public ResourceHandlerProducer(BeanManager beanManager) {
         super.name("resource")
-        	.scope(RequestScoped.class)
-        	.beanClass(beanManager, ResourceHandler.class)
-        	.types(ResourceHandler.class)
-    		.create(e -> FacesContext.getCurrentInstance().getApplication().getResourceHandler());
+            .scope(RequestScoped.class)
+            .beanClass(beanManager, ResourceHandler.class)
+            .types(ResourceHandler.class)
+            .create(e -> FacesContext.getCurrentInstance().getApplication().getResourceHandler());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/SessionMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/SessionMapProducer.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.SessionMap;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -39,10 +40,13 @@ public class SessionMapProducer extends CdiProducer<Map<String, Object>> {
      */
     private static final long serialVersionUID = 1L;
 
-    public SessionMapProducer() {
-        super.name("sessionScope").scope(RequestScoped.class).qualifiers(SessionMap.Literal.INSTANCE)
-                .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
-                .create(e -> FacesContext.getCurrentInstance().getExternalContext().getSessionMap());
+    public SessionMapProducer(BeanManager beanManager) {
+        super.name("sessionScope")
+        	.scope(RequestScoped.class)
+        	.qualifiers(SessionMap.Literal.INSTANCE)
+        	.beanClass(beanManager, Map.class)
+            .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
+            .create(e -> FacesContext.getCurrentInstance().getExternalContext().getSessionMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/SessionMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/SessionMapProducer.java
@@ -42,9 +42,9 @@ public class SessionMapProducer extends CdiProducer<Map<String, Object>> {
 
     public SessionMapProducer(BeanManager beanManager) {
         super.name("sessionScope")
-        	.scope(RequestScoped.class)
-        	.qualifiers(SessionMap.Literal.INSTANCE)
-        	.beanClass(beanManager, Map.class)
+            .scope(RequestScoped.class)
+            .qualifiers(SessionMap.Literal.INSTANCE)
+            .beanClass(beanManager, Map.class)
             .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
             .create(e -> FacesContext.getCurrentInstance().getExternalContext().getSessionMap());
     }

--- a/impl/src/main/java/com/sun/faces/cdi/ViewMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ViewMapProducer.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.ViewMap;
 import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.context.FacesContext;
@@ -40,10 +41,13 @@ public class ViewMapProducer extends CdiProducer<Map<String, Object>> {
      */
     private static final long serialVersionUID = 1L;
 
-    public ViewMapProducer() {
-        super.name("viewScope").scope(RequestScoped.class).qualifiers(ViewMap.Literal.INSTANCE)
-                .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
-                .create(e -> FacesContext.getCurrentInstance().getViewRoot().getViewMap());
+    public ViewMapProducer(BeanManager beanManager) {
+        super.name("viewScope")
+        	.scope(RequestScoped.class)
+        	.qualifiers(ViewMap.Literal.INSTANCE)
+        	.beanClass(beanManager, Map.class)
+            .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
+            .create(e -> FacesContext.getCurrentInstance().getViewRoot().getViewMap());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/ViewMapProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ViewMapProducer.java
@@ -43,9 +43,9 @@ public class ViewMapProducer extends CdiProducer<Map<String, Object>> {
 
     public ViewMapProducer(BeanManager beanManager) {
         super.name("viewScope")
-        	.scope(RequestScoped.class)
-        	.qualifiers(ViewMap.Literal.INSTANCE)
-        	.beanClass(beanManager, Map.class)
+            .scope(RequestScoped.class)
+            .qualifiers(ViewMap.Literal.INSTANCE)
+            .beanClass(beanManager, Map.class)
             .types(new ParameterizedTypeImpl(Map.class, new Type[] { String.class, Object.class }), Map.class, Object.class)
             .create(e -> FacesContext.getCurrentInstance().getViewRoot().getViewMap());
     }

--- a/impl/src/main/java/com/sun/faces/cdi/ViewProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ViewProducer.java
@@ -17,6 +17,7 @@
 package com.sun.faces.cdi;
 
 import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.context.FacesContext;
 
@@ -35,9 +36,12 @@ public class ViewProducer extends CdiProducer<UIViewRoot> {
      */
     private static final long serialVersionUID = 1L;
 
-    public ViewProducer() {
-        super.name("view").scope(RequestScoped.class).types(UIViewRoot.class)
-                .create(e -> FacesContext.getCurrentInstance().getViewRoot());
+    public ViewProducer(BeanManager beanManager) {
+        super.name("view")
+        	.scope(RequestScoped.class)
+        	.beanClass(beanManager, UIViewRoot.class)
+        	.types(UIViewRoot.class)
+            .create(e -> FacesContext.getCurrentInstance().getViewRoot());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/cdi/ViewProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/ViewProducer.java
@@ -38,9 +38,9 @@ public class ViewProducer extends CdiProducer<UIViewRoot> {
 
     public ViewProducer(BeanManager beanManager) {
         super.name("view")
-        	.scope(RequestScoped.class)
-        	.beanClass(beanManager, UIViewRoot.class)
-        	.types(UIViewRoot.class)
+            .scope(RequestScoped.class)
+            .beanClass(beanManager, UIViewRoot.class)
+            .types(UIViewRoot.class)
             .create(e -> FacesContext.getCurrentInstance().getViewRoot());
     }
 

--- a/impl/src/main/java/com/sun/faces/context/FacesContextImpl.java
+++ b/impl/src/main/java/com/sun/faces/context/FacesContextImpl.java
@@ -31,6 +31,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.sun.faces.cdi.CdiExtension;
+import com.sun.faces.cdi.FacesContextProducer;
 import com.sun.faces.el.ELContextImpl;
 import com.sun.faces.renderkit.RenderKitUtils;
 import com.sun.faces.util.FacesLogger;
@@ -560,7 +561,7 @@ public class FacesContextImpl extends FacesContext {
         DEFAULT_FACES_CONTEXT.remove();
 
         // Destroy our instance produced by FacesContextProducer.
-        Set<Bean<?>> beans = beanManager.getBeans(FacesContext.class).stream().filter(bean -> CdiExtension.class.isAssignableFrom(bean.getBeanClass())).collect(toSet());
+        Set<Bean<?>> beans = beanManager.getBeans(FacesContext.class).stream().filter(bean -> bean.getTypes().contains(FacesContextProducer.class)).collect(toSet());
         Bean<?> bean = beanManager.resolve(beans);
         ((AlterableContext) beanManager.getContext(bean.getScope())).destroy(bean);
     }


### PR DESCRIPTION
Fix #5457: revert removal of getBeanClass on Faces artifact producers; adjust it to check if Weld is used and if so return CdiExtension.class