### PR TITLE
Move global EL resolvers from static variables to application variables

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/ApplicationAssociate.java
+++ b/impl/src/main/java/com/sun/faces/application/ApplicationAssociate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to Eclipse Foundation.
+ * Copyright (c) 2021, 2024 Contributors to Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -79,8 +79,8 @@ import com.sun.faces.facelets.util.DevTools;
 import com.sun.faces.facelets.util.FunctionLibrary;
 import com.sun.faces.spi.InjectionProvider;
 import com.sun.faces.util.FacesLogger;
-
 import jakarta.el.CompositeELResolver;
+
 import jakarta.el.ELResolver;
 import jakarta.el.ExpressionFactory;
 import jakarta.faces.FacesException;
@@ -175,7 +175,6 @@ public class ApplicationAssociate {
     private Map<String, List<String>> resourceLibraryContracts;
 
     Map<String, ApplicationResourceBundle> resourceBundles = new HashMap<>();
-
 
     public static void setCurrentInstance(ApplicationAssociate associate) {
         if (associate == null) {
@@ -468,6 +467,10 @@ public class ApplicationAssociate {
         return injectionProvider;
     }
 
+    public ResolversRegistry getGlobalResolversRegistry() {
+        return applicationImpl.getGlobalResolversRegistry();
+    }
+
     public void setContextName(String contextName) {
         this.contextName = contextName;
     }
@@ -562,6 +565,14 @@ public class ApplicationAssociate {
         }
 
         return bundle.getResourceBundle(locale);
+    }
+
+    /**
+     * Returns a container with EL resolvers global to this application associate
+     * @return global EL resolvers for the current application
+     */
+    public ResolversRegistry getApplicationResolvers() {
+        return applicationImpl.getGlobalResolversRegistry();
     }
 
     /**

--- a/impl/src/main/java/com/sun/faces/application/ApplicationImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/ApplicationImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -81,6 +82,7 @@ public class ApplicationImpl extends Application {
     private final InstanceFactory instanceFactory;
     private final SearchExpression searchExpression;
     private final Stage stage;
+    private final ResolversRegistry globalResolversRegistry = new ResolversRegistry();
 
     /**
      * Constructor
@@ -210,6 +212,10 @@ public class ApplicationImpl extends Application {
 
     public CompositeELResolver getApplicationELResolvers() {
         return expressionLanguage.getApplicationELResolvers();
+    }
+
+    public ResolversRegistry getGlobalResolversRegistry() {
+        return globalResolversRegistry;
     }
 
     public FacesCompositeELResolver getCompositeELResolver() {

--- a/impl/src/main/java/com/sun/faces/application/ResolversRegistry.java
+++ b/impl/src/main/java/com/sun/faces/application/ResolversRegistry.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.faces.application;
+
+import com.sun.faces.context.flash.FlashELResolver;
+import com.sun.faces.el.CompositeComponentAttributesELResolver;
+import com.sun.faces.el.EmptyStringToNullELResolver;
+import com.sun.faces.el.FacesResourceBundleELResolver;
+import com.sun.faces.el.ResourceELResolver;
+import com.sun.faces.el.ScopedAttributeELResolver;
+import jakarta.el.ArrayELResolver;
+import jakarta.el.BeanELResolver;
+import jakarta.el.ListELResolver;
+import jakarta.el.MapELResolver;
+import jakarta.el.ResourceBundleELResolver;
+
+public class ResolversRegistry {
+    public final BeanELResolver BEAN_RESOLVER = new BeanELResolver();
+    public final ArrayELResolver ARRAY_RESOLVER = new ArrayELResolver();
+    public final FacesResourceBundleELResolver FACES_BUNDLE_RESOLVER = new FacesResourceBundleELResolver();
+    public final FlashELResolver FLASH_RESOLVER = new FlashELResolver();
+    public final ListELResolver LIST_RESOLVER = new ListELResolver();
+    public final MapELResolver MAP_RESOLVER = new MapELResolver();
+    public final ResourceBundleELResolver BUNDLE_RESOLVER = new ResourceBundleELResolver();
+    public final ScopedAttributeELResolver SCOPED_RESOLVER = new ScopedAttributeELResolver();
+    public final ResourceELResolver RESOURCE_RESOLVER = new ResourceELResolver();
+    public final CompositeComponentAttributesELResolver COMPOSITE_COMPONENT_ATTRIBUTES_EL_RESOLVER = new CompositeComponentAttributesELResolver();
+    public final EmptyStringToNullELResolver EMPTY_STRING_TO_NULL_RESOLVER = new EmptyStringToNullELResolver();
+
+}

--- a/impl/src/main/java/com/sun/faces/el/ELUtils.java
+++ b/impl/src/main/java/com/sun/faces/el/ELUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to Eclipse Foundation.
+ * Copyright (c) 2023, 2024 Contributors to Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -26,19 +26,14 @@ import static com.sun.faces.util.Util.getCdiBeanManager;
 import static java.lang.Boolean.FALSE;
 
 import com.sun.faces.application.ApplicationAssociate;
+import com.sun.faces.application.ResolversRegistry;
 import com.sun.faces.config.WebConfiguration;
-import com.sun.faces.context.flash.FlashELResolver;
 import com.sun.faces.util.Cache;
 import com.sun.faces.util.LRUCache;
-import jakarta.el.ArrayELResolver;
-import jakarta.el.BeanELResolver;
 import jakarta.el.CompositeELResolver;
 import jakarta.el.ELContext;
 import jakarta.el.ELResolver;
 import jakarta.el.ExpressionFactory;
-import jakarta.el.ListELResolver;
-import jakarta.el.MapELResolver;
-import jakarta.el.ResourceBundleELResolver;
 import jakarta.el.ValueExpression;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -106,18 +101,6 @@ public class ELUtils {
      */
     private static final Pattern METHOD_EXPRESSION_LOOKUP = Pattern.compile(".[{]cc[.]attrs[.]\\w+[}]");
 
-    public static final ArrayELResolver ARRAY_RESOLVER = new ArrayELResolver();
-    public static final BeanELResolver BEAN_RESOLVER = new BeanELResolver();
-    public static final FacesResourceBundleELResolver FACES_BUNDLE_RESOLVER = new FacesResourceBundleELResolver();
-    public static final FlashELResolver FLASH_RESOLVER = new FlashELResolver();
-    public static final ListELResolver LIST_RESOLVER = new ListELResolver();
-    public static final MapELResolver MAP_RESOLVER = new MapELResolver();
-    public static final ResourceBundleELResolver BUNDLE_RESOLVER = new ResourceBundleELResolver();
-    public static final ScopedAttributeELResolver SCOPED_RESOLVER = new ScopedAttributeELResolver();
-    public static final ResourceELResolver RESOURCE_RESOLVER = new ResourceELResolver();
-    public static final CompositeComponentAttributesELResolver COMPOSITE_COMPONENT_ATTRIBUTES_EL_RESOLVER = new CompositeComponentAttributesELResolver();
-    public static final EmptyStringToNullELResolver EMPTY_STRING_TO_NULL_RESOLVER = new EmptyStringToNullELResolver();
-
     // ------------------------------------------------------------ Constructors
 
     private ELUtils() {
@@ -153,24 +136,25 @@ public class ELUtils {
     public static void buildFacesResolver(FacesCompositeELResolver composite, ApplicationAssociate associate) {
         checkNotNull(composite, associate);
         addCDIELResolver(composite);
-        composite.add(FLASH_RESOLVER);
-        composite.addPropertyELResolver(COMPOSITE_COMPONENT_ATTRIBUTES_EL_RESOLVER);
+        ResolversRegistry elRegistry = associate.getGlobalResolversRegistry();
+        composite.add(elRegistry.FLASH_RESOLVER);
+        composite.addPropertyELResolver(elRegistry.COMPOSITE_COMPONENT_ATTRIBUTES_EL_RESOLVER);
         addELResolvers(composite, associate.getELResolversFromFacesConfig());
         composite.add(associate.getApplicationELResolvers());
 
         if (WebConfiguration.getInstance().isOptionEnabled(InterpretEmptyStringSubmittedValuesAsNull)) {
-            composite.addPropertyELResolver(EMPTY_STRING_TO_NULL_RESOLVER);
+            composite.addPropertyELResolver(elRegistry.EMPTY_STRING_TO_NULL_RESOLVER);
         }
 
-        composite.addPropertyELResolver(RESOURCE_RESOLVER);
-        composite.addPropertyELResolver(BUNDLE_RESOLVER);
-        composite.addRootELResolver(FACES_BUNDLE_RESOLVER);
+        composite.addPropertyELResolver(elRegistry.RESOURCE_RESOLVER);
+        composite.addPropertyELResolver(elRegistry.BUNDLE_RESOLVER);
+        composite.addRootELResolver(elRegistry.FACES_BUNDLE_RESOLVER);
         addEL3_0_Resolvers(composite, associate);
-        composite.addPropertyELResolver(MAP_RESOLVER);
-        composite.addPropertyELResolver(LIST_RESOLVER);
-        composite.addPropertyELResolver(ARRAY_RESOLVER);
-        composite.addPropertyELResolver(BEAN_RESOLVER);
-        composite.addRootELResolver(SCOPED_RESOLVER);
+        composite.addPropertyELResolver(elRegistry.MAP_RESOLVER);
+        composite.addPropertyELResolver(elRegistry.LIST_RESOLVER);
+        composite.addPropertyELResolver(elRegistry.ARRAY_RESOLVER);
+        composite.addPropertyELResolver(elRegistry.BEAN_RESOLVER);
+        composite.addRootELResolver(elRegistry.SCOPED_RESOLVER);
     }
 
     private static void checkNotNull(FacesCompositeELResolver composite, ApplicationAssociate associate) {


### PR DESCRIPTION
Fixes #5461

This avoids sharing resolvers between multiple applications on the classpath and also avoids memory leaks in application servers after an application and its classloaders are undeploed.

Resolvers are tied to the Faces Application instance.