### PR TITLE
Add minimal configuration for integration tests

### DIFF
--- a/impl/src/main/java/com/sun/faces/util/HtmlUtils.java
+++ b/impl/src/main/java/com/sun/faces/util/HtmlUtils.java
@@ -128,6 +128,10 @@ public class HtmlUtils {
                 // UNICODE entities: encode as needed
                 nextIndex = _writeDecRef(out, buff, buffIndex, buffLength, ch);
             } else {
+                if (forXml && !isAllowedXmlCharacter(ch)) {
+                    return buffIndex;
+                }
+
                 nextIndex = addToBuffer(out, buff, buffIndex, buffLength, ch);
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <module>impl</module>
         <module>action</module>
         <module>rest</module>
+        <module>test</module>
     </modules>
 
    <properties>

--- a/test/base/pom.xml
+++ b/test/base/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.mojarra.test</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.0.8-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>base</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Mojarra ${project.version} - INTEGRATION TESTS - ${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
+            <version>1.9.1.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <version>3.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>4.23.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>5.9.2</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/test/base/pom.xml
+++ b/test/base/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.8-SNAPSHOT</version>
+        <version>4.0.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>base</artifactId>

--- a/test/base/src/main/java/org/eclipse/mojarra/test/base/BaseIT.java
+++ b/test/base/src/main/java/org/eclipse/mojarra/test/base/BaseIT.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package org.eclipse.mojarra.test.base;
+
+import static java.lang.System.getProperty;
+import static java.time.Duration.ofSeconds;
+import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+
+import java.io.File;
+import java.net.URL;
+import java.util.UUID;
+import java.util.function.BooleanSupplier;
+import java.util.logging.Level;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+
+@ExtendWith(ArquillianExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+public abstract class BaseIT {
+
+    private WebDriver browser;
+
+    @ArquillianResource
+    private URL baseURL;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        String warFileName = getProperty("war.file.name") + ".war";
+        return create(ZipImporter.class, warFileName)
+                .importFrom(new File("target/" + warFileName))
+                .as(WebArchive.class);
+    }
+
+    @BeforeAll
+    public void setup() {
+        String arquillianBrowser = System.getProperty("arquillian.browser");
+
+        switch (arquillianBrowser) {
+            case "chrome":
+                WebDriverManager.chromedriver().setup();
+                ChromeDriver chrome = new ChromeDriver(new ChromeOptions().addArguments("--no-sandbox", "--headless"));
+                chrome.setLogLevel(Level.INFO);
+                browser = chrome;
+                break;
+            default:
+                throw new UnsupportedOperationException("arquillian.browser='" + arquillianBrowser + "' is not yet supported");
+        }
+
+        PageFactory.initElements(browser, this);
+    }
+
+    @AfterAll
+    public void teardown() {
+        browser.quit();
+    }
+
+    protected void open(String resource) {
+        browser.get(baseURL + resource);
+    }
+
+    protected String getPageSource() {
+        return browser.getPageSource();
+    }
+
+    protected void guardAjax(Runnable action) {
+        String uuid = UUID.randomUUID().toString();
+        executeScript("window.$ajax = true; faces.ajax.addOnEvent(data => { if (data.status == 'complete') window.$ajax = '" + uuid + "'; })");
+        action.run();
+        waitUntil(() -> executeScript("return window.$ajax == '" + uuid + "' || (!window.$ajax && document.readyState == 'complete');"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T executeScript(String script) {
+        return (T) ((JavascriptExecutor) browser).executeScript(script);
+    }
+
+    private void waitUntil(BooleanSupplier predicate) {
+        new WebDriverWait(browser, ofSeconds(5)).until($ -> predicate.getAsBoolean());
+    }
+}

--- a/test/issue5460/pom.xml
+++ b/test/issue5460/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.8-SNAPSHOT</version>
+        <version>4.0.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5460</artifactId>

--- a/test/issue5460/pom.xml
+++ b/test/issue5460/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.mojarra.test</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.0.8-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>issue5460</artifactId>
+    <packaging>war</packaging>
+
+    <name>Mojarra ${project.version} - INTEGRATION TESTS - ${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.mojarra.test</groupId>
+            <artifactId>base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/test/issue5460/src/main/java/org/eclipse/mojarra/test/issue5460/Issue5460Bean.java
+++ b/test/issue5460/src/main/java/org/eclipse/mojarra/test/issue5460/Issue5460Bean.java
@@ -1,0 +1,64 @@
+package org.eclipse.mojarra.test.issue5460;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class Issue5460Bean {
+
+    private String cc1;
+    private String cc2;
+    private String cc3;
+    private String cc4;
+    private String cc5;
+    private String cc6;
+
+    public String getCc1() {
+        return cc1;
+    }
+
+    public void setCc1(String cc1) {
+        this.cc1 = cc1;
+    }
+
+    public String getCc2() {
+        return cc2;
+    }
+
+    public void setCc2(String cc2) {
+        this.cc2 = cc2;
+    }
+
+    public String getCc3() {
+        return cc3;
+    }
+
+    public void setCc3(String cc3) {
+        this.cc3 = cc3;
+    }
+
+    public String getCc4() {
+        return cc4;
+    }
+
+    public void setCc4(String cc4) {
+        this.cc4 = cc4;
+    }
+
+    public String getCc5() {
+        return cc5;
+    }
+
+    public void setCc5(String cc5) {
+        this.cc5 = cc5;
+    }
+
+    public String getCc6() {
+        return cc6;
+    }
+
+    public void setCc6(String cc6) {
+        this.cc6 = cc6;
+    }
+}

--- a/test/issue5460/src/main/java/org/eclipse/mojarra/test/issue5460/Issue5460Bean.java
+++ b/test/issue5460/src/main/java/org/eclipse/mojarra/test/issue5460/Issue5460Bean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
 package org.eclipse.mojarra.test.issue5460;
 
 import jakarta.enterprise.context.RequestScoped;

--- a/test/issue5460/src/main/java/org/eclipse/mojarra/test/issue5460/Issue5460Component.java
+++ b/test/issue5460/src/main/java/org/eclipse/mojarra/test/issue5460/Issue5460Component.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
 package org.eclipse.mojarra.test.issue5460;
 
 import jakarta.faces.component.FacesComponent;

--- a/test/issue5460/src/main/java/org/eclipse/mojarra/test/issue5460/Issue5460Component.java
+++ b/test/issue5460/src/main/java/org/eclipse/mojarra/test/issue5460/Issue5460Component.java
@@ -1,0 +1,27 @@
+package org.eclipse.mojarra.test.issue5460;
+
+import jakarta.faces.component.FacesComponent;
+import jakarta.faces.component.NamingContainer;
+import jakarta.faces.component.UIInput;
+import jakarta.faces.component.UINamingContainer;
+import jakarta.faces.context.FacesContext;
+
+@FacesComponent("issue5460Component")
+public class Issue5460Component extends UIInput implements NamingContainer {
+
+    @Override
+    public String getFamily() {
+        return UINamingContainer.COMPONENT_FAMILY;
+    }
+
+    @Override
+    public void decode(FacesContext context) {
+        Object value = getValue();
+        setSubmittedValue(value == null ? "" : value);
+        super.decode(context);
+    }
+
+    public String getAttributeResults() {
+        return getAttributes().get("required") + " " + getAttributes().get("styleClass");
+    }
+}

--- a/test/issue5460/src/main/webapp/WEB-INF/web.xml
+++ b/test/issue5460/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+    version="5.0"
+>
+    <servlet>
+        <servlet-name>facesServlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>facesServlet</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/test/issue5460/src/main/webapp/WEB-INF/web.xml
+++ b/test/issue5460/src/main/webapp/WEB-INF/web.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
 <web-app
     xmlns="https://jakarta.ee/xml/ns/jakartaee" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/test/issue5460/src/main/webapp/issue5460.xhtml
+++ b/test/issue5460/src/main/webapp/issue5460.xhtml
@@ -1,4 +1,21 @@
 <!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
 <html lang="en"
     xmlns:h="jakarta.faces.html"
     xmlns:f="jakarta.faces.core"

--- a/test/issue5460/src/main/webapp/issue5460.xhtml
+++ b/test/issue5460/src/main/webapp/issue5460.xhtml
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en"
+    xmlns:h="jakarta.faces.html"
+    xmlns:f="jakarta.faces.core"
+    xmlns:ui="jakarta.faces.facelets"
+    xmlns:my="jakarta.faces.composite/components"
+>
+    <h:head>
+        <title>issue5460</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <div>
+                <my:component id="cc1" value="#{issue5460Bean.cc1}" />
+            </div>
+            <div>
+                <my:component id="cc2" value="#{issue5460Bean.cc2}" styleClass="randomClass" />
+            </div>
+            <div>
+                <my:component id="cc3" value="#{issue5460Bean.cc3}" required="true" />
+            </div>
+            <div>
+                <my:component id="cc4" value="#{issue5460Bean.cc4}" required="true" styleClass="randomClass" />
+            </div>
+            <div>
+                <my:component id="cc5" value="#{issue5460Bean.cc5}" required="#{true}" />
+            </div>
+            <div>
+                <my:component id="cc6" value="#{issue5460Bean.cc6}" required="#{true}" styleClass="randomClass" />
+            </div>
+            <div>
+                <h:commandButton id="submit" value="submit">
+                    <f:ajax execute="@form" render="@form" />
+                </h:commandButton>
+            </div>
+        </h:form>
+    </h:body>
+</html>

--- a/test/issue5460/src/main/webapp/resources/components/component.xhtml
+++ b/test/issue5460/src/main/webapp/resources/components/component.xhtml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
 <ui:component
     xmlns:h="jakarta.faces.html"
     xmlns:f="jakarta.faces.core"

--- a/test/issue5460/src/main/webapp/resources/components/component.xhtml
+++ b/test/issue5460/src/main/webapp/resources/components/component.xhtml
@@ -1,0 +1,25 @@
+<ui:component
+    xmlns:h="jakarta.faces.html"
+    xmlns:f="jakarta.faces.core"
+    xmlns:ui="jakarta.faces.facelets"
+    xmlns:cc="jakarta.faces.composite"
+    xmlns:c="jakarta.tags.core"
+>
+    <cc:interface componentType="issue5460Component">
+        <cc:attribute name="value" required="true" />
+        <cc:attribute name="label" required="false" type="java.lang.String" />
+        <cc:attribute name="required" type="java.lang.Boolean" required="false" default="false" />
+        <cc:attribute name="styleClass" type="java.lang.String" required="false" default="defaultClass" />
+    </cc:interface>
+    <cc:implementation>
+        <c:set var="errorClass" value="#{cc.valid ? '' : 'ui-state-error'}"/>
+        <div id="#{cc.clientId}" class="#{cc.attrs.styleClass}">
+            <h:outputLabel id="label" for="input" value="#{cc.attrs.label}" styleClass="#{errorClass}" />
+            <h:inputText id="input" value="#{cc.attrs.value}" label="#{cc.attrs.label}" styleClass="#{errorClass}" />
+            <h:outputText id="required" value="#{cc.required}" />
+            <h:outputText id="valid" value="#{cc.valid}" />
+            <h:outputText id="attributeResults" value="#{cc.attributeResults}" />
+            <h:message id="message" for="#{cc.id}" />
+        </div>
+    </cc:implementation>
+</ui:component>

--- a/test/issue5460/src/test/java/org/eclipse/mojarra/test/issue5460/Issue5460IT.java
+++ b/test/issue5460/src/test/java/org/eclipse/mojarra/test/issue5460/Issue5460IT.java
@@ -1,0 +1,140 @@
+package org.eclipse.mojarra.test.issue5460;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.mojarra.test.base.BaseIT;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+class Issue5460IT extends BaseIT {
+
+    @FindBy(id = "form:cc1:required")
+    private WebElement cc1required;
+
+    @FindBy(id = "form:cc1:valid")
+    private WebElement cc1valid;
+
+    @FindBy(id = "form:cc1:message")
+    private WebElement cc1message;
+
+    @FindBy(id = "form:cc1:attributeResults")
+    private WebElement cc1attributeResults;
+
+    @FindBy(id = "form:cc2:required")
+    private WebElement cc2required;
+
+    @FindBy(id = "form:cc2:valid")
+    private WebElement cc2valid;
+
+    @FindBy(id = "form:cc2:message")
+    private WebElement cc2message;
+
+    @FindBy(id = "form:cc2:attributeResults")
+    private WebElement cc2attributeResults;
+
+    @FindBy(id = "form:cc3:required")
+    private WebElement cc3required;
+
+    @FindBy(id = "form:cc3:valid")
+    private WebElement cc3valid;
+
+    @FindBy(id = "form:cc3:message")
+    private WebElement cc3message;
+
+    @FindBy(id = "form:cc3:attributeResults")
+    private WebElement cc3attributeResults;
+
+    @FindBy(id = "form:cc4:required")
+    private WebElement cc4required;
+
+    @FindBy(id = "form:cc4:valid")
+    private WebElement cc4valid;
+
+    @FindBy(id = "form:cc4:message")
+    private WebElement cc4message;
+
+    @FindBy(id = "form:cc4:attributeResults")
+    private WebElement cc4attributeResults;
+
+    @FindBy(id = "form:cc5:required")
+    private WebElement cc5required;
+
+    @FindBy(id = "form:cc5:valid")
+    private WebElement cc5valid;
+
+    @FindBy(id = "form:cc5:message")
+    private WebElement cc5message;
+
+    @FindBy(id = "form:cc5:attributeResults")
+    private WebElement cc5attributeResults;
+
+    @FindBy(id = "form:cc6:required")
+    private WebElement cc6required;
+
+    @FindBy(id = "form:cc6:valid")
+    private WebElement cc6valid;
+
+    @FindBy(id = "form:cc6:message")
+    private WebElement cc6message;
+
+    @FindBy(id = "form:cc6:attributeResults")
+    private WebElement cc6attributeResults;
+
+    @FindBy(id = "form:submit")
+    private WebElement submit;
+
+    /**
+     * https://github.com/eclipse-ee4j/mojarra/issues/5460
+     * https://github.com/eclipse-ee4j/mojarra/issues/5417
+     */
+    @Test
+    void test() {
+        open("issue5460.xhtml");
+
+        assertAll(
+            () -> assertEquals("false", cc1required.getText()), () -> assertEquals("true", cc1valid.getText()),
+            () -> assertEquals("false defaultClass", cc1attributeResults.getText()),
+            () -> assertEquals("", cc1message.getText()), () -> assertEquals("false", cc2required.getText()),
+            () -> assertEquals("true", cc2valid.getText()),
+            () -> assertEquals("false randomClass", cc2attributeResults.getText()),
+            () -> assertEquals("", cc2message.getText()), () -> assertEquals("true", cc3required.getText()),
+            () -> assertEquals("true", cc3valid.getText()),
+            () -> assertEquals("true defaultClass", cc3attributeResults.getText()),
+            () -> assertEquals("", cc3message.getText()), () -> assertEquals("true", cc4required.getText()),
+            () -> assertEquals("true", cc4valid.getText()),
+            () -> assertEquals("true randomClass", cc4attributeResults.getText()),
+            () -> assertEquals("", cc4message.getText()), () -> assertEquals("true", cc5required.getText()),
+            () -> assertEquals("true", cc5valid.getText()),
+            () -> assertEquals("true defaultClass", cc5attributeResults.getText()),
+            () -> assertEquals("", cc5message.getText()), () -> assertEquals("true", cc6required.getText()),
+            () -> assertEquals("true", cc6valid.getText()),
+            () -> assertEquals("true randomClass", cc6attributeResults.getText()),
+            () -> assertEquals("", cc6message.getText())
+        );
+
+        guardAjax(submit::click);
+
+        assertAll(
+            () -> assertEquals("false", cc1required.getText()), () -> assertEquals("true", cc1valid.getText()),
+            () -> assertEquals("false defaultClass", cc1attributeResults.getText()),
+            () -> assertEquals("", cc1message.getText()), () -> assertEquals("false", cc2required.getText()),
+            () -> assertEquals("true", cc2valid.getText()),
+            () -> assertEquals("false randomClass", cc2attributeResults.getText()),
+            () -> assertEquals("", cc2message.getText()), () -> assertEquals("true", cc3required.getText()),
+            () -> assertEquals("false", cc3valid.getText()),
+            () -> assertEquals("true defaultClass", cc3attributeResults.getText()),
+            () -> assertEquals("form:cc3: Validation Error: Value is required.", cc3message.getText()),
+            () -> assertEquals("true", cc4required.getText()), () -> assertEquals("false", cc4valid.getText()),
+            () -> assertEquals("true randomClass", cc4attributeResults.getText()),
+            () -> assertEquals("form:cc4: Validation Error: Value is required.", cc4message.getText()),
+            () -> assertEquals("true", cc5required.getText()), () -> assertEquals("false", cc5valid.getText()),
+            () -> assertEquals("true defaultClass", cc5attributeResults.getText()),
+            () -> assertEquals("form:cc5: Validation Error: Value is required.", cc5message.getText()),
+            () -> assertEquals("true", cc6required.getText()), () -> assertEquals("false", cc6valid.getText()),
+            () -> assertEquals("true randomClass", cc6attributeResults.getText()),
+            () -> assertEquals("form:cc6: Validation Error: Value is required.", cc6message.getText())
+        );
+    }
+}

--- a/test/issue5460/src/test/java/org/eclipse/mojarra/test/issue5460/Issue5460IT.java
+++ b/test/issue5460/src/test/java/org/eclipse/mojarra/test/issue5460/Issue5460IT.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
 package org.eclipse.mojarra.test.issue5460;
 
 import static org.junit.jupiter.api.Assertions.assertAll;

--- a/test/issue5464/pom.xml
+++ b/test/issue5464/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.mojarra.test</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.0.8-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>issue5464</artifactId>
+    <packaging>war</packaging>
+
+    <name>Mojarra ${project.version} - INTEGRATION TESTS - ${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.mojarra.test</groupId>
+            <artifactId>base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/test/issue5464/pom.xml
+++ b/test/issue5464/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.0.8-SNAPSHOT</version>
+        <version>4.0.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5464</artifactId>

--- a/test/issue5464/src/main/java/org/eclipse/mojarra/test/issue5464/Issue5464Bean.java
+++ b/test/issue5464/src/main/java/org/eclipse/mojarra/test/issue5464/Issue5464Bean.java
@@ -26,8 +26,6 @@ public class Issue5464Bean {
     private String output;
 
     public void submit() {
-        
-        System.out.println("====> retrieved input " + input);
         output = "Result: " + input;
     }
 

--- a/test/issue5464/src/main/java/org/eclipse/mojarra/test/issue5464/Issue5464Bean.java
+++ b/test/issue5464/src/main/java/org/eclipse/mojarra/test/issue5464/Issue5464Bean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
 package org.eclipse.mojarra.test.issue5464;
 
 import jakarta.enterprise.context.RequestScoped;

--- a/test/issue5464/src/main/java/org/eclipse/mojarra/test/issue5464/Issue5464Bean.java
+++ b/test/issue5464/src/main/java/org/eclipse/mojarra/test/issue5464/Issue5464Bean.java
@@ -1,0 +1,30 @@
+package org.eclipse.mojarra.test.issue5464;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class Issue5464Bean {
+
+    private String input;
+    private String output;
+
+    public void submit() {
+        
+        System.out.println("====> retrieved input " + input);
+        output = "Result: " + input;
+    }
+
+    public String getInput() {
+        return input;
+    }
+
+    public void setInput(String input) {
+        this.input = input;
+    }
+
+    public String getOutput() {
+        return output;
+    }
+}

--- a/test/issue5464/src/main/webapp/WEB-INF/web.xml
+++ b/test/issue5464/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+    version="5.0"
+>
+    <servlet>
+        <servlet-name>facesServlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>facesServlet</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/test/issue5464/src/main/webapp/WEB-INF/web.xml
+++ b/test/issue5464/src/main/webapp/WEB-INF/web.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
 <web-app
     xmlns="https://jakarta.ee/xml/ns/jakartaee" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/test/issue5464/src/main/webapp/issue5464.xhtml
+++ b/test/issue5464/src/main/webapp/issue5464.xhtml
@@ -1,4 +1,21 @@
 <!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
 <html lang="en"
     xmlns:h="jakarta.faces.html"
     xmlns:f="jakarta.faces.core"

--- a/test/issue5464/src/main/webapp/issue5464.xhtml
+++ b/test/issue5464/src/main/webapp/issue5464.xhtml
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en"
+    xmlns:h="jakarta.faces.html"
+    xmlns:f="jakarta.faces.core"
+    xmlns:ui="jakarta.faces.facelets"
+>
+    <h:head>
+        <title>issue5464</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <div>
+                <h:inputText id="input" value="#{issue5464Bean.input}" />
+            </div>
+            <div>
+                <h:commandButton id="submit" value="submit" action="#{issue5464Bean.submit}">
+                    <f:ajax execute="@form" render="@form" />
+                </h:commandButton>
+            </div>
+            <div>
+                <h:outputText id="output" value="#{issue5464Bean.output}" />
+            </div>
+        </h:form>
+    </h:body>
+</html>

--- a/test/issue5464/src/test/java/org/eclipse/mojarra/test/issue5464/Issue5464IT.java
+++ b/test/issue5464/src/test/java/org/eclipse/mojarra/test/issue5464/Issue5464IT.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
 package org.eclipse.mojarra.test.issue5464;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/test/issue5464/src/test/java/org/eclipse/mojarra/test/issue5464/Issue5464IT.java
+++ b/test/issue5464/src/test/java/org/eclipse/mojarra/test/issue5464/Issue5464IT.java
@@ -1,0 +1,42 @@
+package org.eclipse.mojarra.test.issue5464;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.mojarra.test.base.BaseIT;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+class Issue5464IT extends BaseIT {
+
+    @FindBy(id = "form:input")
+    private WebElement input;
+
+    @FindBy(id = "form:submit")
+    private WebElement submit;
+
+    @FindBy(id = "form:output")
+    private WebElement output;
+
+    /**
+     * https://github.com/eclipse-ee4j/mojarra/issues/5464
+     */
+    @Test
+    void testFFFE() {
+        open("issue5464.xhtml");
+        input.sendKeys("f\uFFFEoo");
+        guardAjax(submit::click);
+        assertEquals("Result: foo", output.getText());
+    }
+
+    /**
+     * https://github.com/eclipse-ee4j/mojarra/issues/4516
+     */
+    @Test
+    void test000C() {
+        open("issue5464.xhtml");
+        input.sendKeys("f\u000Coo");
+        guardAjax(submit::click);
+        assertEquals("Result: foo", output.getText());
+    }
+}

--- a/test/issue5488/pom.xml
+++ b/test/issue5488/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.mojarra.test</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.0.9-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>issue5488</artifactId>
+    <packaging>war</packaging>
+
+    <name>Mojarra ${project.version} - INTEGRATION TESTS - ${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.mojarra.test</groupId>
+            <artifactId>base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/test/issue5488/src/main/java/org/eclipse/mojarra/test/issue5488/Issue5488Bean.java
+++ b/test/issue5488/src/main/java/org/eclipse/mojarra/test/issue5488/Issue5488Bean.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package org.eclipse.mojarra.test.issue5488;
+
+import static jakarta.faces.component.UIComponent.getCurrentComponent;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.faces.application.FacesMessage;
+import jakarta.faces.context.FacesContext;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class Issue5488Bean {
+
+    public void listener() {
+        addInvokedMessage("listener");
+    }
+
+    public void action() {
+        addInvokedMessage("action");
+    }
+
+    private static void addInvokedMessage(String methodName) {
+        FacesContext context = FacesContext.getCurrentInstance();
+        context.addMessage(null, new FacesMessage(methodName + " invoked on " + getCurrentComponent(context).getClientId(context)));
+    }
+}

--- a/test/issue5488/src/main/webapp/WEB-INF/web.xml
+++ b/test/issue5488/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+    version="5.0"
+>
+    <servlet>
+        <servlet-name>facesServlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>facesServlet</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/test/issue5488/src/main/webapp/issue5488.xhtml
+++ b/test/issue5488/src/main/webapp/issue5488.xhtml
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="en"
+    xmlns:h="jakarta.faces.html"
+    xmlns:f="jakarta.faces.core"
+    xmlns:ui="jakarta.faces.facelets"
+>
+    <h:head>
+        <title>issue5488</title>
+    </h:head>
+    <h:body>
+        <h:form id="form1"> <!-- This basically verifies that the specified issue is fixed in h:commandButton for good. -->
+            <h:inputText id="input" />
+            <h:commandButton id="button" value="submit" action="#{issue5488Bean.action}">
+                <f:ajax event="blur" listener="#{issue5488Bean.listener}" render="messages" />
+                <f:ajax execute="@form" render="messages"/>
+            </h:commandButton>
+            <h:messages id="messages" />
+        </h:form>
+        <h:form id="form2"> <!-- This basically reconfirms that the specified issue doesn't and won't ever happen in h:commandLink. -->
+            <h:inputText id="input" />
+            <h:commandLink id="link" value="submit" action="#{issue5488Bean.action}">
+                <f:ajax event="blur" listener="#{issue5488Bean.listener}" render="messages" />
+                <f:ajax execute="@form" render="messages"/>
+            </h:commandLink>
+            <h:messages id="messages" />
+        </h:form>
+        <h:form id="form3"> <!-- This basically reassess that issue3355 (issue3351IT) remains fixed as it caused the regression in h:commandButton. -->
+            <h:commandButton id="button1" type="button" value="button1" actionListener="#{issue5488Bean.listener}">
+                <f:ajax execute="@form" render="messages"/>
+            </h:commandButton>
+            <h:commandButton id="button2" type="button" value="button2" actionListener="#{issue5488Bean.listener}">
+                <f:ajax execute="@form" render="messages"/>
+            </h:commandButton>
+            <h:messages id="messages" />
+        </h:form>
+    </h:body>
+</html>

--- a/test/issue5488/src/test/java/org/eclipse/mojarra/test/issue5488/Issue5488IT.java
+++ b/test/issue5488/src/test/java/org/eclipse/mojarra/test/issue5488/Issue5488IT.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package org.eclipse.mojarra.test.issue5488;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.mojarra.test.base.BaseIT;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+class Issue5488IT extends BaseIT {
+
+    @FindBy(id = "form1:input")
+    private WebElement form1input;
+
+    @FindBy(id = "form1:button")
+    private WebElement form1button;
+
+    @FindBy(id = "form1:messages")
+    private WebElement form1messages;
+
+    @FindBy(id = "form2:input")
+    private WebElement form2input;
+
+    @FindBy(id = "form2:link")
+    private WebElement form2link;
+
+    @FindBy(id = "form2:messages")
+    private WebElement form2messages;
+
+    @FindBy(id = "form3:button1")
+    private WebElement form3button1;
+
+    @FindBy(id = "form3:button2")
+    private WebElement form3button2;
+
+    @FindBy(id = "form3:messages")
+    private WebElement form3messages;
+
+    /**
+     * https://github.com/eclipse-ee4j/mojarra/issues/5488
+     */
+    @Test
+    void testCommandButtonBlurred() {
+        open("issue5488.xhtml");
+        form1input.sendKeys(Keys.TAB);
+        guardAjax(() -> form1button.sendKeys(Keys.TAB));
+
+        var messages = form1messages.getText();
+        assertEquals("listener invoked on form1:button", messages); // and thus not action invoked as well
+    }
+
+    /**
+     * https://github.com/eclipse-ee4j/mojarra/issues/5488
+     */
+    @Test
+    void testCommandButtonClicked() {
+        open("issue5488.xhtml");
+        guardAjax(form1button::click);
+        assertEquals("action invoked on form1:button", form1messages.getText()); // and thus not listener invoked as well
+    }
+
+    /**
+     * https://github.com/eclipse-ee4j/mojarra/issues/5488
+     */
+    @Test
+    void testCommandLinkBlurred() {
+        open("issue5488.xhtml");
+        form2input.sendKeys(Keys.TAB);
+        guardAjax(() -> form2link.sendKeys(Keys.TAB));
+        assertEquals("listener invoked on form2:link", form2messages.getText()); // and thus not action invoked as well
+    }
+
+    /**
+     * https://github.com/eclipse-ee4j/mojarra/issues/5488
+     */
+    @Test
+    void testCommandLinkClicked() {
+        open("issue5488.xhtml");
+        guardAjax(form2link::click);
+        assertEquals("action invoked on form2:link", form2messages.getText()); // and thus not listener invoked as well
+    }
+
+    /**
+     * https://github.com/eclipse-ee4j/mojarra/issues/3355
+     */
+    @Test
+    void testPlainButton1() {
+        open("issue5488.xhtml");
+        guardAjax(form3button1::click);
+        assertEquals("listener invoked on form3:button1", form3messages.getText()); // and thus not on form3:button2 as well
+    }
+
+    /**
+     * https://github.com/eclipse-ee4j/mojarra/issues/3355
+     */
+    @Test
+    void testPlainButton2() {
+        open("issue5488.xhtml");
+        guardAjax(form3button2::click);
+        assertEquals("listener invoked on form3:button2", form3messages.getText()); // and thus not on form3:button1 as well
+    }
+}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.0.8-SNAPSHOT</version>
+        <version>4.0.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.mojarra.test</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -35,6 +35,7 @@
         <module>base</module>
         <module>issue5460</module>
         <module>issue5464</module>
+        <module>issue5488</module>
     </modules>
 
     <properties>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish</groupId>
+        <artifactId>mojarra-parent</artifactId>
+        <version>4.0.8-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.eclipse.mojarra.test</groupId>
+    <artifactId>pom</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Mojarra ${project.version} - INTEGRATION TESTS</name>
+
+    <modules>
+        <module>base</module>
+        <module>issue5460</module>
+        <module>issue5464</module>
+    </modules>
+
+    <properties>
+        <glassfish.version>7.0.16</glassfish.version>
+        <arquillian.browser>chrome</arquillian.browser>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-web-api</artifactId>
+            <version>10.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
+            <version>1.8.0.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <version>3.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>4.23.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.4.0</version>
+                <configuration>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.7.1</version>
+                <configuration>
+                    <outputDirectory>${project.build.directory}</outputDirectory>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <systemPropertyVariables>
+                        <arquillian.browser>${arquillian.browser}</arquillian.browser>
+                        <war.file.name>${project.build.finalName}</war.file.name>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>glassfish</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.omnifaces.arquillian</groupId>
+                    <artifactId>arquillian-glassfish-server-managed</artifactId>
+                    <version>1.4</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-glassfish</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.glassfish.main.distributions</groupId>
+                                            <artifactId>glassfish</artifactId>
+                                            <version>${glassfish.version}</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>update-mojarra</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.glassfish</groupId>
+                                            <artifactId>jakarta.faces</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>jar</type>
+                                            <overWrite>true</overWrite>
+                                            <outputDirectory>${project.build.directory}/glassfish7/glassfish/modules</outputDirectory>
+                                            <destFileName>jakarta.faces.jar</destFileName>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <glassfish.home>${project.build.directory}/glassfish7</glassfish.home>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>


### PR DESCRIPTION
Also added IT tests for #5460 and #5464 and spotted one more place where #5464 should be fixed.

NOTE: the technical reason for adding back the IT config to Mojarra project is because we CANNOT add new tests to the TCK of an already-released Faces version. We can only add them for the next Faces version. But this also means that these won't be executed when the current version is being patched/bugfixed. Hence we can only add them to the Mojarra project. Once a next TCK version is to be prepared we can simply move them from Mojarra into Faces project for TCK.