### PR TITLE
Fix null reference error when calling faces.ajax.request()

### DIFF
--- a/impl/src/main/resources/META-INF/resources/jakarta.faces/faces-uncompressed.js
+++ b/impl/src/main/resources/META-INF/resources/jakarta.faces/faces-uncompressed.js
@@ -560,7 +560,7 @@ if ( !( (window.faces && window.faces.specversion && window.faces.specversion >=
          * @ignore
          */
         const deleteNode = function deleteNode(node) {
-            if (node) node.remove();
+            if (node && node.parentNode) node.remove();
         };
 
         /**


### PR DESCRIPTION
Fixes #5499.

The null reference has been occurring since `if (node && node.parentNode) node.parentNode.removeChild(node);` is replaced with `if (node) node.remove();` in the commit f2f343a.
It can be fixed by adding a null check for `node.parentNode` as before.