### PR TITLE
Backport: Fix null reference error when calling faces.ajax.request()

### DIFF
--- a/impl/src/main/resources/META-INF/resources/jakarta.faces/faces-uncompressed.js
+++ b/impl/src/main/resources/META-INF/resources/jakarta.faces/faces-uncompressed.js
@@ -560,7 +560,7 @@ if ( !( (window.faces && window.faces.specversion && window.faces.specversion >=
          * @ignore
          */
         const deleteNode = function deleteNode(node) {
-            if (node) node.remove();
+            if (node && node.parentNode) node.remove();
         };
 
         /**


### PR DESCRIPTION
This backports #5500 into the 4.1 branch.

Fixes #5499.
