### PR TITLE
Fix #5488: non-action ajax event shouldn't trigger action event

### DIFF
--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/ButtonRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/ButtonRenderer.java
@@ -171,29 +171,17 @@ public class ButtonRenderer extends HtmlBasicRenderer {
      */
     private static boolean wasClicked(FacesContext context, UIComponent component, String clientId) {
 
-        // Was our command the one that caused this submission?
-        // we don' have to worry about getting the value from request parameter
-        // because we just need to know if this command caused the submission. We
-        // can get the command name by calling currentValue. This way we can
-        // get around the IE bug.
-
         if (clientId == null) {
             clientId = component.getClientId(context);
         }
 
         if (context.getPartialViewContext().isAjaxRequest()) {
-            return BEHAVIOR_SOURCE_PARAM.getValue(context).equals(clientId);
+            return RenderKitUtils.isPartialOrBehaviorAction(context, clientId);
         } else {
             Map<String, String> requestParameterMap = context.getExternalContext().getRequestParameterMap();
 
             if (requestParameterMap.get(clientId) == null) {
-
-                // Check to see whether we've got an action event
-                // as a result of a partial/behavior postback.
-                if (RenderKitUtils.isPartialOrBehaviorAction(context, clientId)) {
-                    return true;
-                }
-
+                // Check to see whether we've got an action event from button of type="image"
                 StringBuilder builder = new StringBuilder(clientId);
                 String xValue = builder.append(".x").toString();
                 builder.setLength(clientId.length());


### PR DESCRIPTION
Fix #5488: non-action ajax event shouldn't trigger action event; while at it also cleaned up existing code comments

IT is via commit https://github.com/eclipse-ee4j/mojarra/pull/5469/commits/25b9aedb566c3a81c0f47adbecd66fe0df790b66 added to the still pending PR https://github.com/eclipse-ee4j/mojarra/pull/5469 (with the long term purpose to move it into the TCK when next Faces version is to be released because the TCK setup in its current form doesn't allow adding new ITs for an already released version)