### PR TITLE
Reduce logging level of exception which is already rethrown

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -940,8 +940,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
      */
     protected void handleRenderException(FacesContext context, Exception e) throws IOException {
 
-        // Always log
-        if (LOGGER.isLoggable(SEVERE)) {
+        if (LOGGER.isLoggable(FINE)) {
             UIViewRoot root = context.getViewRoot();
             StringBuffer sb = new StringBuffer(64);
             sb.append("Error Rendering View");
@@ -950,7 +949,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
                 sb.append(root.getViewId());
                 sb.append(']');
             }
-            LOGGER.log(SEVERE, sb.toString(), e);
+            LOGGER.log(FINE, sb.toString(), e);
         }
 
         if (e instanceof RuntimeException) {


### PR DESCRIPTION
Reduce logging level of exception which is already rethrown during render response -- this only causes duplicate logs https://github.com/eclipse-ee4j/mojarra/issues/5449

In case you have a deja vu, this was indeed fixed earlier but only for other lifecycle phases: https://github.com/eclipse-ee4j/mojarra/pull/5411