### PR TITLE
Fix #5511: don't anymore rely on CodeSource#getLocation()

### DIFF
--- a/impl/src/main/java/com/sun/faces/config/manager/tasks/ProvideMetadataToAnnotationScanTask.java
+++ b/impl/src/main/java/com/sun/faces/config/manager/tasks/ProvideMetadataToAnnotationScanTask.java
@@ -55,15 +55,15 @@ public final class ProvideMetadataToAnnotationScanTask {
 
         for (DocumentInfo docInfo : documentInfos) {
 
-            URI sourceURI = docInfo.getSourceURI();
-            Matcher jarMatcher = FACES_CONFIG_XML_IN_JAR_PATTERN.matcher(sourceURI == null ? "" : sourceURI.toString());
+            URI facesConfigURI = docInfo.getSourceURI();
+            Matcher jarMatcher = FACES_CONFIG_XML_IN_JAR_PATTERN.matcher(facesConfigURI == null ? "" : facesConfigURI.toString());
 
             if (jarMatcher.matches()) {
                 String jarName = jarMatcher.group(2);
                 if (!jarNames.contains(jarName)) {
                     FacesConfigInfo configInfo = new FacesConfigInfo(docInfo);
                     if (!configInfo.isMetadataComplete()) {
-                        uris.add(sourceURI);
+                        uris.add(facesConfigURI);
                         jarNames.add(jarName);
                     } else {
                         /*
@@ -74,12 +74,12 @@ public final class ProvideMetadataToAnnotationScanTask {
                          * annotatedSet because the faces-config.xml that owns it has metadata-complete="true".
                          */
                         ArrayList<Class<?>> toRemove = new ArrayList<>(1);
-                        String sourceURIString = sourceURI.toString();
+                        String facesConfigURIString = facesConfigURI.toString();
                         if (annotatedSet != null) {
                             for (Class<?> clazz : annotatedSet) {
-                                String location = CURRENT_RESOURCE_IN_JAR_PATTERN.split(clazz.getResource(".").toString(), 2)[0];
+                                String jarURIString = CURRENT_RESOURCE_IN_JAR_PATTERN.split(clazz.getResource(".").toString(), 2)[0];
 
-                                if (sourceURIString.startsWith(location)) {
+                                if (facesConfigURIString.startsWith(jarURIString)) {
                                     toRemove.add(clazz);
                                 }
                             }

--- a/impl/src/main/java/com/sun/faces/config/manager/tasks/ProvideMetadataToAnnotationScanTask.java
+++ b/impl/src/main/java/com/sun/faces/config/manager/tasks/ProvideMetadataToAnnotationScanTask.java
@@ -17,6 +17,7 @@
 package com.sun.faces.config.manager.tasks;
 
 import java.net.URI;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
@@ -75,8 +76,14 @@ public final class ProvideMetadataToAnnotationScanTask {
                         String sourceURIString = sourceURI.toString();
                         if (annotatedSet != null) {
                             for (Class<?> clazz : annotatedSet) {
-                                if (sourceURIString.contains(clazz.getProtectionDomain().getCodeSource().getLocation().toString())) {
-                                    toRemove.add(clazz);
+                                URL resource = clazz.getClassLoader().getResource(clazz.getName().replace(".", "/") + ".class");
+
+                                if (resource != null) {
+                                    String location = resource.toString().split("(?<=\\.jar)[!/].*", 2)[0];
+
+                                    if (sourceURIString.startsWith(location)) {
+                                        toRemove.add(clazz);
+                                    }
                                 }
                             }
                             annotatedSet.removeAll(toRemove);

--- a/impl/src/main/java/com/sun/faces/config/manager/tasks/ProvideMetadataToAnnotationScanTask.java
+++ b/impl/src/main/java/com/sun/faces/config/manager/tasks/ProvideMetadataToAnnotationScanTask.java
@@ -77,7 +77,8 @@ public final class ProvideMetadataToAnnotationScanTask {
                         String facesConfigURIString = facesConfigURI.toString();
                         if (annotatedSet != null) {
                             for (Class<?> clazz : annotatedSet) {
-                                String jarURIString = CURRENT_RESOURCE_IN_JAR_PATTERN.split(clazz.getResource(".").toString(), 2)[0];
+                                URL classURI = clazz.getClassLoader().getResource(clazz.getName().replace('.', '/') + ".class");
+                                String jarURIString = CURRENT_RESOURCE_IN_JAR_PATTERN.split(classURI.toString(), 2)[0];
 
                                 if (facesConfigURIString.startsWith(jarURIString)) {
                                     toRemove.add(clazz);

--- a/test/example_jar_with_metadata_complete_false/pom.xml
+++ b/test/example_jar_with_metadata_complete_false/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.mojarra.test</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.0.9-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>example_jar_with_metadata_complete_false</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Mojarra ${project.version} - INTEGRATION TESTS - ${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.faces</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/test/example_jar_with_metadata_complete_false/pom.xml
+++ b/test/example_jar_with_metadata_complete_false/pom.xml
@@ -35,6 +35,7 @@
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.faces</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/test/example_jar_with_metadata_complete_false/src/main/java/org/eclipse/mojarra/test/example_jar_with_metadata_complete_false/ExampleFacesComponent.java
+++ b/test/example_jar_with_metadata_complete_false/src/main/java/org/eclipse/mojarra/test/example_jar_with_metadata_complete_false/ExampleFacesComponent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package org.eclipse.mojarra.test.example_jar_with_metadata_complete_false;
+
+import jakarta.faces.component.FacesComponent;
+import jakarta.faces.component.html.HtmlOutputText;
+
+@FacesComponent(createTag = true, namespace="example_jar_with_metadata_complete_false")
+public class ExampleFacesComponent extends HtmlOutputText {
+
+}

--- a/test/example_jar_with_metadata_complete_false/src/main/resources/META-INF/faces-config.xml
+++ b/test/example_jar_with_metadata_complete_false/src/main/resources/META-INF/faces-config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<faces-config 
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_0.xsd"
+    version="4.0" metadata-complete="false"
+>
+</faces-config>

--- a/test/example_jar_with_metadata_complete_true/pom.xml
+++ b/test/example_jar_with_metadata_complete_true/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.mojarra.test</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.0.9-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>example_jar_with_metadata_complete_true</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Mojarra ${project.version} - INTEGRATION TESTS - ${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.faces</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/test/example_jar_with_metadata_complete_true/pom.xml
+++ b/test/example_jar_with_metadata_complete_true/pom.xml
@@ -35,6 +35,7 @@
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.faces</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/test/example_jar_with_metadata_complete_true/src/main/java/org/eclipse/mojarra/test/example_jar_with_metadata_complete_true/ExampleFacesComponent.java
+++ b/test/example_jar_with_metadata_complete_true/src/main/java/org/eclipse/mojarra/test/example_jar_with_metadata_complete_true/ExampleFacesComponent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package org.eclipse.mojarra.test.example_jar_with_metadata_complete_true;
+
+import jakarta.faces.component.FacesComponent;
+import jakarta.faces.component.html.HtmlOutputText;
+
+@FacesComponent(createTag = true, namespace="example_jar_with_metadata_complete_true")
+public class ExampleFacesComponent extends HtmlOutputText {
+
+}

--- a/test/example_jar_with_metadata_complete_true/src/main/resources/META-INF/faces-config.xml
+++ b/test/example_jar_with_metadata_complete_true/src/main/resources/META-INF/faces-config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<faces-config 
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_0.xsd"
+    version="4.0" metadata-complete="true"
+>
+</faces-config>

--- a/test/issue5507/src/main/webapp/WEB-INF/web.xml
+++ b/test/issue5507/src/main/webapp/WEB-INF/web.xml
@@ -30,7 +30,5 @@
     <servlet-mapping>
         <servlet-name>facesServlet</servlet-name>
         <url-pattern>*.xhtml</url-pattern>
-        <url-pattern>*.jsf</url-pattern>
-        <url-pattern>/faces/*</url-pattern>
     </servlet-mapping>
 </web-app>

--- a/test/issue5511/pom.xml
+++ b/test/issue5511/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.mojarra.test</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.0.9-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>issue5511</artifactId>
+    <packaging>war</packaging>
+
+    <name>Mojarra ${project.version} - INTEGRATION TESTS - ${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.mojarra.test</groupId>
+            <artifactId>example_jar_with_metadata_complete_false</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.mojarra.test</groupId>
+            <artifactId>example_jar_with_metadata_complete_true</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.mojarra.test</groupId>
+            <artifactId>base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/test/issue5511/src/main/webapp/WEB-INF/web.xml
+++ b/test/issue5511/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+    version="5.0"
+>
+    <servlet>
+        <servlet-name>facesServlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>facesServlet</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+        <url-pattern>*.jsf</url-pattern>
+        <url-pattern>/faces/*</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/test/issue5511/src/main/webapp/WEB-INF/web.xml
+++ b/test/issue5511/src/main/webapp/WEB-INF/web.xml
@@ -30,7 +30,5 @@
     <servlet-mapping>
         <servlet-name>facesServlet</servlet-name>
         <url-pattern>*.xhtml</url-pattern>
-        <url-pattern>*.jsf</url-pattern>
-        <url-pattern>/faces/*</url-pattern>
     </servlet-mapping>
 </web-app>

--- a/test/issue5511/src/main/webapp/issue5511-using-jar-with-metadata-complete-false.xhtml
+++ b/test/issue5511/src/main/webapp/issue5511-using-jar-with-metadata-complete-false.xhtml
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="en"
+    xmlns:h="jakarta.faces.html"
+    xmlns:f="jakarta.faces.core"
+    xmlns:ui="jakarta.faces.facelets"
+    xmlns:ex="example_jar_with_metadata_complete_false"
+>
+    <h:head>
+        <title>issue5511 - trying to use annotated @FacesComponent from JAR with metadata-complete=false</title>
+    </h:head>
+    <h:body>
+        <ex:exampleFacesComponent id="exampleFacesComponent" value="Hello World" />
+    </h:body>
+</html>

--- a/test/issue5511/src/main/webapp/issue5511-using-jar-with-metadata-complete-true.xhtml
+++ b/test/issue5511/src/main/webapp/issue5511-using-jar-with-metadata-complete-true.xhtml
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="en"
+    xmlns:h="jakarta.faces.html"
+    xmlns:f="jakarta.faces.core"
+    xmlns:ui="jakarta.faces.facelets"
+    xmlns:ex="example_jar_with_metadata_complete_true"
+>
+    <h:head>
+        <title>issue5511 - trying to use annotated @FacesComponent from JAR with metadata-complete=true</title>
+    </h:head>
+    <h:body>
+        <ex:exampleFacesComponent id="exampleFacesComponent" value="Hello World" />
+    </h:body>
+</html>

--- a/test/issue5511/src/test/java/org/eclipse/mojarra/test/issue5511/Issue5511IT.java
+++ b/test/issue5511/src/test/java/org/eclipse/mojarra/test/issue5511/Issue5511IT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package org.eclipse.mojarra.test.issue5511;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.mojarra.test.base.BaseIT;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * https://github.com/eclipse-ee4j/mojarra/issues/5511
+ */
+class Issue5511IT extends BaseIT {
+
+    @FindBy(id = "exampleFacesComponent")
+    private WebElement exampleFacesComponent;
+
+    @Test
+    void testJarWithMetadataCompleteFalse() {
+        open("issue5511-using-jar-with-metadata-complete-false.xhtml");
+        assertEquals("span", exampleFacesComponent.getTagName().toLowerCase(), "The ex:exampleFacesComponent SHOULD be processed because of metadata-complete=false on its JAR");
+        assertEquals("Hello World", exampleFacesComponent.getText(), "Because it renders a span via HtmlOutputText, it should output its value as well.");
+    }
+
+    @Test
+    void testJarWithMetadataCompleteTrue() {
+        open("issue5511-using-jar-with-metadata-complete-true.xhtml");
+        assertEquals("ex:examplefacescomponent", exampleFacesComponent.getTagName().toLowerCase(), "The ex:exampleFacesComponent SHOULD NOT be processed because of metadata-complete=true on its JAR");
+        assertEquals("", exampleFacesComponent.getText(), "Because it does not render to a valid HTML element, it should not output anything either.");
+    }
+}

--- a/test/issue5511/src/test/java/org/eclipse/mojarra/test/issue5511/Issue5511IT.java
+++ b/test/issue5511/src/test/java/org/eclipse/mojarra/test/issue5511/Issue5511IT.java
@@ -33,14 +33,14 @@ class Issue5511IT extends BaseIT {
     @Test
     void testJarWithMetadataCompleteFalse() {
         open("issue5511-using-jar-with-metadata-complete-false.xhtml");
-        assertEquals("span", exampleFacesComponent.getTagName().toLowerCase(), "The ex:exampleFacesComponent SHOULD be processed because of metadata-complete=false on its JAR");
+        assertEquals("span", exampleFacesComponent.getTagName().toLowerCase(), "The @FacesComponent annotation SHOULD be processed because of metadata-complete=false on its JAR");
         assertEquals("Hello World", exampleFacesComponent.getText(), "Because it renders a span via HtmlOutputText, it should output its value as well.");
     }
 
     @Test
     void testJarWithMetadataCompleteTrue() {
         open("issue5511-using-jar-with-metadata-complete-true.xhtml");
-        assertEquals("ex:examplefacescomponent", exampleFacesComponent.getTagName().toLowerCase(), "The ex:exampleFacesComponent SHOULD NOT be processed because of metadata-complete=true on its JAR");
+        assertEquals("ex:examplefacescomponent", exampleFacesComponent.getTagName().toLowerCase(), "The @FacesComponent annotation SHOULD NOT be processed because of metadata-complete=true on its JAR");
         assertEquals("", exampleFacesComponent.getText(), "Because it does not render to a valid HTML element, it should not output anything either.");
     }
 }

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -33,11 +33,14 @@
 
     <modules>
         <module>base</module>
+        <module>example_jar_with_metadata_complete_false</module>
+        <module>example_jar_with_metadata_complete_true</module>
         <module>issue5460</module>
         <module>issue5464</module>
         <module>issue5488</module>
         <module>issue5503</module>
         <module>issue5507</module>
+        <module>issue5511</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Fix #5511: don't anymore rely on CodeSource#getLocation(), instead obtain the URL of the resource itself via its own class loader