### PR TITLE
Handle empty mapping in normalizeRequestURI

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/MultiViewHandler.java
+++ b/impl/src/main/java/com/sun/faces/application/view/MultiViewHandler.java
@@ -458,6 +458,10 @@ public class MultiViewHandler extends ViewHandler {
      * @since 1.2
      */
     protected String normalizeRequestURI(String viewId, String mapping) {
+        if (mapping.isEmpty()) {
+            return viewId;
+        }
+        
         boolean logged = false;
 
         while (viewId.startsWith(mapping)) {


### PR DESCRIPTION
Fixes #5525.

I assume `mapping` is not `null`, but the assumption was in the previous version as well by means of calling `.startsWith(mapping)`.

Project builds, and the fix can be tested by trivial example where `facesServlet` would be mapped to `/*`.