### PR TITLE
Don't attempt to set response buffer size on a committed response

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -898,7 +898,11 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
 
         // set the buffer for content, -1 indicates nothing should be set.
         if (responseBufferSize != -1) {
-            extContext.setResponseBufferSize(responseBufferSize);
+            if (!extContext.isResponseCommitted()) {
+                extContext.setResponseBufferSize(responseBufferSize);
+            } else {
+                LOGGER.warning("Skipping attempt to set buffer size on a committed response");
+            }
         }
 
         // get our content type


### PR DESCRIPTION
Changes made to fix https://github.com/eclipse-ee4j/mojarra/issues/5164 and https://github.com/eclipse-ee4j/mojarra/issues/5262 causes breakages in the Jakarta EE 10 Security TCK (specifically in the "old" bit).

```
[INFO]      [exec] [javatest.batch] FAILED........com/sun/ts/tests/securityapi/ham/customform/base/Client.java#testCustomFormHAMHasCorrectQualifier
[INFO]      [exec] [javatest.batch] FAILED........com/sun/ts/tests/securityapi/ham/customform/base/Client.java#testCustomFormHAMValidateRequest
[INFO]      [exec] [javatest.batch] FAILED........com/sun/ts/tests/securityapi/ham/customform/base/Client.java#testCustomFormLoginToContinueErrorPage
```

This is reproducible in Payara 6 and GlassFish 7 when using a Mojarra version higher than 4.0.0 (the first change was introduced in 4.0.1).

I'm not 100% certain if this is just a workaround for a dodgy flow, but it fixes the TCK.

The TCK fails because Mojarra is attempting to redirect from a login page after authentication and is attempting to set the response buffer size on the redirected request (which has been committed), causing the redirection to fail and the TCK to not find the correct content. If you refresh the page it _has_ been authenticated, so that's working, it just specifically fails at the point of redirection because Mojarra appears to be too optimistically trying to set the response buffer size.