### PR TITLE
Fix mojarra 5 initialization with empty dd files

### DIFF
--- a/impl/src/main/java/com/sun/faces/config/FacesInitializer.java
+++ b/impl/src/main/java/com/sun/faces/config/FacesInitializer.java
@@ -20,15 +20,13 @@ package com.sun.faces.config;
 import static com.sun.faces.RIConstants.ANNOTATED_CLASSES;
 import static com.sun.faces.RIConstants.FACES_SERVLET_MAPPINGS;
 import static com.sun.faces.RIConstants.FACES_SERVLET_REGISTRATION;
+import static com.sun.faces.util.Util.getExistingFacesServletRegistration;
 import static com.sun.faces.util.Util.isEmpty;
 import static java.util.logging.Level.WARNING;
 
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
-
-import com.sun.faces.util.FacesLogger;
 
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.faces.annotation.FacesConfig;
@@ -66,6 +64,8 @@ import jakarta.servlet.ServletRegistration;
 import jakarta.servlet.annotation.HandlesTypes;
 import jakarta.websocket.server.ServerContainer;
 
+import com.sun.faces.util.FacesLogger;
+
 /**
  * Initializes Jakarta Faces if at least one of the following conditions is met:
  *
@@ -98,8 +98,6 @@ public class FacesInitializer implements ServletContainerInitializer {
 
     private static final String FACES_CONFIG_RESOURCE_PATH = "/WEB-INF/faces-config.xml";
     private static final String FACES_SERVLET_CLASS_NAME = FacesServlet.class.getName();
-    private static final String[] FACES_SERVLET_MAPPINGS_WITH_XHTML = { "/faces/*", "*.jsf", "*.faces", "*.xhtml" };
-    private static final String[] FACES_SERVLET_MAPPINGS_WITHOUT_XHTML = { "/faces/*", "*.jsf", "*.faces" };
 
     // -------------------------------- Methods from ServletContainerInitializer
 
@@ -174,18 +172,6 @@ public class FacesInitializer implements ServletContainerInitializer {
         return getExistingFacesServletRegistration(context) != null;
     }
 
-    private static ServletRegistration getExistingFacesServletRegistration(ServletContext servletContext) {
-        Map<String, ? extends ServletRegistration> existing = servletContext.getServletRegistrations();
-
-        for (ServletRegistration registration : existing.values()) {
-            if (FACES_SERVLET_CLASS_NAME.equals(registration.getClassName())) {
-                return registration;
-            }
-        }
-
-        return null;
-    }
-
     private static void handleMappingConcerns(ServletContext servletContext, FacesContext facesContext) throws ServletException {
         ServletRegistration existingFacesServletRegistration = getExistingFacesServletRegistration(servletContext);
 
@@ -196,14 +182,6 @@ public class FacesInitializer implements ServletContainerInitializer {
         }
 
         ServletRegistration newFacesServletRegistration = servletContext.addServlet(FacesServlet.class.getSimpleName(), FACES_SERVLET_CLASS_NAME);
-
-        if (ContextParam.DISABLE_FACESSERVLET_TO_XHTML.isSet(facesContext)) {
-            newFacesServletRegistration.addMapping(FACES_SERVLET_MAPPINGS_WITHOUT_XHTML);
-        }
-        else {
-            newFacesServletRegistration.addMapping(FACES_SERVLET_MAPPINGS_WITH_XHTML);
-        }
-
         servletContext.setAttribute(FACES_SERVLET_MAPPINGS, newFacesServletRegistration.getMappings());
         servletContext.setAttribute(FACES_SERVLET_REGISTRATION, newFacesServletRegistration);
     }

--- a/impl/src/main/java/com/sun/faces/lifecycle/Phase.java
+++ b/impl/src/main/java/com/sun/faces/lifecycle/Phase.java
@@ -60,10 +60,7 @@ public abstract class Phase {
     public void doPhase(FacesContext context, Lifecycle lifecycle, ListIterator<PhaseListener> listeners) {
 
         context.setCurrentPhaseId(getId());
-        PhaseEvent event = null;
-        if (listeners.hasNext()) {
-            event = new PhaseEvent(context, getId(), lifecycle);
-        }
+        PhaseEvent event = new PhaseEvent(context, getId(), lifecycle);
 
         // start timing - include before and after phase processing
         Timer timer = Timer.getInstance();

--- a/impl/src/main/java/com/sun/faces/util/Util.java
+++ b/impl/src/main/java/com/sun/faces/util/Util.java
@@ -77,13 +77,6 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
-import com.sun.faces.RIConstants;
-import com.sun.faces.application.ApplicationAssociate;
-import com.sun.faces.config.WebConfiguration;
-import com.sun.faces.config.manager.FacesSchema;
-import com.sun.faces.facelets.component.UIRepeat;
-import com.sun.faces.io.FastStringWriter;
-
 import jakarta.el.ValueExpression;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.CDI;
@@ -110,6 +103,13 @@ import jakarta.servlet.ServletRegistration;
 import jakarta.servlet.http.HttpServletMapping;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.MappingMatch;
+
+import com.sun.faces.RIConstants;
+import com.sun.faces.application.ApplicationAssociate;
+import com.sun.faces.config.WebConfiguration;
+import com.sun.faces.config.manager.FacesSchema;
+import com.sun.faces.facelets.component.UIRepeat;
+import com.sun.faces.io.FastStringWriter;
 
 /**
  * <B>Util</B> is a class ...
@@ -183,7 +183,7 @@ public class Util {
         return emptyList();
     }
 
-    private static ServletRegistration getExistingFacesServletRegistration(ServletContext servletContext) {
+    public static ServletRegistration getExistingFacesServletRegistration(ServletContext servletContext) {
         Map<String, ? extends ServletRegistration> existing = servletContext.getServletRegistrations();
         for (ServletRegistration registration : existing.values()) {
             if (FACES_SERVLET_CLASS.equals(registration.getClassName())) {


### PR DESCRIPTION
Fixed two issues discovered while finally getting Faces 5.0 / Mojarra 5.0 TCK to work as per https://github.com/jakartaee/faces/pull/1988

- new `FacesConfig.ContextParam` cannot be checked in `FacesInitializer` because there is no guarantee that CDI is present at that moment (due to `ServletContainerInitializer` ordering being undefined, see also https://github.com/jakartaee/servlet/issues/548), so logic has been moved into `ConfigureListener`
- fix regression of https://github.com/eclipse-ee4j/mojarra/issues/5491 it caused `java.lang.NullPointerException: Cannot invoke
"jakarta.faces.event.PhaseEvent.getPhaseId()" because "event" is null` when an empty project is deployed which has no phase listeners