### PR TITLE
Fix identity of BindingFacesMessage

### DIFF
--- a/impl/src/main/java/com/sun/faces/util/MessageFactory.java
+++ b/impl/src/main/java/com/sun/faces/util/MessageFactory.java
@@ -19,6 +19,7 @@ package com.sun.faces.util;
 import java.text.MessageFormat;
 import java.util.Locale;
 import java.util.MissingResourceException;
+import java.util.Objects;
 import java.util.ResourceBundle;
 
 import jakarta.el.ValueExpression;
@@ -322,6 +323,19 @@ public class MessageFactory {
         private final Locale locale;
         private final Object[] parameters;
         private Object[] resolvedParameters;
+        
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), locale, parameters, resolvedParameters);
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            return super.equals(object)
+                && Objects.equals(locale, ((BindingFacesMessage) object).locale)
+                && Objects.equals(parameters, ((BindingFacesMessage) object).parameters)
+                && Objects.equals(resolvedParameters, ((BindingFacesMessage) object).resolvedParameters);
+        }
     }
 
 } // end of class MessageFactory

--- a/impl/src/main/java/jakarta/faces/validator/MessageFactory.java
+++ b/impl/src/main/java/jakarta/faces/validator/MessageFactory.java
@@ -19,6 +19,7 @@ package jakarta.faces.validator;
 import java.text.MessageFormat;
 import java.util.Locale;
 import java.util.MissingResourceException;
+import java.util.Objects;
 import java.util.ResourceBundle;
 
 import jakarta.el.ValueExpression;
@@ -322,6 +323,19 @@ class MessageFactory {
         private Locale locale;
         private Object[] parameters;
         private Object[] resolvedParameters;
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), locale, parameters, resolvedParameters);
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            return super.equals(object)
+                && Objects.equals(locale, ((BindingFacesMessage) object).locale)
+                && Objects.equals(parameters, ((BindingFacesMessage) object).parameters)
+                && Objects.equals(resolvedParameters, ((BindingFacesMessage) object).resolvedParameters);
+        }
     }
 
 } // end of class MessageFactory


### PR DESCRIPTION
Fix identity of BindingFacesMessage; it broke since introduction of equals/hashCode for FacesMessage in
https://github.com/jakartaee/faces/issues/1823

Reproducer: trigger 2 different bean validation errors on the same property, it should show 2 separate messages instead of only the last one.

Discovered while analyzing o:validateBean IT failure since switching from Mojarra 4.0.x to 4.1.x.