### PR TITLE
Store response encoding during initial request.

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -43,6 +43,7 @@ import static jakarta.faces.application.ProjectStage.Development;
 import static jakarta.faces.application.Resource.COMPONENT_RESOURCE_KEY;
 import static jakarta.faces.application.StateManager.IS_BUILDING_INITIAL_STATE;
 import static jakarta.faces.application.StateManager.STATE_SAVING_METHOD_SERVER;
+import static jakarta.faces.application.ViewHandler.CHARACTER_ENCODING_KEY;
 import static jakarta.faces.application.ViewHandler.DEFAULT_FACELETS_SUFFIX;
 import static jakarta.faces.application.ViewVisitOption.RETURN_AS_MINIMAL_IMPLICIT_OUTCOME;
 import static jakarta.faces.component.UIComponent.BEANINFO_KEY;
@@ -918,6 +919,10 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
 
         contentType = getResponseContentType(context, initWriter.getContentType());
         encoding = Util.getResponseEncoding(context, Optional.ofNullable(initWriter.getCharacterEncoding()));
+
+        // Store the response encoding in the session (Spec section "2.5.2.2. Determining the Character Encoding")
+        Map<String, Object> sessionMap = context.getExternalContext().getSessionMap();
+        sessionMap.put(CHARACTER_ENCODING_KEY, encoding);
 
         // apply them to the response
         char[] buffer = new char[1028];


### PR DESCRIPTION
This is a proposal to resolve https://github.com/eclipse-ee4j/mojarra/issues/5543

Version 4.0.6 introduces a change (fault?) in behavior, which breaks character encoding detection under some circumstances. I think the change was introduced in #5385.

Originally, the FaceletViewHandlingStrategy had [this line](https://github.com/eclipse-ee4j/mojarra/pull/5385/files#diff-b3a9aacd3be9aefe5ab7fe6e92c87862f999bff1c8523313a2c76451f5136422L1010) (`sessionMap.put(CHARACTER_ENCODING_KEY, encoding);`), which stored the response encoding into the external context session. The stored encoding could then be taken into account during next request in the `ViewHandler`:

https://github.com/eclipse-ee4j/mojarra/blob/263095b2d23e39de4709772af441a1bfde35855d/impl/src/main/java/jakarta/faces/application/ViewHandler.java#L389

Storing the response encoding is I think in line with spec section "2.5.2.2. Determining the Character Encoding" (https://jakarta.ee/specifications/faces/4.0/jakarta-faces-4.0#determining-the-character-encoding), which mentions:

> At the end of the render-response phase, the ViewHandler must store the response character encoding used by the underlying response object (e.g., the Jakarta Servlet or Portlet response) in the session (if and only if a session already exists) under a well known, implementation-dependent key.

The mentioned PR added the storing of the encoding to ViewHandler:

https://github.com/eclipse-ee4j/mojarra/pull/5385/files#diff-6903369dd9e9cf64f15a5126c3d098577e81cb1dc05c760c6586d827966268beR235

but that IMO is not the right place in the lifecycle, or at least it doesn't have the same effect. In my case it's not executed as the encoding at that point is null.

The reproducer for this is a page containing a simple form:

```
        <h:form>
		<h:inputText value="#{testBean.text}"/>
		<h:commandButton value="click here" />
		<h:outputText value="#{testBean.text}"/>
	</h:form>
```

When you enter an accented character into the input and press the button, the output field should display the character. With the version 4.0.6+ the encoding gets mangled, character is not displayed correctly.