### PR TITLE
Do not log an exception on connection closed by client (infamous Broken pipe error) - into 4.0.x branch

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to Eclipse Foundation.
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -36,7 +37,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
-import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
@@ -313,7 +313,7 @@ public class ResourceHandlerImpl extends ResourceHandler {
                     }
 
                 } catch (IOException ioe) {
-                    if (isConnectionAbort(ioe)) { // to be removed, when the exception is standardised in servlet.
+                    if (Util.isConnectionAbort(ioe)) { // to be removed, when the exception is standardised in servlet.
                         send404(context, resourceName, libraryName, false);
                     } else {
                         send404(context, resourceName, libraryName, ioe, true);
@@ -339,28 +339,6 @@ public class ResourceHandlerImpl extends ResourceHandler {
             send404(context, resourceName, libraryName, true);
         }
 
-    }
-
-    private static boolean isConnectionAbort(IOException ioe) {
-        if (ioe instanceof ClosedChannelException) {
-            return true;
-        }
-
-        String exceptionClassName = ioe.getClass().getCanonicalName();
-
-        if (exceptionClassName.equals("org.apache.catalina.connector.ClientAbortException") ||
-                exceptionClassName.equals("org.eclipse.jetty.io.EofException")) {
-            return true;
-        }
-
-        String exceptionMessage = ioe.getMessage();
-
-        if (exceptionMessage == null) {
-            return false;
-        }
-
-        String lowercasedExceptionMessage = exceptionMessage.toLowerCase();
-        return lowercasedExceptionMessage.contains("connection") && lowercasedExceptionMessage.contains("abort"); // #5264
     }
 
     private boolean libraryNameIsSafe(String libraryName) {

--- a/impl/src/main/java/com/sun/faces/context/ExceptionHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/context/ExceptionHandlerImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -24,6 +25,7 @@ import java.util.logging.Logger;
 
 import com.sun.faces.renderkit.RenderKitUtils;
 import com.sun.faces.util.FacesLogger;
+import com.sun.faces.util.Util;
 
 import jakarta.el.ELException;
 import jakarta.faces.FacesException;
@@ -37,6 +39,8 @@ import jakarta.faces.event.ExceptionQueuedEvent;
 import jakarta.faces.event.ExceptionQueuedEventContext;
 import jakarta.faces.event.PhaseId;
 import jakarta.faces.event.SystemEvent;
+
+import java.io.IOException;
 
 /**
  * <p>
@@ -205,8 +209,11 @@ public class ExceptionHandlerImpl extends ExceptionHandler {
         try {
             extContext.responseReset();
         } catch (Exception e) {
-            if (LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.log(Level.INFO, "Exception when handling error trying to reset the response.", wrapped);
+            boolean isConnectionAbort = wrapped instanceof IOException && Util.isConnectionAbort((IOException)wrapped);
+            if (!isConnectionAbort) {
+                if (LOGGER.isLoggable(Level.WARNING)) {
+                    LOGGER.log(Level.WARNING, "Exception when handling error trying to reset the response.", wrapped);
+                }
             }
         }
         if (null != wrapped && wrapped instanceof FacesFileNotFoundException) {


### PR DESCRIPTION
Similar logic to ResourceHandlerImpl, which doesn't log an exception on connection closed.  Exception is not logged because it's caused by the client, there's no way to recover and the warning message only pollutes logs. Now the code treats  "connection closed" exception thrown by Grizzly.