### PR TITLE
Improved #5543; save encoding in session AFTER rendering view

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -454,6 +454,11 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
                 writer.endDocument();
             }
 
+            // Save encoding in Session for consult in subsequent postback request as per spec section "2.5.2.2. Determining the Character Encoding".
+            if (ctx.getExternalContext().getSession(false) != null) {
+                ctx.getExternalContext().getSessionMap().put(CHARACTER_ENCODING_KEY, writer.getCharacterEncoding());
+            }
+
             // Finish writing
             writer.close();
 
@@ -928,11 +933,6 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
 
         // Save encoding in UIViewRoot for faster consult when Util#getResponseEncoding() is invoked again elsewhere.
         context.getViewRoot().getAttributes().put(FACELETS_ENCODING_KEY, encoding);
-
-        // Save encoding in Session for consult in subsequent postback request as per spec section "2.5.2.2. Determining the Character Encoding".
-        if (context.getExternalContext().getSession(false) != null) {
-            context.getExternalContext().getSessionMap().put(CHARACTER_ENCODING_KEY, encoding);
-        }
 
         // Now, clone with the real writer
         ResponseWriter writer = initWriter.cloneWithWriter(extContext.getResponseOutputWriter());

--- a/impl/src/main/java/com/sun/faces/util/Util.java
+++ b/impl/src/main/java/com/sun/faces/util/Util.java
@@ -1667,7 +1667,7 @@ public class Util {
 
         if (encoding == null && context.getExternalContext().getSession(false) != null) {
             // 4. If still none found then get previously known request or response encoding from session.
-            //    See also ViewHandler#initView() and FaceletViewHandlingStrategy#createResponseWriter().
+            //    See also ViewHandler#initView() and FaceletViewHandlingStrategy#renderView().
             encoding = (String) context.getExternalContext().getSessionMap().get(CHARACTER_ENCODING_KEY);
 
             if (encoding != null && LOGGER.isLoggable(FINEST)) {


### PR DESCRIPTION
Improved #5543; save encoding in session AFTER rendering view as it will otherwise fail on 1st request when session hasn't been created yet.

Discovered while running the [recently improved Faces 5.0 TCK](https://github.com/jakartaee/faces/pull/2044) against Mojarra 5.0 on GlassFish 8. The updated TCK doesn't anymore reuse the existing browser session for subsequent tests so this apparently slipped through in old TCK.