### PR TITLE
Fix #5604: Search expression handler should check for empty expressions

### DIFF
--- a/impl/src/main/java/com/sun/faces/component/search/SearchExpressionHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/component/search/SearchExpressionHandlerImpl.java
@@ -360,7 +360,10 @@ public class SearchExpressionHandlerImpl extends SearchExpressionHandler {
         }
 
         // lets not forget about part after the separator
-        tokens.add(buffer.toString());
+        String bufferAsString = buffer.toString().trim();
+        if (bufferAsString.length() > 0) {
+            tokens.add(bufferAsString);
+        }
 
         return tokens.toArray(new String[tokens.size()]);
     }

--- a/impl/src/test/java/com/sun/faces/component/search/SearchExpressionHandlerImplTest.java
+++ b/impl/src/test/java/com/sun/faces/component/search/SearchExpressionHandlerImplTest.java
@@ -1,0 +1,91 @@
+package com.sun.faces.component.search;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+public class SearchExpressionHandlerImplTest {
+
+    @Mock
+    private FacesContext mockedFacesContext;
+
+    private SearchExpressionHandlerImpl handler = new SearchExpressionHandlerImpl();
+
+    @Test
+    public void testSplitSpaceSeparatedExpressions() {
+        String[] expressions = handler.splitExpressions(mockedFacesContext, "@this that");
+        assertEquals(List.of("@this", "that"), asList(expressions));
+    }
+
+    @Test
+    public void testSplitSpaceSeparatedExpressionsWithLeadingSpace() {
+        String[] expressions = handler.splitExpressions(mockedFacesContext, " @this that");
+        assertEquals(List.of("@this", "that"), asList(expressions));
+    }
+
+    @Test
+    public void testSplitSpaceSeparatedExpressionsWithTrailingSpace() {
+        String[] expressions = handler.splitExpressions(mockedFacesContext, "@this that ");
+        assertEquals(List.of("@this", "that"), asList(expressions));
+    }
+
+    @Test
+    public void testSplitSpaceSeparatedExpressionsWithDoubleSpace() {
+        String[] expressions = handler.splitExpressions(mockedFacesContext, "@this  that");
+        assertEquals(List.of("@this", "that"), asList(expressions));
+    }
+
+    @Test
+    public void testSplitCommaSeparatedExpressions() {
+        String[] expressions = handler.splitExpressions(mockedFacesContext, "@this,that");
+        assertEquals(List.of("@this", "that"), asList(expressions));
+    }
+
+    @Test
+    public void testSplitCommaSeparatedExpressionsWithLeadingComma() {
+        String[] expressions = handler.splitExpressions(mockedFacesContext, ",@this,that");
+        assertEquals(List.of("@this", "that"), asList(expressions));
+    }
+
+    @Test
+    public void testSplitCommaSeparatedExpressionsWithTrailingComma() {
+        String[] expressions = handler.splitExpressions(mockedFacesContext, "@this,that,");
+        assertEquals(List.of("@this", "that"), asList(expressions));
+    }
+
+    @Test
+    public void testSplitCommaSeparatedExpressionsWithDoubleComma() {
+        String[] expressions = handler.splitExpressions(mockedFacesContext, "@this,,that");
+        assertEquals(List.of("@this", "that"), asList(expressions));
+    }
+
+    @Test
+    public void testSplitCommaSpaceSeparatedExpressions() {
+        String[] expressions = handler.splitExpressions(mockedFacesContext, "@this, that");
+        assertEquals(List.of("@this", "that"), asList(expressions));
+    }
+
+    @Test
+    public void testSplitCommaSpaceSeparatedExpressionsWithLeadingCommaSpace() {
+        String[] expressions = handler.splitExpressions(mockedFacesContext, ", @this, that");
+        assertEquals(List.of("@this", "that"), asList(expressions));
+    }
+
+    @Test
+    public void testSplitCommaSpaceSeparatedExpressionsWithTrailingCommaSpace() {
+        String[] expressions = handler.splitExpressions(mockedFacesContext, "@this, that, ");
+        assertEquals(List.of("@this", "that"), asList(expressions));
+    }
+
+    @Test
+    public void testSplitCommaSpaceSeparatedExpressionsWithDoubleCommaSpace() {
+        String[] expressions = handler.splitExpressions(mockedFacesContext, "@this, , that");
+        assertEquals(List.of("@this", "that"), asList(expressions));
+    }
+}


### PR DESCRIPTION
https://github.com/eclipse-ee4j/mojarra/issues/5604