### PR TITLE
[4.0] Fix thread-safety issue in ServerSideStateHelper actualMap

### DIFF
--- a/impl/src/main/java/com/sun/faces/renderkit/ServerSideStateHelper.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/ServerSideStateHelper.java
@@ -175,7 +175,7 @@ public class ServerSideStateHelper extends StateHelper {
                     }
                     Map<String, Object[]> actualMap = TypedCollections.dynamicallyCastMap(logicalMap.get(idInLogicalMap), String.class, Object[].class);
                     if (actualMap == null) {
-                        actualMap = new LRUMap<>(numberOfViews);
+                        actualMap = Collections.synchronizedMap(new LRUMap<>(numberOfViews));
                         logicalMap.put(idInLogicalMap, actualMap);
                     }
 


### PR DESCRIPTION
The actualMap LRUMap instances are created without synchronization wrapper. This creates potential race conditions when multiple threads access the same map; e.g. serialization logic of the container from the previous request. While the outer logicalMap is properly synchronized, the inner actualMap instances need their own synchronization for defense-in-depth thread safety.

The fix wraps actualMap creation with Collections.synchronizedMap() analogoues to other access patterns and logicalMap.