### PR TITLE
jakartaee/faces#1590: faces.util.chain must also support CSP; while at it bumped versions to 5

### DIFF
--- a/impl/src/main/resources/META-INF/resources/jakarta.faces/faces-uncompressed.js
+++ b/impl/src/main/resources/META-INF/resources/jakarta.faces/faces-uncompressed.js
@@ -2982,7 +2982,7 @@ if ( !( (window.faces && window.faces.specversion && window.faces.specversion >=
                 window[facesChainEvent] = event;
                 const script = 'window.' + facesChainResult + ' = (function(event) { ' + arguments[i] + ' }).call(window.' + facesChainThis + ', window.' + facesChainEvent + ');';
                 executeScriptWithNonce(head, script, nonce);
-                result = window[tempResult];
+                result = window[facesChainResult];
             }
             finally {
                 delete window[facesChainThis];


### PR DESCRIPTION
#1590

as per https://github.com/eclipse-ee4j/mojarra/pull/5606#issuecomment-3598168116 faces.util.chain slipped through CSP support, this has been caught up

TCK needed a few fixes because of change in rendered HTML, https://github.com/jakartaee/faces/pull/2068 but then it's all green.