### PR TITLE
jakartaee/faces#2032: allow passthrough on facets

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentSupport.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentSupport.java
@@ -30,11 +30,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.BiFunction;
 
-import com.sun.faces.RIConstants;
-import com.sun.faces.context.StateContext;
-import com.sun.faces.facelets.tag.faces.core.FacetHandler;
-import com.sun.faces.util.Util;
-
 import jakarta.faces.FacesException;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.UIPanel;
@@ -47,6 +42,11 @@ import jakarta.faces.view.facelets.FaceletContext;
 import jakarta.faces.view.facelets.Tag;
 import jakarta.faces.view.facelets.TagAttribute;
 import jakarta.faces.view.facelets.TagAttributeException;
+
+import com.sun.faces.RIConstants;
+import com.sun.faces.context.StateContext;
+import com.sun.faces.facelets.tag.faces.core.FacetHandler;
+import com.sun.faces.util.Util;
 
 /**
  *
@@ -618,6 +618,16 @@ public final class ComponentSupport {
         }
         return false;
 
+    }
+
+    public static boolean hasPassthroughAttributes(Tag t) {
+        for (String namespace : PassThroughAttributeLibrary.NAMESPACES) {
+            TagAttribute[] passthroughAttrs = t.getAttributes().getAll(namespace);
+            if (passthroughAttrs != null && passthroughAttrs.length > 0) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static void copyPassthroughAttributes(FaceletContext ctx, UIComponent c, Tag t) {

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/BaseTableRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/BaseTableRenderer.java
@@ -22,15 +22,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import com.sun.faces.renderkit.Attribute;
-import com.sun.faces.renderkit.RenderKitUtils;
-import com.sun.faces.util.Util;
-
 import jakarta.faces.component.UIColumn;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.UIData;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
+
+import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.RenderKitUtils;
+import com.sun.faces.util.Util;
 
 /**
  * Base class for concrete Grid and Table renderers.
@@ -131,7 +131,7 @@ public abstract class BaseTableRenderer extends HtmlBasicRenderer {
             if (captionStyle != null) {
                 writer.writeAttribute("style", captionStyle, "captionStyle");
             }
-            encodeRecursive(context, caption);
+            encodeRecursive(context, caption, true);
             writer.endElement("caption");
         }
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/GridRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/GridRenderer.java
@@ -19,12 +19,12 @@ package com.sun.faces.renderkit.html_basic;
 import java.io.IOException;
 import java.util.Iterator;
 
-import com.sun.faces.renderkit.Attribute;
-import com.sun.faces.renderkit.AttributeManager;
-
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
+
+import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.AttributeManager;
 
 /**
  * <B>GridRenderer</B> is a class that renders <code>UIPanel</code> component as a "Grid".
@@ -162,7 +162,7 @@ public class GridRenderer extends BaseTableRenderer {
             }
             writer.writeAttribute("colspan", String.valueOf(info.columns.size()), null);
             writer.writeAttribute("scope", "colgroup", null);
-            encodeRecursive(context, header);
+            encodeRecursive(context, header, true);
             writer.endElement("th");
             writer.endElement("tr");
             writer.writeText("\n", table, null);
@@ -187,7 +187,7 @@ public class GridRenderer extends BaseTableRenderer {
                 writer.writeAttribute("class", footerClass, "footerClass");
             }
             writer.writeAttribute("colspan", String.valueOf(info.columns.size()), null);
-            encodeRecursive(context, footer);
+            encodeRecursive(context, footer, true);
             writer.endElement("td");
             writer.endElement("tr");
             writer.writeText("\n", table, null);

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/TableRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/TableRenderer.java
@@ -23,15 +23,15 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import com.sun.faces.renderkit.Attribute;
-import com.sun.faces.renderkit.AttributeManager;
-import com.sun.faces.util.Util;
-
 import jakarta.faces.component.UIColumn;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.UIData;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
+
+import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.AttributeManager;
+import com.sun.faces.util.Util;
 
 /**
  * <p>
@@ -199,7 +199,7 @@ public class TableRenderer extends BaseTableRenderer {
 
         UIComponent colGroups = getFacet(table, "colgroups");
         if (colGroups != null) {
-            encodeRecursive(context, colGroups);
+            encodeRecursive(context, colGroups, true);
         }
 
     }
@@ -229,8 +229,7 @@ public class TableRenderer extends BaseTableRenderer {
                 }
                 UIComponent facet = getFacet(column, "footer");
                 if (facet != null) {
-                    writer.writeText("", table, null);
-                    encodeRecursive(context, facet);
+                    encodeRecursive(context, facet, true);
                 }
                 writer.endElement("td");
                 writer.writeText("\n", table, null);
@@ -246,7 +245,7 @@ public class TableRenderer extends BaseTableRenderer {
             if (info.columns.size() > 1) {
                 writer.writeAttribute("colspan", String.valueOf(info.columns.size()), null);
             }
-            encodeRecursive(context, footer);
+            encodeRecursive(context, footer, true);
             writer.endElement("td");
             renderRowEnd(context, table, writer);
         }
@@ -277,7 +276,7 @@ public class TableRenderer extends BaseTableRenderer {
                 writer.writeAttribute("colspan", String.valueOf(info.columns.size()), null);
             }
             writer.writeAttribute("scope", "colgroup", null);
-            encodeRecursive(context, header);
+            encodeRecursive(context, header, true);
             writer.endElement("th");
             renderRowEnd(context, table, writer);
         }
@@ -295,7 +294,7 @@ public class TableRenderer extends BaseTableRenderer {
                 writer.writeAttribute("scope", "col", null);
                 UIComponent facet = getFacet(column, "header");
                 if (facet != null) {
-                    encodeRecursive(context, facet);
+                    encodeRecursive(context, facet, true);
                 }
                 writer.endElement("th");
                 writer.writeText("\n", table, null);


### PR DESCRIPTION
jakartaee/faces#2032

e.g.

```
<h:dataTable id="table" value="#{['one','two','three']}" var="item">
    <f:facet name="header">
        header
    </f:facet>
    <h:column>
        <f:facet name="header" pt:class="my-header1" pt:style="font-size:8px" />
        <f:facet name="footer" pt:styleClass="my-footer" pt:style="font-size:8px">
            footer
        </f:facet>
        #{item}1
    </h:column>
    <h:column>
        <f:facet name="header" pt:class="my-header2" pt:title="tooltip">
            col2
        </f:facet>
        #{item}2
    </h:column>
</h:dataTable>
```

will now render

```
<table>
    <thead>
        <tr>
            <th>header</th>
        </tr>
        <tr>
            <th style="font-size: 8px" class="my-header1"></th>
            <th title="tooltip" class="my-header2">col2</th>
        </tr>
    </thead>
    <tfoot>
        <tr>
            <td style="font-size: 8px" class="my-footer">footer</td>
            <td></td>
        </tr>
    </tfoot>
    <tbody>
        <tr>
            <td>one1</td>
            <td>one2</td>
        </tr>
        <tr>
            <td>two1</td>
            <td>two2</td>
        </tr>
        <tr>
            <td>three1</td>
            <td>three2</td>
        </tr>
    </tbody>
</table>
```

