### PR TITLE
Fix #5721 prefer extension fallback for exact mappings

### DIFF
--- a/impl/src/main/java/com/sun/faces/util/Util.java
+++ b/impl/src/main/java/com/sun/faces/util/Util.java
@@ -1081,35 +1081,52 @@ public class Util {
         // If needed, cache this after initialization of Faces
         Object context = externalContext.getContext();
         if (context instanceof ServletContext) {
-            return getFacesServletMappings((ServletContext) context).stream()
-                    .filter(mapping -> mapping.contains("*"))
-                    .map(mapping -> new HttpServletMapping() {
+            HttpServletMapping pathMapping = null;
 
-                        @Override
-                        public String getServletName() {
-                            return "";
-                        }
+            for (String mapping : getFacesServletMappings((ServletContext) context)) {
+                if (!mapping.contains("*")) {
+                    continue;
+                }
 
-                        @Override
-                        public String getPattern() {
-                            return mapping;
-                        }
+                HttpServletMapping wildcardMapping = toWildcardMapping(mapping);
+                if (wildcardMapping.getMappingMatch() == MappingMatch.EXTENSION) {
+                    return wildcardMapping;
+                }
 
-                        @Override
-                        public String getMatchValue() {
-                            return null;
-                        }
+                if (pathMapping == null) {
+                    pathMapping = wildcardMapping;
+                }
+            }
 
-                        @Override
-                        public MappingMatch getMappingMatch() {
-                            return isPrefixMapped(mapping)? MappingMatch.PATH : MappingMatch.EXTENSION;
-                        }
-                    })
-                    .findFirst()
-                    .orElse(null);
+            return pathMapping;
         }
 
         return null;
+    }
+
+    private static HttpServletMapping toWildcardMapping(String mapping) {
+        return new HttpServletMapping() {
+
+            @Override
+            public String getServletName() {
+                return "";
+            }
+
+            @Override
+            public String getPattern() {
+                return mapping;
+            }
+
+            @Override
+            public String getMatchValue() {
+                return null;
+            }
+
+            @Override
+            public MappingMatch getMappingMatch() {
+                return isPrefixMapped(mapping) ? MappingMatch.PATH : MappingMatch.EXTENSION;
+            }
+        };
     }
 
     /**

--- a/impl/src/test/java/com/sun/faces/application/resource/ResourceImplTest.java
+++ b/impl/src/test/java/com/sun/faces/application/resource/ResourceImplTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.application.resource;
+
+import static jakarta.faces.application.ProjectStage.Development;
+import static jakarta.faces.application.ResourceHandler.FACES_SCRIPT_LIBRARY_NAME;
+import static jakarta.faces.application.ResourceHandler.FACES_SCRIPT_RESOURCE_NAME;
+import static jakarta.faces.application.ResourceHandler.RESOURCE_IDENTIFIER;
+import static jakarta.servlet.http.MappingMatch.EXACT;
+import static jakarta.servlet.http.MappingMatch.EXTENSION;
+import static jakarta.servlet.http.MappingMatch.PATH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.InputStream;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.faces.junit.JUnitFacesTestCaseBase;
+import com.sun.faces.mock.MockApplication;
+import com.sun.faces.mock.MockFacesMappingSupport;
+
+import jakarta.faces.context.FacesContext;
+
+public class ResourceImplTest extends JUnitFacesTestCaseBase {
+
+    private static final String CONTEXT_PATH = "/app";
+    private static final ResourceHelper RESOURCE_HELPER = new ResourceHelper() {
+
+        @Override
+        public String getBaseResourcePath() {
+            return "/resources";
+        }
+
+        @Override
+        public String getBaseContractsPath() {
+            return "/contracts";
+        }
+
+        @Override
+        public URL getURL(ResourceInfo resource, FacesContext ctx) {
+            return null;
+        }
+
+        @Override
+        public LibraryInfo findLibrary(String libraryName, String localePrefix, String contract, FacesContext ctx) {
+            return null;
+        }
+
+        @Override
+        public ResourceInfo findResource(LibraryInfo library, String resourceName, String localePrefix, boolean compressable, FacesContext ctx) {
+            return null;
+        }
+
+        @Override
+        protected InputStream getNonCompressedInputStream(ResourceInfo resource, FacesContext ctx) {
+            return null;
+        }
+    };
+
+    @Test
+    public void getRequestPathReturnsExactHitForExactMappedResource() {
+        configureRequest(MockFacesMappingSupport.mapping(EXACT, "/exact", "exact"), "/exact", RESOURCE_IDENTIFIER + "/theme.css", "*.xhtml", "/faces/*");
+
+        assertEquals("/app/jakarta.faces.resource/theme.css", createResource("theme.css", null, null, null, null, null).getRequestPath());
+    }
+
+    @Test
+    public void getRequestPathKeepsExtensionFallbackForExactRequests() {
+        ResourceImpl resource = createResource("theme.css", null, null, null, null, null);
+
+        configureRequest(MockFacesMappingSupport.mapping(EXACT, "/exact", "exact"), "/exact", "*.xhtml");
+        String exactRequestPath = resource.getRequestPath();
+
+        configureRequest(MockFacesMappingSupport.mapping(EXTENSION, "*.xhtml", "theme"), "/exact", "*.xhtml");
+        String extensionBaselinePath = resource.getRequestPath();
+
+        assertEquals("/app/jakarta.faces.resource/theme.css.xhtml", exactRequestPath);
+        assertEquals(extensionBaselinePath, exactRequestPath);
+    }
+
+    @Test
+    public void getRequestPathKeepsDirectPathBehavior() {
+        ResourceImpl resource = createResource("theme.css", "layout", "1_0", null, "en", "blue");
+
+        configureRequest(MockFacesMappingSupport.mapping(PATH, "/faces/*", "theme"), "/exact", "/faces/*");
+        String directPathRequestPath = resource.getRequestPath();
+
+        assertEquals("/app/faces/jakarta.faces.resource/theme.css?ln=layout&v=1_0&loc=en&con=blue", directPathRequestPath);
+    }
+
+    @Test
+    public void getRequestPathPrefersExtensionFallbackWhenBothWildcardsExist() {
+        ResourceImpl resource = createResource("theme.css", "layout", "1_0", null, "en", "blue");
+
+        configureRequest(MockFacesMappingSupport.mapping(EXACT, "/exact", "exact"), "/exact", "*.jsf", "/faces/*");
+        String exactRequestPath = resource.getRequestPath();
+
+        assertEquals("/app/jakarta.faces.resource/theme.css.jsf?ln=layout&v=1_0&loc=en&con=blue", exactRequestPath);
+        assertEquals(exactRequestPath.indexOf("ln="), exactRequestPath.lastIndexOf("ln="));
+        assertEquals(exactRequestPath.indexOf("v="), exactRequestPath.lastIndexOf("v="));
+        assertEquals(exactRequestPath.indexOf("loc="), exactRequestPath.lastIndexOf("loc="));
+        assertEquals(exactRequestPath.indexOf("con="), exactRequestPath.lastIndexOf("con="));
+    }
+
+    @Test
+    public void getRequestPathPrefersExtensionFallbackForFacesScriptInDevelopment() {
+        MockApplication developmentApplication = new MockApplication() {
+
+            @Override
+            public jakarta.faces.application.ProjectStage getProjectStage() {
+                return Development;
+            }
+        };
+        developmentApplication.setViewHandler(application.getViewHandler());
+        application = developmentApplication;
+        facesContext.setApplication(application);
+
+        ResourceImpl resource = createResource(FACES_SCRIPT_RESOURCE_NAME, FACES_SCRIPT_LIBRARY_NAME, null, null, null, null);
+
+        configureRequest(MockFacesMappingSupport.mapping(EXACT, "/exact", "exact"), "/exact", "*.jsf", "/faces/*");
+        String exactRequestPath = resource.getRequestPath();
+
+        assertEquals("/app/jakarta.faces.resource/faces.js.jsf?ln=jakarta.faces&stage=Development", exactRequestPath);
+    }
+
+    @Test
+    public void getRequestPathThrowsWhenNoWildcardFallbackExists() {
+        configureRequest(MockFacesMappingSupport.mapping(EXACT, "/exact", "exact"), "/exact");
+
+        assertThrows(IllegalStateException.class, () -> createResource("theme.css", null, null, null, null, null).getRequestPath());
+    }
+
+    private void configureRequest(jakarta.servlet.http.HttpServletMapping mapping, String... servletMappings) {
+        request = MockFacesMappingSupport.request(CONTEXT_PATH, mapping, session);
+        externalContext = MockFacesMappingSupport.externalContext(servletContext, request, response);
+        facesContext.setExternalContext(externalContext);
+        MockFacesMappingSupport.setFacesServletMappings(servletContext, servletMappings);
+    }
+
+    private ResourceImpl createResource(String resourceName, String libraryName, String libraryVersion, String resourceVersion, String localePrefix, String contract) {
+        ContractInfo contractInfo = contract != null ? new ContractInfo(contract) : null;
+        VersionInfo libraryVersionInfo = libraryVersion != null ? new VersionInfo(libraryVersion, null) : null;
+        VersionInfo resourceVersionInfo = resourceVersion != null ? new VersionInfo(resourceVersion, extensionOf(resourceName)) : null;
+
+        ResourceInfo resourceInfo;
+        if (libraryName != null) {
+            LibraryInfo libraryInfo = new LibraryInfo(libraryName, libraryVersionInfo, localePrefix, contract, RESOURCE_HELPER);
+            resourceInfo = new ResourceInfo(libraryInfo, contractInfo, resourceName, resourceVersionInfo);
+        } else {
+            resourceInfo = new ResourceInfo(contractInfo, resourceName, resourceVersionInfo, RESOURCE_HELPER);
+        }
+
+        return new ResourceImpl(resourceInfo, "text/css", 0, 0);
+    }
+
+    private String extensionOf(String resourceName) {
+        int extensionIndex = resourceName.lastIndexOf('.');
+        return extensionIndex >= 0 ? resourceName.substring(extensionIndex + 1) : null;
+    }
+}

--- a/impl/src/test/java/com/sun/faces/application/view/MultiViewHandlerTest.java
+++ b/impl/src/test/java/com/sun/faces/application/view/MultiViewHandlerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.application.view;
+
+import static jakarta.servlet.http.MappingMatch.EXACT;
+import static jakarta.servlet.http.MappingMatch.EXTENSION;
+import static jakarta.servlet.http.MappingMatch.PATH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sun.faces.junit.JUnitFacesTestCaseBase;
+import com.sun.faces.mock.MockFacesMappingSupport;
+
+import jakarta.faces.FactoryFinder;
+
+public class MultiViewHandlerTest extends JUnitFacesTestCaseBase {
+
+    private static final String CONTEXT_PATH = "/app";
+
+    private MultiViewHandler viewHandler;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        FactoryFinder.setFactory(FactoryFinder.VIEW_DECLARATION_LANGUAGE_FACTORY, ViewDeclarationLanguageFactoryImpl.class.getName());
+        viewHandler = new MultiViewHandler();
+    }
+
+    @Test
+    public void getActionURLReturnsExactHitForConfiguredFaceletsExtension() {
+        configureRequest(MockFacesMappingSupport.mapping(EXACT, "/exact", "exact"), "/exact", "/target", "*.xhtml", "/faces/*");
+
+        assertEquals("/app/target", viewHandler.getActionURL(facesContext, "/target.xhtml"));
+    }
+
+    @Test
+    public void getActionURLKeepsExtensionFallbackForExactRequests() {
+        configureRequest(MockFacesMappingSupport.mapping(EXACT, "/exact", "exact"), "/exact", "*.xhtml");
+        String exactRequestUrl = viewHandler.getActionURL(facesContext, "/fallback.xhtml");
+
+        configureRequest(MockFacesMappingSupport.mapping(EXTENSION, "*.xhtml", "fallback"), "/exact", "*.xhtml");
+        String extensionBaselineUrl = viewHandler.getActionURL(facesContext, "/fallback.xhtml");
+
+        assertEquals("/app/fallback.xhtml", exactRequestUrl);
+        assertEquals(extensionBaselineUrl, exactRequestUrl);
+    }
+
+    @Test
+    public void getActionURLKeepsDirectPathBehavior() {
+        configureRequest(MockFacesMappingSupport.mapping(PATH, "/faces/*", "fallback"), "/exact", "/faces/*");
+
+        assertEquals("/app/faces/fallback.xhtml", viewHandler.getActionURL(facesContext, "/fallback.xhtml"));
+    }
+
+    @Test
+    public void getActionURLPrefersExtensionFallbackWhenBothWildcardsExist() {
+        configureRequest(MockFacesMappingSupport.mapping(EXACT, "/exact", "exact"), "/exact", "*.jsf", "/faces/*");
+
+        String exactRequestUrl = viewHandler.getActionURL(facesContext, "/fallback.xhtml");
+
+        assertEquals("/app/fallback.jsf", exactRequestUrl);
+    }
+
+    @Test
+    public void getActionURLThrowsWhenNoWildcardFallbackExists() {
+        configureRequest(MockFacesMappingSupport.mapping(EXACT, "/exact", "exact"), "/exact");
+
+        assertThrows(IllegalStateException.class, () -> viewHandler.getActionURL(facesContext, "/fallback.xhtml"));
+    }
+
+    private void configureRequest(jakarta.servlet.http.HttpServletMapping mapping, String... servletMappings) {
+        request = MockFacesMappingSupport.request(CONTEXT_PATH, mapping, session);
+        externalContext = MockFacesMappingSupport.externalContext(servletContext, request, response);
+        facesContext.setExternalContext(externalContext);
+        MockFacesMappingSupport.setFacesServletMappings(servletContext, servletMappings);
+    }
+}

--- a/impl/src/test/java/com/sun/faces/mock/MockFacesMappingSupport.java
+++ b/impl/src/test/java/com/sun/faces/mock/MockFacesMappingSupport.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.mock;
+
+import static com.sun.faces.RIConstants.FACES_SERVLET_MAPPINGS;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+
+import jakarta.servlet.http.HttpServletMapping;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.MappingMatch;
+
+public final class MockFacesMappingSupport {
+
+    private MockFacesMappingSupport() {
+    }
+
+    public static MockHttpServletRequest request(String contextPath, HttpServletMapping mapping, HttpSession session) {
+        return new MappingHttpServletRequest(contextPath, mapping, session);
+    }
+
+    public static MockExternalContext externalContext(MockServletContext servletContext, MockHttpServletRequest request, MockHttpServletResponse response) {
+        return new MappingExternalContext(servletContext, request, response);
+    }
+
+    public static void setFacesServletMappings(MockServletContext servletContext, String... mappings) {
+        servletContext.setAttribute(FACES_SERVLET_MAPPINGS, new LinkedHashSet<>(Arrays.asList(mappings)));
+    }
+
+    public static HttpServletMapping mapping(MappingMatch match, String pattern, String matchValue) {
+        return new HttpServletMapping() {
+
+            @Override
+            public String getMatchValue() {
+                return matchValue;
+            }
+
+            @Override
+            public String getPattern() {
+                return pattern;
+            }
+
+            @Override
+            public String getServletName() {
+                return "FacesServlet";
+            }
+
+            @Override
+            public MappingMatch getMappingMatch() {
+                return match;
+            }
+        };
+    }
+
+    private static final class MappingHttpServletRequest extends MockHttpServletRequest {
+
+        private final HttpServletMapping mapping;
+
+        private MappingHttpServletRequest(String contextPath, HttpServletMapping mapping, HttpSession session) {
+            super(session);
+            this.mapping = mapping;
+            setPathElements(contextPath, mapping.getPattern(), null, null);
+        }
+
+        @Override
+        public HttpServletMapping getHttpServletMapping() {
+            return mapping;
+        }
+    }
+
+    private static final class MappingExternalContext extends MockExternalContext {
+
+        private final MockHttpServletRequest request;
+
+        private MappingExternalContext(MockServletContext servletContext, MockHttpServletRequest request, MockHttpServletResponse response) {
+            super(servletContext, request, response);
+            this.request = request;
+        }
+
+        @Override
+        public String getRequestContextPath() {
+            return request.getContextPath();
+        }
+
+        @Override
+        public String getRequestPathInfo() {
+            return request.getPathInfo();
+        }
+
+        @Override
+        public String getRequestServletPath() {
+            return request.getServletPath();
+        }
+
+        @Override
+        public String encodeActionURL(String url) {
+            return url;
+        }
+
+        @Override
+        public String encodeResourceURL(String url) {
+            return url;
+        }
+    }
+}


### PR DESCRIPTION
 Fixes #5721.

  ## Problem

  When the current request is exact mapped, Mojarra falls back to a wildcard Faces servlet mapping when it needs to generate action URLs or resource URLs.

  Today that fallback effectively depends on the first wildcard mapping Mojarra finds. If an application defines both an extension mapping and a path mapping, that can generate the wrong fallback URL based on declaration order.

  ## Change

  When the current request is exact mapped and Mojarra needs a wildcard fallback:

  - prefer an extension mapping if one exists
  - otherwise keep the existing path-mapping fallback
  - keep the existing failure behavior when no wildcard fallback exists

  ## Why

  This keeps exact-mapped fallback behavior aligned with extension-mapped Faces URL generation instead of letting declaration order choose the wrong wildcard mapping.

  ## Files

  - `impl/src/main/java/com/sun/faces/util/Util.java`
  - `impl/src/test/java/com/sun/faces/application/view/MultiViewHandlerTest.java`
  - `impl/src/test/java/com/sun/faces/application/resource/ResourceImplTest.java`
  - `impl/src/test/java/com/sun/faces/mock/MockFacesMappingSupport.java`

  ## Validation

  Added unit coverage for:

  - exact request + extension fallback
  - exact request + path fallback
  - exact request + both wildcard mappings present
  - exact request + no wildcard fallback
  - resource URL query parameter stability

  This is also the behavior that unblocked the exact-mapping Faces TCK case we were debugging:

  - `ee.jakarta.tck.faces.test.servlet40.exactmapping_selenium.Spec1260IT`

  ## Scope

  This PR is intentionally limited to exact-mapping fallback selection.
