### PR TITLE
Fix #5723 restore inline behavior handlers when CSP is not active

### DIFF
--- a/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
@@ -425,7 +425,8 @@ public class RenderKitUtils {
             ? Collections.singletonList(new ClientBehaviorContext.Parameter("incExec", true))
             : Collections.emptyList();
 
-        addBehaviorEventListener(context, component, clientId, params, handlerName, userHandler, behaviorEventName, domEventName, null, false, incExec, true);
+        addBehaviorEventListener(context, component, clientId, params, handlerName, userHandler, behaviorEventName, domEventName, null, false, incExec,
+                ResourceHandlerImpl.resolveCurrentNonce(context) != null, true);
     }
 
     // Renders the onclick event listener for command buttons. Handles
@@ -451,7 +452,8 @@ public class RenderKitUtils {
             }
         }
 
-        addBehaviorEventListener(context, component, null, params, handlerName, userHandler, behaviorEventName, domEventName, submitTarget, needsSubmit, false, true);
+        addBehaviorEventListener(context, component, null, params, handlerName, userHandler, behaviorEventName, domEventName, submitTarget, needsSubmit, false,
+                ResourceHandlerImpl.resolveCurrentNonce(context) != null, true);
 
     }
 
@@ -656,7 +658,8 @@ public class RenderKitUtils {
                     Attribute attr = knownAttributes[index];
 
                     if (isBehaviorEventAttribute(attr, behaviorEventName)) {
-                        addBehaviorEventListener(context, component, null, null, name, value, behaviorEventName, behaviorEventName, null, false, false, false);
+                        addBehaviorEventListener(context, component, null, null, name, value, behaviorEventName, behaviorEventName, null, false, false,
+                                ResourceHandlerImpl.resolveCurrentNonce(context) != null, false);
 
                         renderedBehavior = true;
                     } else {
@@ -668,7 +671,8 @@ public class RenderKitUtils {
                 Object value = attrMap.get(name);
                 if (value != null && shouldRenderAttribute(value)) {
                     if (name.substring(2).equals(behaviorEventName)) {
-                        addBehaviorEventListener(context, component, null, null, name, value, behaviorEventName, behaviorEventName, null, false, false, false);
+                        addBehaviorEventListener(context, component, null, null, name, value, behaviorEventName, behaviorEventName, null, false, false,
+                                ResourceHandlerImpl.resolveCurrentNonce(context) != null, false);
 
                         renderedBehavior = true;
                     } else {
@@ -699,7 +703,8 @@ public class RenderKitUtils {
                 String attrName = attribute.getName();
                 String[] events = attribute.getEvents();
                 if (events != null && events.length > 0 && behaviorEventName.equals(events[0])) {
-                    addBehaviorEventListener(context, component, null, null, attrName, null, behaviorEventName, behaviorEventName, null, false, false, false);
+                    addBehaviorEventListener(context, component, null, null, attrName, null, behaviorEventName, behaviorEventName, null, false, false,
+                            ResourceHandlerImpl.resolveCurrentNonce(context) != null, false);
                     return;
                 }
             }
@@ -761,7 +766,8 @@ public class RenderKitUtils {
             // If we've got a behavior for this attribute,
             // we may need to chain scripts together, so use
             // renderEventListener().
-            addBehaviorEventListener(context, component, null, null, attrName, value, eventName, eventName, null, false, false, false);
+            addBehaviorEventListener(context, component, null, null, attrName, value, eventName, eventName, null, false, false,
+                    ResourceHandlerImpl.resolveCurrentNonce(context) != null, false);
         }
     }
 
@@ -1671,7 +1677,8 @@ public class RenderKitUtils {
      * render the submit script to make the link submit.
      */
     private static void addBehaviorEventListener(FacesContext context, UIComponent component, String clientId, Collection<ClientBehaviorContext.Parameter> params, String handlerName,
-            Object handlerValue, String behaviorEventName, String domEventName, String submitTarget, boolean needsSubmit, boolean includeExec, boolean flushPendingBehaviorEventListeners) throws IOException {
+            Object handlerValue, String behaviorEventName, String domEventName, String submitTarget, boolean needsSubmit, boolean includeExec,
+            boolean renderAsEventListener, boolean flushPendingBehaviorEventListeners) throws IOException {
 
         String userHandler = getNonEmptyUserHandler(handlerValue);
         List<ClientBehavior> behaviors = getClientBehaviors(component, behaviorEventName);
@@ -1703,6 +1710,13 @@ public class RenderKitUtils {
                 break;
             default:
                 assert false;
+        }
+
+        if (!renderAsEventListener) {
+            if (handler != null) {
+                context.getResponseWriter().writeAttribute(handlerName, handler, null);
+            }
+            return;
         }
 
         if (flushPendingBehaviorEventListeners) {

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/ButtonRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/ButtonRenderer.java
@@ -31,6 +31,7 @@ import jakarta.faces.context.ResponseWriter;
 import jakarta.faces.event.ActionEvent;
 
 import com.sun.faces.RIConstants;
+import com.sun.faces.application.resource.ResourceHandlerImpl;
 import com.sun.faces.renderkit.Attribute;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
@@ -125,6 +126,10 @@ public class ButtonRenderer extends HtmlBasicRenderer {
             writer.writeAttribute("class", styleClass, "styleClass");
         }
 
+        if (ResourceHandlerImpl.resolveCurrentNonce(context) == null) {
+            RenderKitUtils.renderOnclickEventListener(context, component, getBehaviorParameters(component), null, false);
+        }
+
         // PENDING(edburns): Prior to i_spec_1111, this element
         // was rendered unconditionally
 
@@ -152,7 +157,9 @@ public class ButtonRenderer extends HtmlBasicRenderer {
             RenderKitUtils.renderFacesJsIfNecessary(context);
         }
 
-        RenderKitUtils.renderOnclickEventListener(context, component, params, null, false);
+        if (ResourceHandlerImpl.resolveCurrentNonce(context) != null) {
+            RenderKitUtils.renderOnclickEventListener(context, component, params, null, false);
+        }
     }
 
     // --------------------------------------------------------- Private Methods

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/CommandLinkRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/CommandLinkRenderer.java
@@ -30,6 +30,7 @@ import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
 import jakarta.faces.event.ActionEvent;
 
+import com.sun.faces.application.resource.ResourceHandlerImpl;
 import com.sun.faces.renderkit.Attribute;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
@@ -120,14 +121,16 @@ public class CommandLinkRenderer extends LinkRenderer {
         } else {
             writer.endElement("a");
 
-            String target = (String) component.getAttributes().get("target");
-            if (target != null) {
-                target = target.trim();
-            } else {
-                target = "";
+            if (ResourceHandlerImpl.resolveCurrentNonce(context) != null) {
+                String target = (String) component.getAttributes().get("target");
+                if (target != null) {
+                    target = target.trim();
+                } else {
+                    target = "";
+                }
+                Collection<ClientBehaviorContext.Parameter> params = getBehaviorParameters(component);
+                RenderKitUtils.renderOnclickEventListener(context, component, params, target, true);
             }
-            Collection<ClientBehaviorContext.Parameter> params = getBehaviorParameters(component);
-            RenderKitUtils.renderOnclickEventListener(context, component, params, target, true);
         }
     }
 
@@ -164,6 +167,18 @@ public class CommandLinkRenderer extends LinkRenderer {
         RenderKitUtils.renderPassThruAttributes(context, writer, command, null, false, ATTRIBUTES, "click", "action");
 
         RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, command);
+
+        if (ResourceHandlerImpl.resolveCurrentNonce(context) == null) {
+            String target = (String) command.getAttributes().get("target");
+            if (target != null) {
+                target = target.trim();
+            } else {
+                target = "";
+            }
+
+            Collection<ClientBehaviorContext.Parameter> params = getBehaviorParameters(command);
+            RenderKitUtils.renderOnclickEventListener(context, command, params, target, true);
+        }
 
         writeCommonLinkAttributes(writer, command);
 

--- a/test/issue5606/pom.xml
+++ b/test/issue5606/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.mojarra.test</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.1.8-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>issue5606</artifactId>
+    <packaging>war</packaging>
+
+    <name>Mojarra ${project.version} - INTEGRATION TESTS - ${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.mojarra.test</groupId>
+            <artifactId>base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/test/issue5606/src/main/webapp/WEB-INF/beans.xml
+++ b/test/issue5606/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/test/issue5606/src/main/webapp/WEB-INF/web.xml
+++ b/test/issue5606/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+    version="5.0"
+>
+    <servlet>
+        <servlet-name>facesServlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>facesServlet</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/test/issue5606/src/main/webapp/issue5606.xhtml
+++ b/test/issue5606/src/main/webapp/issue5606.xhtml
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="en"
+    xmlns:f="jakarta.faces.core"
+    xmlns:h="jakarta.faces.html"
+>
+    <h:head>
+        <title>issue5606</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <h:commandLink id="link" value="commandLink" />
+            <h:outputText id="executed" value="#{not empty param['form:link']}" />
+            <h:commandButton id="ajaxButton" value="ajaxButton">
+                <f:ajax render="ajaxExecuted" />
+            </h:commandButton>
+            <h:panelGroup id="ajaxExecuted">
+                <h:outputText value="#{facesContext.partialViewContext.ajaxRequest ? 'true' : 'false'}" />
+            </h:panelGroup>
+        </h:form>
+    </h:body>
+</html>

--- a/test/issue5606/src/test/java/org/eclipse/mojarra/test/issue5606/Issue5606IT.java
+++ b/test/issue5606/src/test/java/org/eclipse/mojarra/test/issue5606/Issue5606IT.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package org.eclipse.mojarra.test.issue5606;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.mojarra.test.base.BaseIT;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+class Issue5606IT extends BaseIT {
+
+    @FindBy(id = "form:link")
+    private WebElement link;
+
+    @FindBy(id = "form:ajaxButton")
+    private WebElement ajaxButton;
+
+    @FindBy(id = "form:executed")
+    private WebElement executed;
+
+    @FindBy(id = "form:ajaxExecuted")
+    private WebElement ajaxExecuted;
+
+    /**
+     * https://github.com/eclipse-ee4j/mojarra/issues/5606
+     */
+    @Test
+    void testCommandLinkRendersInlineOnclickWithoutCsp() {
+        open("issue5606.xhtml");
+
+        String onclick = link.getDomAttribute("onclick");
+        assertNotNull(onclick);
+        assertTrue(onclick.contains("mojarra.cljs"), onclick);
+
+        String responseBody = getResponseBody("issue5606.xhtml");
+        assertTrue(responseBody.contains("onclick="), responseBody);
+        assertTrue(!responseBody.contains("mojarra.ael('form:link','click'"), responseBody);
+    }
+
+    /**
+     * https://github.com/eclipse-ee4j/mojarra/issues/5606
+     */
+    @Test
+    void testCommandLinkClickStillWorksWithoutCsp() {
+        open("issue5606.xhtml");
+        guardHttp(link::click);
+        assertEquals("true", executed.getText());
+    }
+
+    /**
+     * https://github.com/eclipse-ee4j/mojarra/issues/5606
+     */
+    @Test
+    void testCommandButtonAjaxRendersInlineOnclickWithoutCsp() {
+        open("issue5606.xhtml");
+
+        String onclick = ajaxButton.getDomAttribute("onclick");
+        assertNotNull(onclick);
+        assertTrue(onclick.contains("mojarra.ab"), onclick);
+
+        String responseBody = getResponseBody("issue5606.xhtml");
+        assertTrue(responseBody.contains("id=\"form:ajaxButton\""), responseBody);
+        assertTrue(responseBody.contains("onclick="), responseBody);
+        assertTrue(!responseBody.contains("mojarra.ael('form:ajaxButton','click'"), responseBody);
+    }
+
+    /**
+     * https://github.com/eclipse-ee4j/mojarra/issues/5606
+     */
+    @Test
+    void testCommandButtonAjaxClickStillWorksWithoutCsp() {
+        open("issue5606.xhtml");
+        guardAjax(ajaxButton::click);
+        assertEquals("true", ajaxExecuted.getText());
+    }
+}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -50,6 +50,7 @@
         <module>issue5584</module>
         <module>issue5594</module>
         <module>issue5596</module>
+        <module>issue5606</module>
         <module>issue5663</module>
         <module>issue5676</module>
     </modules>


### PR DESCRIPTION
• Fixes #5723.

## Problem

Recent behavior-listener rendering changes regressed non-CSP command component output.

When CSP nonce support is not active, Mojarra should still render the inline `onclick` hooks used by command components such as:

- `h:commandLink`
- `h:commandButton` with `f:ajax`

Instead, behavior attachment can move to the CSP-style listener path even when no CSP nonce is active, which suppresses the inline `onclick` markup.

## Change

- keep CSP behavior-script rendering when a nonce is active
- restore inline `onclick` rendering when CSP nonce support is not active

## Why

This preserves the CSP-safe listener model for nonce-enabled pages without regressing the existing non-CSP command component behavior.

## Files

- `impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java`
- `impl/src/main/java/com/sun/faces/renderkit/html_basic/ButtonRenderer.java`
- `impl/src/main/java/com/sun/faces/renderkit/html_basic/CommandLinkRenderer.java`
- `test/pom.xml`
- `test/issue5606/**`

## Validation

Added `test/issue5606` integration coverage for:

- commandLink renders inline `onclick` without CSP
- commandLink click still works without CSP
- ajax command button renders inline `onclick` without CSP
- ajax command button click still works without CSP

Existing CSP coverage remains separate in `test/csp`.

With #5722 and this fix, WebLogic Server was able to pass the latest Faces TCK 4.1.2

## Scope

This PR is intentionally limited to the non-CSP renderer regression.

It does not include the separate exact-mapping fallback fix from #5721.
