### PR TITLE
4.1.8 has been released

### DIFF
--- a/action/pom.xml
+++ b/action/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>

--- a/action/pom.xml
+++ b/action/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>

--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>

--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -29,7 +29,7 @@
    <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
    <artifactId>jakarta.faces</artifactId>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -29,7 +29,7 @@
    <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
    <artifactId>jakarta.faces</artifactId>

--- a/impl/src/main/java/com/sun/faces/util/Util.java
+++ b/impl/src/main/java/com/sun/faces/util/Util.java
@@ -1081,35 +1081,52 @@ public class Util {
         // If needed, cache this after initialization of Faces
         Object context = externalContext.getContext();
         if (context instanceof ServletContext) {
-            return getFacesServletMappings((ServletContext) context).stream()
-                    .filter(mapping -> mapping.contains("*"))
-                    .map(mapping -> new HttpServletMapping() {
+            HttpServletMapping pathMapping = null;
 
-                        @Override
-                        public String getServletName() {
-                            return "";
-                        }
+            for (String mapping : getFacesServletMappings((ServletContext) context)) {
+                if (!mapping.contains("*")) {
+                    continue;
+                }
 
-                        @Override
-                        public String getPattern() {
-                            return mapping;
-                        }
+                HttpServletMapping wildcardMapping = toWildcardMapping(mapping);
+                if (wildcardMapping.getMappingMatch() == MappingMatch.EXTENSION) {
+                    return wildcardMapping;
+                }
 
-                        @Override
-                        public String getMatchValue() {
-                            return null;
-                        }
+                if (pathMapping == null) {
+                    pathMapping = wildcardMapping;
+                }
+            }
 
-                        @Override
-                        public MappingMatch getMappingMatch() {
-                            return isPrefixMapped(mapping)? MappingMatch.PATH : MappingMatch.EXTENSION;
-                        }
-                    })
-                    .findFirst()
-                    .orElse(null);
+            return pathMapping;
         }
 
         return null;
+    }
+
+    private static HttpServletMapping toWildcardMapping(String mapping) {
+        return new HttpServletMapping() {
+
+            @Override
+            public String getServletName() {
+                return "";
+            }
+
+            @Override
+            public String getPattern() {
+                return mapping;
+            }
+
+            @Override
+            public String getMatchValue() {
+                return null;
+            }
+
+            @Override
+            public MappingMatch getMappingMatch() {
+                return isPrefixMapped(mapping) ? MappingMatch.PATH : MappingMatch.EXTENSION;
+            }
+        };
     }
 
     /**

--- a/impl/src/test/java/com/sun/faces/application/resource/ResourceImplTest.java
+++ b/impl/src/test/java/com/sun/faces/application/resource/ResourceImplTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.application.resource;
+
+import static jakarta.faces.application.ProjectStage.Development;
+import static jakarta.faces.application.ResourceHandler.FACES_SCRIPT_LIBRARY_NAME;
+import static jakarta.faces.application.ResourceHandler.FACES_SCRIPT_RESOURCE_NAME;
+import static jakarta.faces.application.ResourceHandler.RESOURCE_IDENTIFIER;
+import static jakarta.servlet.http.MappingMatch.EXACT;
+import static jakarta.servlet.http.MappingMatch.EXTENSION;
+import static jakarta.servlet.http.MappingMatch.PATH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.InputStream;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.faces.junit.JUnitFacesTestCaseBase;
+import com.sun.faces.mock.MockApplication;
+import com.sun.faces.mock.MockFacesMappingSupport;
+
+import jakarta.faces.context.FacesContext;
+
+public class ResourceImplTest extends JUnitFacesTestCaseBase {
+
+    private static final String CONTEXT_PATH = "/app";
+    private static final ResourceHelper RESOURCE_HELPER = new ResourceHelper() {
+
+        @Override
+        public String getBaseResourcePath() {
+            return "/resources";
+        }
+
+        @Override
+        public String getBaseContractsPath() {
+            return "/contracts";
+        }
+
+        @Override
+        public URL getURL(ResourceInfo resource, FacesContext ctx) {
+            return null;
+        }
+
+        @Override
+        public LibraryInfo findLibrary(String libraryName, String localePrefix, String contract, FacesContext ctx) {
+            return null;
+        }
+
+        @Override
+        public ResourceInfo findResource(LibraryInfo library, String resourceName, String localePrefix, boolean compressable, FacesContext ctx) {
+            return null;
+        }
+
+        @Override
+        protected InputStream getNonCompressedInputStream(ResourceInfo resource, FacesContext ctx) {
+            return null;
+        }
+    };
+
+    @Test
+    public void getRequestPathReturnsExactHitForExactMappedResource() {
+        configureRequest(MockFacesMappingSupport.mapping(EXACT, "/exact", "exact"), "/exact", RESOURCE_IDENTIFIER + "/theme.css", "*.xhtml", "/faces/*");
+
+        assertEquals("/app/jakarta.faces.resource/theme.css", createResource("theme.css", null, null, null, null, null).getRequestPath());
+    }
+
+    @Test
+    public void getRequestPathKeepsExtensionFallbackForExactRequests() {
+        ResourceImpl resource = createResource("theme.css", null, null, null, null, null);
+
+        configureRequest(MockFacesMappingSupport.mapping(EXACT, "/exact", "exact"), "/exact", "*.xhtml");
+        String exactRequestPath = resource.getRequestPath();
+
+        configureRequest(MockFacesMappingSupport.mapping(EXTENSION, "*.xhtml", "theme"), "/exact", "*.xhtml");
+        String extensionBaselinePath = resource.getRequestPath();
+
+        assertEquals("/app/jakarta.faces.resource/theme.css.xhtml", exactRequestPath);
+        assertEquals(extensionBaselinePath, exactRequestPath);
+    }
+
+    @Test
+    public void getRequestPathKeepsDirectPathBehavior() {
+        ResourceImpl resource = createResource("theme.css", "layout", "1_0", null, "en", "blue");
+
+        configureRequest(MockFacesMappingSupport.mapping(PATH, "/faces/*", "theme"), "/exact", "/faces/*");
+        String directPathRequestPath = resource.getRequestPath();
+
+        assertEquals("/app/faces/jakarta.faces.resource/theme.css?ln=layout&v=1_0&loc=en&con=blue", directPathRequestPath);
+    }
+
+    @Test
+    public void getRequestPathPrefersExtensionFallbackWhenBothWildcardsExist() {
+        ResourceImpl resource = createResource("theme.css", "layout", "1_0", null, "en", "blue");
+
+        configureRequest(MockFacesMappingSupport.mapping(EXACT, "/exact", "exact"), "/exact", "*.jsf", "/faces/*");
+        String exactRequestPath = resource.getRequestPath();
+
+        assertEquals("/app/jakarta.faces.resource/theme.css.jsf?ln=layout&v=1_0&loc=en&con=blue", exactRequestPath);
+        assertEquals(exactRequestPath.indexOf("ln="), exactRequestPath.lastIndexOf("ln="));
+        assertEquals(exactRequestPath.indexOf("v="), exactRequestPath.lastIndexOf("v="));
+        assertEquals(exactRequestPath.indexOf("loc="), exactRequestPath.lastIndexOf("loc="));
+        assertEquals(exactRequestPath.indexOf("con="), exactRequestPath.lastIndexOf("con="));
+    }
+
+    @Test
+    public void getRequestPathPrefersExtensionFallbackForFacesScriptInDevelopment() {
+        MockApplication developmentApplication = new MockApplication() {
+
+            @Override
+            public jakarta.faces.application.ProjectStage getProjectStage() {
+                return Development;
+            }
+        };
+        developmentApplication.setViewHandler(application.getViewHandler());
+        application = developmentApplication;
+        facesContext.setApplication(application);
+
+        ResourceImpl resource = createResource(FACES_SCRIPT_RESOURCE_NAME, FACES_SCRIPT_LIBRARY_NAME, null, null, null, null);
+
+        configureRequest(MockFacesMappingSupport.mapping(EXACT, "/exact", "exact"), "/exact", "*.jsf", "/faces/*");
+        String exactRequestPath = resource.getRequestPath();
+
+        assertEquals("/app/jakarta.faces.resource/faces.js.jsf?ln=jakarta.faces&stage=Development", exactRequestPath);
+    }
+
+    @Test
+    public void getRequestPathThrowsWhenNoWildcardFallbackExists() {
+        configureRequest(MockFacesMappingSupport.mapping(EXACT, "/exact", "exact"), "/exact");
+
+        assertThrows(IllegalStateException.class, () -> createResource("theme.css", null, null, null, null, null).getRequestPath());
+    }
+
+    private void configureRequest(jakarta.servlet.http.HttpServletMapping mapping, String... servletMappings) {
+        request = MockFacesMappingSupport.request(CONTEXT_PATH, mapping, session);
+        externalContext = MockFacesMappingSupport.externalContext(servletContext, request, response);
+        facesContext.setExternalContext(externalContext);
+        MockFacesMappingSupport.setFacesServletMappings(servletContext, servletMappings);
+    }
+
+    private ResourceImpl createResource(String resourceName, String libraryName, String libraryVersion, String resourceVersion, String localePrefix, String contract) {
+        ContractInfo contractInfo = contract != null ? new ContractInfo(contract) : null;
+        VersionInfo libraryVersionInfo = libraryVersion != null ? new VersionInfo(libraryVersion, null) : null;
+        VersionInfo resourceVersionInfo = resourceVersion != null ? new VersionInfo(resourceVersion, extensionOf(resourceName)) : null;
+
+        ResourceInfo resourceInfo;
+        if (libraryName != null) {
+            LibraryInfo libraryInfo = new LibraryInfo(libraryName, libraryVersionInfo, localePrefix, contract, RESOURCE_HELPER);
+            resourceInfo = new ResourceInfo(libraryInfo, contractInfo, resourceName, resourceVersionInfo);
+        } else {
+            resourceInfo = new ResourceInfo(contractInfo, resourceName, resourceVersionInfo, RESOURCE_HELPER);
+        }
+
+        return new ResourceImpl(resourceInfo, "text/css", 0, 0);
+    }
+
+    private String extensionOf(String resourceName) {
+        int extensionIndex = resourceName.lastIndexOf('.');
+        return extensionIndex >= 0 ? resourceName.substring(extensionIndex + 1) : null;
+    }
+}

--- a/impl/src/test/java/com/sun/faces/application/view/MultiViewHandlerTest.java
+++ b/impl/src/test/java/com/sun/faces/application/view/MultiViewHandlerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.application.view;
+
+import static jakarta.servlet.http.MappingMatch.EXACT;
+import static jakarta.servlet.http.MappingMatch.EXTENSION;
+import static jakarta.servlet.http.MappingMatch.PATH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sun.faces.junit.JUnitFacesTestCaseBase;
+import com.sun.faces.mock.MockFacesMappingSupport;
+
+import jakarta.faces.FactoryFinder;
+
+public class MultiViewHandlerTest extends JUnitFacesTestCaseBase {
+
+    private static final String CONTEXT_PATH = "/app";
+
+    private MultiViewHandler viewHandler;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        FactoryFinder.setFactory(FactoryFinder.VIEW_DECLARATION_LANGUAGE_FACTORY, ViewDeclarationLanguageFactoryImpl.class.getName());
+        viewHandler = new MultiViewHandler();
+    }
+
+    @Test
+    public void getActionURLReturnsExactHitForConfiguredFaceletsExtension() {
+        configureRequest(MockFacesMappingSupport.mapping(EXACT, "/exact", "exact"), "/exact", "/target", "*.xhtml", "/faces/*");
+
+        assertEquals("/app/target", viewHandler.getActionURL(facesContext, "/target.xhtml"));
+    }
+
+    @Test
+    public void getActionURLKeepsExtensionFallbackForExactRequests() {
+        configureRequest(MockFacesMappingSupport.mapping(EXACT, "/exact", "exact"), "/exact", "*.xhtml");
+        String exactRequestUrl = viewHandler.getActionURL(facesContext, "/fallback.xhtml");
+
+        configureRequest(MockFacesMappingSupport.mapping(EXTENSION, "*.xhtml", "fallback"), "/exact", "*.xhtml");
+        String extensionBaselineUrl = viewHandler.getActionURL(facesContext, "/fallback.xhtml");
+
+        assertEquals("/app/fallback.xhtml", exactRequestUrl);
+        assertEquals(extensionBaselineUrl, exactRequestUrl);
+    }
+
+    @Test
+    public void getActionURLKeepsDirectPathBehavior() {
+        configureRequest(MockFacesMappingSupport.mapping(PATH, "/faces/*", "fallback"), "/exact", "/faces/*");
+
+        assertEquals("/app/faces/fallback.xhtml", viewHandler.getActionURL(facesContext, "/fallback.xhtml"));
+    }
+
+    @Test
+    public void getActionURLPrefersExtensionFallbackWhenBothWildcardsExist() {
+        configureRequest(MockFacesMappingSupport.mapping(EXACT, "/exact", "exact"), "/exact", "*.jsf", "/faces/*");
+
+        String exactRequestUrl = viewHandler.getActionURL(facesContext, "/fallback.xhtml");
+
+        assertEquals("/app/fallback.jsf", exactRequestUrl);
+    }
+
+    @Test
+    public void getActionURLThrowsWhenNoWildcardFallbackExists() {
+        configureRequest(MockFacesMappingSupport.mapping(EXACT, "/exact", "exact"), "/exact");
+
+        assertThrows(IllegalStateException.class, () -> viewHandler.getActionURL(facesContext, "/fallback.xhtml"));
+    }
+
+    private void configureRequest(jakarta.servlet.http.HttpServletMapping mapping, String... servletMappings) {
+        request = MockFacesMappingSupport.request(CONTEXT_PATH, mapping, session);
+        externalContext = MockFacesMappingSupport.externalContext(servletContext, request, response);
+        facesContext.setExternalContext(externalContext);
+        MockFacesMappingSupport.setFacesServletMappings(servletContext, servletMappings);
+    }
+}

--- a/impl/src/test/java/com/sun/faces/mock/MockFacesMappingSupport.java
+++ b/impl/src/test/java/com/sun/faces/mock/MockFacesMappingSupport.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.mock;
+
+import static com.sun.faces.RIConstants.FACES_SERVLET_MAPPINGS;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+
+import jakarta.servlet.http.HttpServletMapping;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.MappingMatch;
+
+public final class MockFacesMappingSupport {
+
+    private MockFacesMappingSupport() {
+    }
+
+    public static MockHttpServletRequest request(String contextPath, HttpServletMapping mapping, HttpSession session) {
+        return new MappingHttpServletRequest(contextPath, mapping, session);
+    }
+
+    public static MockExternalContext externalContext(MockServletContext servletContext, MockHttpServletRequest request, MockHttpServletResponse response) {
+        return new MappingExternalContext(servletContext, request, response);
+    }
+
+    public static void setFacesServletMappings(MockServletContext servletContext, String... mappings) {
+        servletContext.setAttribute(FACES_SERVLET_MAPPINGS, new LinkedHashSet<>(Arrays.asList(mappings)));
+    }
+
+    public static HttpServletMapping mapping(MappingMatch match, String pattern, String matchValue) {
+        return new HttpServletMapping() {
+
+            @Override
+            public String getMatchValue() {
+                return matchValue;
+            }
+
+            @Override
+            public String getPattern() {
+                return pattern;
+            }
+
+            @Override
+            public String getServletName() {
+                return "FacesServlet";
+            }
+
+            @Override
+            public MappingMatch getMappingMatch() {
+                return match;
+            }
+        };
+    }
+
+    private static final class MappingHttpServletRequest extends MockHttpServletRequest {
+
+        private final HttpServletMapping mapping;
+
+        private MappingHttpServletRequest(String contextPath, HttpServletMapping mapping, HttpSession session) {
+            super(session);
+            this.mapping = mapping;
+            setPathElements(contextPath, mapping.getPattern(), null, null);
+        }
+
+        @Override
+        public HttpServletMapping getHttpServletMapping() {
+            return mapping;
+        }
+    }
+
+    private static final class MappingExternalContext extends MockExternalContext {
+
+        private final MockHttpServletRequest request;
+
+        private MappingExternalContext(MockServletContext servletContext, MockHttpServletRequest request, MockHttpServletResponse response) {
+            super(servletContext, request, response);
+            this.request = request;
+        }
+
+        @Override
+        public String getRequestContextPath() {
+            return request.getContextPath();
+        }
+
+        @Override
+        public String getRequestPathInfo() {
+            return request.getPathInfo();
+        }
+
+        @Override
+        public String getRequestServletPath() {
+            return request.getServletPath();
+        }
+
+        @Override
+        public String encodeActionURL(String url) {
+            return url;
+        }
+
+        @Override
+        public String encodeResourceURL(String url) {
+            return url;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
    <groupId>org.glassfish</groupId>
    <artifactId>mojarra-parent</artifactId>
-   <version>4.1.8</version>
+   <version>4.1.9-SNAPSHOT</version>
    <packaging>pom</packaging>
 
    <name>Mojarra ${project.version} - Project</name>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
    <groupId>org.glassfish</groupId>
    <artifactId>mojarra-parent</artifactId>
-   <version>4.1.8-SNAPSHOT</version>
+   <version>4.1.8</version>
    <packaging>pom</packaging>
 
    <name>Mojarra ${project.version} - Project</name>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.mojarra</groupId>

--- a/test/base/pom.xml
+++ b/test/base/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>base</artifactId>

--- a/test/base/pom.xml
+++ b/test/base/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>base</artifactId>

--- a/test/csp/pom.xml
+++ b/test/csp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>csp</artifactId>

--- a/test/csp/pom.xml
+++ b/test/csp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>csp</artifactId>

--- a/test/example_jar_with_metadata_complete_false/pom.xml
+++ b/test/example_jar_with_metadata_complete_false/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>example_jar_with_metadata_complete_false</artifactId>

--- a/test/example_jar_with_metadata_complete_false/pom.xml
+++ b/test/example_jar_with_metadata_complete_false/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>example_jar_with_metadata_complete_false</artifactId>

--- a/test/example_jar_with_metadata_complete_true/pom.xml
+++ b/test/example_jar_with_metadata_complete_true/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>example_jar_with_metadata_complete_true</artifactId>

--- a/test/example_jar_with_metadata_complete_true/pom.xml
+++ b/test/example_jar_with_metadata_complete_true/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>example_jar_with_metadata_complete_true</artifactId>

--- a/test/issue5059/pom.xml
+++ b/test/issue5059/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5059</artifactId>

--- a/test/issue5059/pom.xml
+++ b/test/issue5059/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>issue5059</artifactId>

--- a/test/issue5460/pom.xml
+++ b/test/issue5460/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5460</artifactId>

--- a/test/issue5460/pom.xml
+++ b/test/issue5460/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>issue5460</artifactId>

--- a/test/issue5464/pom.xml
+++ b/test/issue5464/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5464</artifactId>

--- a/test/issue5464/pom.xml
+++ b/test/issue5464/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>issue5464</artifactId>

--- a/test/issue5488/pom.xml
+++ b/test/issue5488/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>issue5488</artifactId>

--- a/test/issue5488/pom.xml
+++ b/test/issue5488/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5488</artifactId>

--- a/test/issue5503/pom.xml
+++ b/test/issue5503/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>issue5503</artifactId>

--- a/test/issue5503/pom.xml
+++ b/test/issue5503/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5503</artifactId>

--- a/test/issue5507/pom.xml
+++ b/test/issue5507/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>issue5507</artifactId>

--- a/test/issue5507/pom.xml
+++ b/test/issue5507/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5507</artifactId>

--- a/test/issue5511/pom.xml
+++ b/test/issue5511/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5511</artifactId>

--- a/test/issue5511/pom.xml
+++ b/test/issue5511/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>issue5511</artifactId>

--- a/test/issue5515/pom.xml
+++ b/test/issue5515/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>issue5515</artifactId>

--- a/test/issue5515/pom.xml
+++ b/test/issue5515/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5515</artifactId>

--- a/test/issue5541/pom.xml
+++ b/test/issue5541/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5541</artifactId>

--- a/test/issue5541/pom.xml
+++ b/test/issue5541/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>issue5541</artifactId>

--- a/test/issue5543/pom.xml
+++ b/test/issue5543/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5543</artifactId>

--- a/test/issue5543/pom.xml
+++ b/test/issue5543/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>issue5543</artifactId>

--- a/test/issue5576/pom.xml
+++ b/test/issue5576/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5576</artifactId>

--- a/test/issue5576/pom.xml
+++ b/test/issue5576/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>issue5576</artifactId>

--- a/test/issue5584/pom.xml
+++ b/test/issue5584/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5584</artifactId>

--- a/test/issue5584/pom.xml
+++ b/test/issue5584/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>issue5584</artifactId>

--- a/test/issue5594/pom.xml
+++ b/test/issue5594/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>issue5594</artifactId>

--- a/test/issue5594/pom.xml
+++ b/test/issue5594/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5594</artifactId>

--- a/test/issue5596/pom.xml
+++ b/test/issue5596/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5596</artifactId>

--- a/test/issue5596/pom.xml
+++ b/test/issue5596/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>issue5596</artifactId>

--- a/test/issue5663/pom.xml
+++ b/test/issue5663/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5663</artifactId>

--- a/test/issue5663/pom.xml
+++ b/test/issue5663/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>issue5663</artifactId>

--- a/test/issue5676/pom.xml
+++ b/test/issue5676/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>issue5676</artifactId>

--- a/test/issue5676/pom.xml
+++ b/test/issue5676/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.mojarra.test</groupId>
         <artifactId>pom</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>issue5676</artifactId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.1.8</version>
+        <version>4.1.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.mojarra.test</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>mojarra-parent</artifactId>
-        <version>4.1.8-SNAPSHOT</version>
+        <version>4.1.8</version>
     </parent>
 
     <groupId>org.eclipse.mojarra.test</groupId>


### PR DESCRIPTION
NOTE: #5721 is NOT part of the actual 4.1.8 release. It was inadvertedly merged into 4.1.8 branch after it was released.

The 4.1.8 branch was unintentionally lingering because the Jenkins job failed to run the gh pr+merge+milestone+release job due to an expired token.