### PR TITLE
Fix #5735: add MojarraVersion so faces.js gets v= param

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -235,14 +235,18 @@
                 </includes>
                 <excludes>
                     <exclude>**/LogStrings*.properties</exclude>
+                    <exclude>**/mojarra.properties</exclude>
+                    <exclude>**/faces-uncompressed.js</exclude>
                 </excludes>
             </resource>
-            <!-- Sets the Main Faces version into the log strings -->
+            <!-- Sets the Mojarra version into the log strings, mojarra.properties (read by MojarraVersion at runtime), and the @version JSDoc tag of faces-uncompressed.js. -->
             <resource>
                 <directory>src/main/resources</directory>
                 <filtering>true</filtering>
                 <includes>
                     <include>**/LogStrings*.properties</include>
+                    <include>**/mojarra.properties</include>
+                    <include>**/faces-uncompressed.js</include>
                 </includes>
             </resource>
         </resources>
@@ -287,7 +291,7 @@
                 <executions>
                     <execution>
                         <id>minify-faces-js</id>
-                        <phase>generate-sources</phase>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>compress</goal>
                         </goals>
@@ -297,7 +301,7 @@
                             <aggregations>
                                 <aggregation>
                                     <includes>
-                                        <include>${project.basedir}/src/main/resources/META-INF/resources/jakarta.faces/faces-uncompressed.js</include>
+                                        <include>${project.build.outputDirectory}/META-INF/resources/jakarta.faces/faces-uncompressed.js</include>
                                     </includes>
                                     <output>${project.build.directory}/generated-resources/yui/faces.js</output>
                                 </aggregation>
@@ -306,30 +310,7 @@
                                 <include>*.js</include>
                             </includes>
                             <sourceDirectory>${project.build.directory}/generated-resources/yui</sourceDirectory>
-                            <outputDirectory>${project.build.directory}/generated-resources/yui/META-INF/resources/jakarta.faces/</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <!-- Adds the paths where the source and resources generated above was stored -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.3.0</version>
-                <executions>
-                    <execution>
-                        <id>generate-resources</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>add-resource</goal>
-                        </goals>
-                        <configuration>
-                            <resources>
-                                <resource>
-                                    <directory>${project.build.directory}/generated-resources/yui</directory>
-                                </resource>
-                            </resources>
+                            <outputDirectory>${project.build.outputDirectory}/META-INF/resources/jakarta.faces/</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/impl/src/main/java/com/sun/faces/RIConstants.java
+++ b/impl/src/main/java/com/sun/faces/RIConstants.java
@@ -116,6 +116,14 @@ public class RIConstants {
     public static final String FACES_CONFIG_VERSION = FACES_PREFIX + "facesConfigVersion";
 
     /**
+     * App map key under which a {@code Map<String, Object>} exposing {@code version} /
+     * {@code specversion} / {@code implversion} of this Mojarra build is published so EL
+     * inside resources (e.g. {@code faces.js}) can read it via
+     * {@code #{applicationScope["com.sun.faces.mojarraVersion"]}}.
+     */
+    public static final String MOJARRA_VERSION = FACES_PREFIX + "mojarraVersion";
+
+    /**
      * Convenience key to temporarily store the set of annotated classes in the servlet context.
      */
     public static final String ANNOTATED_CLASSES = FACES_PREFIX + "AnnotatedClasses";

--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceImpl.java
@@ -50,6 +50,7 @@ import java.util.logging.Logger;
 
 import com.sun.faces.application.ApplicationAssociate;
 import com.sun.faces.util.FacesLogger;
+import com.sun.faces.util.MojarraVersion;
 
 import jakarta.faces.application.ProjectStage;
 import jakarta.faces.application.Resource;
@@ -293,6 +294,10 @@ public class ResourceImpl extends Resource implements Externalizable {
         }
         if (resourceInfo.getVersion() != null) {
             version += resourceInfo.getVersion().toString();
+        }
+
+        if (version.isEmpty() && FACES_SCRIPT_LIBRARY_NAME.equals(getLibraryName()) && MojarraVersion.IMPLEMENTATION_VERSION != null) {
+            version = MojarraVersion.IMPLEMENTATION_VERSION;
         }
 
         if (version.length() > 0) {

--- a/impl/src/main/java/com/sun/faces/config/ConfigureListener.java
+++ b/impl/src/main/java/com/sun/faces/config/ConfigureListener.java
@@ -20,6 +20,7 @@ import static com.sun.faces.RIConstants.ANNOTATED_CLASSES;
 import static com.sun.faces.RIConstants.ERROR_PAGE_PRESENT_KEY_NAME;
 import static com.sun.faces.RIConstants.FACES_SERVLET_MAPPINGS;
 import static com.sun.faces.RIConstants.FACES_SERVLET_REGISTRATION;
+import static com.sun.faces.RIConstants.MOJARRA_VERSION;
 import static com.sun.faces.config.InitFacesContext.getInitContextServletContextMap;
 import static com.sun.faces.config.WebConfiguration.BooleanWebContextInitParameter.EnableLazyBeanValidation;
 import static com.sun.faces.config.WebConfiguration.BooleanWebContextInitParameter.EnableThreading;
@@ -69,6 +70,7 @@ import com.sun.faces.el.ELContextImpl;
 import com.sun.faces.push.WebsocketEndpoint;
 import com.sun.faces.util.FacesLogger;
 import com.sun.faces.util.MojarraThreadFactory;
+import com.sun.faces.util.MojarraVersion;
 import com.sun.faces.util.ReflectionUtils;
 import com.sun.faces.util.Timer;
 import com.sun.faces.util.Util;
@@ -128,6 +130,8 @@ public class ConfigureListener implements ServletRequestListener, HttpSessionLis
         LOGGER.log(FINE, () -> format("ConfigureListener.contextInitialized({0})", servletContext.getContextPath()));
 
         webConfig = WebConfiguration.getInstance(servletContext);
+
+        servletContext.setAttribute(MOJARRA_VERSION, MojarraVersion.toMap());
 
         // Check to see if the FacesServlet is present in the
         // web.xml. If it is, perform faces configuration as normal,

--- a/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
+++ b/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
@@ -71,6 +71,7 @@ import com.sun.faces.application.view.FaceletViewHandlingStrategy;
 import com.sun.faces.facelets.util.Classpath;
 import com.sun.faces.lifecycle.HttpMethodRestrictionsPhaseListener;
 import com.sun.faces.util.FacesLogger;
+import com.sun.faces.util.MojarraVersion;
 import com.sun.faces.util.Util;
 
 /**
@@ -116,8 +117,6 @@ public class WebConfiguration {
 
     private boolean hasFlows;
 
-    private String specificationVersion;
-
     // ------------------------------------------------------------ Constructors
 
     private WebConfiguration(ServletContext servletContext) {
@@ -137,8 +136,6 @@ public class WebConfiguration {
         getOptionValue(WebContextInitParameter.ResourceExcludes, " ");
         getOptionValue(WebContextInitParameter.FaceletsViewMappings, ";");
         getOptionValue(WebContextInitParameter.FaceletsSuffix, " ");
-
-        specificationVersion = getClass().getPackage().getSpecificationVersion();
     }
 
     // ---------------------------------------------------------- Public Methods
@@ -206,7 +203,7 @@ public class WebConfiguration {
     }
 
     public String getSpecificationVersion() {
-        return specificationVersion;
+        return MojarraVersion.SPECIFICATION_VERSION;
     }
 
     /**

--- a/impl/src/main/java/com/sun/faces/util/MojarraVersion.java
+++ b/impl/src/main/java/com/sun/faces/util/MojarraVersion.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Build-time identity of this Mojarra build, derived from {@code mojarra.properties}
+ * which is token-substituted by maven-resources-plugin at build time. The properties
+ * file is shipped on the impl classpath at {@code /com/sun/faces/mojarra.properties}.
+ * Reading it via the classpath survives exploded WARs and IDE test runs where the
+ * JAR MANIFEST is not available.
+ */
+public final class MojarraVersion {
+
+    /** Spec version as {@code major.minor} (e.g. {@code "4.0"}); {@code null} if {@code mojarra.properties} could not be loaded. */
+    public static final String SPECIFICATION_VERSION;
+
+    /** Full implementation version (e.g. {@code "4.0.18-SNAPSHOT"}); {@code null} if {@code mojarra.properties} could not be loaded. */
+    public static final String IMPLEMENTATION_VERSION;
+
+    /** Spec version as packed int: {@code major * 10000 + minor * 100} (e.g. {@code 40000} for {@code "4.0"}). */
+    public static final int SPECIFICATION_VERSION_INT;
+
+    /** Implementation incremental version as int (e.g. {@code 18} for {@code "4.0.18-SNAPSHOT"}). */
+    public static final int IMPLEMENTATION_VERSION_INT;
+
+    private static final String PROPERTIES_RESOURCE = "/com/sun/faces/mojarra.properties";
+    private static final String VERSION_SEPARATOR = "[.\\-_]";
+
+    static {
+        IMPLEMENTATION_VERSION = loadVersion();
+        SPECIFICATION_VERSION = stripPatch(IMPLEMENTATION_VERSION);
+        SPECIFICATION_VERSION_INT = parseSpec(IMPLEMENTATION_VERSION);
+        IMPLEMENTATION_VERSION_INT = parseImpl(IMPLEMENTATION_VERSION);
+    }
+
+    private static String loadVersion() {
+        Properties props = new Properties();
+        try (InputStream in = MojarraVersion.class.getResourceAsStream(PROPERTIES_RESOURCE)) {
+            if (in == null) {
+                return null;
+            }
+            props.load(in);
+        } catch (IOException e) {
+            return null;
+        }
+        return props.getProperty("version");
+    }
+
+    private static String stripPatch(String v) {
+        if (v == null) {
+            return null;
+        }
+        String[] parts = v.split(VERSION_SEPARATOR);
+        if (parts.length < 2) {
+            return v;
+        }
+        return parts[0] + "." + parts[1];
+    }
+
+    private static int parseSpec(String v) {
+        if (v == null) {
+            return 0;
+        }
+        try {
+            String[] parts = v.split(VERSION_SEPARATOR);
+            int major = parts.length > 0 ? Integer.parseInt(parts[0]) : 0;
+            int minor = parts.length > 1 ? Integer.parseInt(parts[1]) : 0;
+            return major * 10000 + minor * 100;
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    private static int parseImpl(String v) {
+        if (v == null) {
+            return 0;
+        }
+        try {
+            String[] parts = v.split(VERSION_SEPARATOR);
+            return parts.length > 2 ? Integer.parseInt(parts[2]) : 0;
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Returns an immutable map of {@code version} / {@code specversion} / {@code implversion}
+     * suitable for publishing as an application-scoped attribute so EL can read it. {@code version}
+     * falls back to {@code "DEV-SNAPSHOT"} when {@link #IMPLEMENTATION_VERSION} is {@code null}
+     * (i.e. {@code mojarra.properties} was not loadable from the classpath).
+     */
+    public static Map<String, Object> toMap() {
+        return Map.of(
+            "version", IMPLEMENTATION_VERSION != null ? IMPLEMENTATION_VERSION : "DEV-SNAPSHOT",
+            "specversion", SPECIFICATION_VERSION_INT,
+            "implversion", IMPLEMENTATION_VERSION_INT);
+    }
+
+    private MojarraVersion() {
+        throw new AssertionError();
+    }
+}

--- a/impl/src/main/java/com/sun/faces/util/MojarraVersion.java
+++ b/impl/src/main/java/com/sun/faces/util/MojarraVersion.java
@@ -33,13 +33,13 @@ public final class MojarraVersion {
     /** Spec version as {@code major.minor} (e.g. {@code "4.0"}); {@code null} if {@code mojarra.properties} could not be loaded. */
     public static final String SPECIFICATION_VERSION;
 
-    /** Full implementation version (e.g. {@code "4.0.18-SNAPSHOT"}); {@code null} if {@code mojarra.properties} could not be loaded. */
+    /** Full implementation version (e.g. {@code "4.0.19"}); {@code null} if {@code mojarra.properties} could not be loaded. */
     public static final String IMPLEMENTATION_VERSION;
 
     /** Spec version as packed int: {@code major * 10000 + minor * 100} (e.g. {@code 40000} for {@code "4.0"}). */
     public static final int SPECIFICATION_VERSION_INT;
 
-    /** Implementation incremental version as int (e.g. {@code 18} for {@code "4.0.18-SNAPSHOT"}). */
+    /** Implementation incremental version as int (e.g. {@code 18} for {@code "4.0.19"}). */
     public static final int IMPLEMENTATION_VERSION_INT;
 
     private static final String PROPERTIES_RESOURCE = "/com/sun/faces/mojarra.properties";

--- a/impl/src/main/resources/META-INF/resources/jakarta.faces/faces-uncompressed.js
+++ b/impl/src/main/resources/META-INF/resources/jakarta.faces/faces-uncompressed.js
@@ -18,13 +18,13 @@
 
 /**
  @project Faces JavaScript Library
- @version 4.0.17
+ @version ${project.version}
  @description This is the standard implementation of the Faces JavaScript Library.
  */
 
 // Detect if this is already loaded, and if loaded, if it's a higher version
-if (!((faces && faces.specversion && faces.specversion >= 40000 ) &&
-      (faces.implversion && faces.implversion >= 17))) {
+if (!((faces && faces.specversion && faces.specversion >= parseInt('#{applicationScope["com.sun.faces.mojarraVersion"].specversion}', 10)) &&
+      (faces.implversion && faces.implversion >= parseInt('#{applicationScope["com.sun.faces.mojarraVersion"].implversion}', 10)))) {
 
     // --- JS Lang --------------------------------------------------------------------
     var UDEF = 'undefined';
@@ -3720,7 +3720,7 @@ if (!((faces && faces.specversion && faces.specversion >= 40000 ) &&
      * minor release number, leftmost digits, major release number.
      * This number may only be incremented by a new release of the specification.</p>
      */
-    faces.specversion = 40000;
+    faces.specversion = parseInt('#{applicationScope["com.sun.faces.mojarraVersion"].specversion}', 10);
 
     /**
      * <p>An integer specifying the implementation version that this file implements.
@@ -3728,7 +3728,7 @@ if (!((faces && faces.specversion && faces.specversion >= 40000 ) &&
      * <code>faces.specversion</code>
      * This number is implementation dependent.</p>
      */
-    faces.implversion = 17;
+    faces.implversion = parseInt('#{applicationScope["com.sun.faces.mojarraVersion"].implversion}', 10);
 
 
 } //end if version detection block

--- a/impl/src/main/resources/com/sun/faces/mojarra.properties
+++ b/impl/src/main/resources/com/sun/faces/mojarra.properties
@@ -1,0 +1,5 @@
+#
+# Token-substituted by maven-resources-plugin at build time. Single source of truth for the
+# Mojarra version string consumed at runtime by com.sun.faces.util.MojarraVersion.
+#
+version=${project.version}

--- a/impl/src/test/java/com/sun/faces/application/resource/ResourceImplTest.java
+++ b/impl/src/test/java/com/sun/faces/application/resource/ResourceImplTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import com.sun.faces.junit.JUnitFacesTestCaseBase;
 import com.sun.faces.mock.MockApplication;
 import com.sun.faces.mock.MockFacesMappingSupport;
+import com.sun.faces.util.MojarraVersion;
 
 import jakarta.faces.context.FacesContext;
 
@@ -136,7 +137,18 @@ public class ResourceImplTest extends JUnitFacesTestCaseBase {
         configureRequest(MockFacesMappingSupport.mapping(EXACT, "/exact", "exact"), "/exact", "*.jsf", "/faces/*");
         String exactRequestPath = resource.getRequestPath();
 
-        assertEquals("/app/jakarta.faces.resource/faces.js.jsf?ln=jakarta.faces&stage=Development", exactRequestPath);
+        String versionParam = MojarraVersion.IMPLEMENTATION_VERSION != null ? "&v=" + MojarraVersion.IMPLEMENTATION_VERSION : "";
+        assertEquals("/app/jakarta.faces.resource/faces.js.jsf?ln=jakarta.faces" + versionParam + "&stage=Development", exactRequestPath);
+    }
+
+    @Test
+    public void getRequestPathDoesNotAppendImplVersionForOtherLibrariesWithoutVersion() {
+        ResourceImpl resource = createResource("theme.css", "layout", null, null, null, null);
+
+        configureRequest(MockFacesMappingSupport.mapping(EXACT, "/exact", "exact"), "/exact", "*.jsf", "/faces/*");
+        String exactRequestPath = resource.getRequestPath();
+
+        assertEquals("/app/jakarta.faces.resource/theme.css.jsf?ln=layout", exactRequestPath);
     }
 
     @Test

--- a/impl/src/test/ts/test-setup.ts
+++ b/impl/src/test/ts/test-setup.ts
@@ -10,7 +10,7 @@ declare global {
     var mojarra: Record<string, unknown>;
 }
 
-export const FACES_JS_UNCOMPRESSED = path.resolve(__dirname, "../../main/resources/META-INF/resources/jakarta.faces/faces-uncompressed.js");
+export const FACES_JS_UNCOMPRESSED = path.resolve(__dirname, "../../../target/classes/META-INF/resources/jakarta.faces/faces-uncompressed.js");
 export const FACES_JS = path.resolve(__dirname, "../../../target/classes/META-INF/resources/jakarta.faces/faces.js");
 
 /**
@@ -36,9 +36,12 @@ export function parseFacesJsVersion(): { specversion: number; implversion: numbe
  */
 export function loadFacesJs(): void {
     const source = fs.readFileSync(FACES_JS, "utf-8");
+    const { specversion, implversion } = parseFacesJsVersion();
     const evaluated = source
         .replace("#{facesContext.namingContainerSeparatorChar}", ":")
-        .replace("#{facesContext.externalContext.requestContextPath}", "/test");
+        .replace("#{facesContext.externalContext.requestContextPath}", "/test")
+        .replace(/#\{applicationScope\["com\.sun\.faces\.mojarraVersion"\]\.specversion\}/g, String(specversion))
+        .replace(/#\{applicationScope\["com\.sun\.faces\.mojarraVersion"\]\.implversion\}/g, String(implversion));
 
     const script = document.createElement("script");
     script.textContent = evaluated;


### PR DESCRIPTION
Fix #5735: add MojarraVersion so faces.js gets v= param; while at it automatically fill faces-uncompressed.js `@version`, `specversion` and `implversion` as well with EL-resolved MojarraVersion

cc: @NicolaIsotta 