### PR TITLE
Fix #5739: Render every on* attribute via addEventListener so even user defined handlers are CSP safe

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/RenderKitUtils.java
@@ -403,12 +403,6 @@ public class RenderKitUtils {
         String handlerName = BEHAVIOR_EVENT_ATTRIBUTE_PREFIX + domEventName;
         Object userHandler = component.getAttributes().get(handlerName);
 
-        // Fast path: if there's no behavior and we have a user-defined handler, just write it directly as an attribute
-        if (!hasBehaviorForDefaultEvent && userHandler != null) {
-            context.getResponseWriter().writeAttribute(handlerName, userHandler, null);
-            return;
-        }
-
         // Determine which behavior event name to use (component-level or DOM-level)
         String behaviorEventName = componentEventName;
         if (component instanceof ClientBehaviorHolder) {
@@ -422,7 +416,7 @@ public class RenderKitUtils {
             ? Collections.singletonList(new ClientBehaviorContext.Parameter("incExec", true))
             : Collections.emptyList();
 
-        addBehaviorEventListener(context, component, clientId, params, handlerName, userHandler, behaviorEventName, domEventName, null, false, incExec, true);
+        addBehaviorEventListener(context, component, clientId, params, handlerName, userHandler, behaviorEventName, domEventName, null, false, incExec);
     }
 
     // Renders the onclick event listener for command buttons. Handles
@@ -449,7 +443,7 @@ public class RenderKitUtils {
             }
         }
 
-        addBehaviorEventListener(context, component, null, params, handlerName, userHandler, behaviorEventName, domEventName, submitTarget, needsSubmit, false, true);
+        addBehaviorEventListener(context, component, null, params, handlerName, userHandler, behaviorEventName, domEventName, submitTarget, needsSubmit, false);
     }
 
     // Renders the script element with the function for command scripts.
@@ -646,28 +640,15 @@ public class RenderKitUtils {
             // an array to a Map<String, Attribute>. This would change
             // the search time from O(log n) to O(1).
             int index = Arrays.binarySearch(knownAttributes, Attribute.attr(name));
-            if (index >= 0) {
+            if (index >= 0 || isBehaviorEventAttribute(name)) {
                 Object value = attrMap.get(name);
                 if (value != null && shouldRenderAttribute(value)) {
-
-                    Attribute attr = knownAttributes[index];
-
-                    if (isBehaviorEventAttribute(attr, behaviorEventName)) {
-                        addBehaviorEventListener(context, component, null, null, name, value, behaviorEventName, behaviorEventName, null, false, false, false);
-
-                        renderedBehavior = true;
-                    } else {
-                        writer.writeAttribute(prefixAttribute(name, isXhtml), value, name);
-                    }
-                }
-            }
-            else if (isBehaviorEventAttribute(name)) {
-                Object value = attrMap.get(name);
-                if (value != null && shouldRenderAttribute(value)) {
-                    if (name.substring(2).equals(behaviorEventName)) {
-                        addBehaviorEventListener(context, component, null, null, name, value, behaviorEventName, behaviorEventName, null, false, false, false);
-
-                        renderedBehavior = true;
+                    if (isBehaviorEventAttribute(name)) {
+                        String eventName = name.substring(BEHAVIOR_EVENT_ATTRIBUTE_PREFIX.length());
+                        addBehaviorEventListener(context, component, null, null, name, value, eventName, eventName, null, false, false);
+                        if (eventName.equals(behaviorEventName)) {
+                            renderedBehavior = true;
+                        }
                     } else {
                         writer.writeAttribute(prefixAttribute(name, isXhtml), value, name);
                     }
@@ -697,7 +678,7 @@ public class RenderKitUtils {
                 String attrName = attribute.getName();
                 String[] events = attribute.getEvents();
                 if (events != null && events.length > 0 && behaviorEventName.equals(events[0])) {
-                    addBehaviorEventListener(context, component, null, null, attrName, null, behaviorEventName, behaviorEventName, null, false, false, false);
+                    addBehaviorEventListener(context, component, null, null, attrName, null, behaviorEventName, behaviorEventName, null, false, false);
                     return;
                 }
             }
@@ -752,14 +733,12 @@ public class RenderKitUtils {
 
         Object value = attrMap.get(attrName);
 
-        if (value != null && shouldRenderAttribute(value) && !hasBehavior) {
-            writer.writeAttribute(prefixAttribute(attrName, isXhtml), value, attrName);
-        } else if (hasBehavior) {
+        boolean hasValue = value != null && shouldRenderAttribute(value);
 
-            // If we've got a behavior for this attribute,
-            // we may need to chain scripts together, so use
-            // renderHandler().
-            addBehaviorEventListener(context, component, null, null, attrName, value, eventName, eventName, null, false, false, false);
+        if (hasBehavior || (hasValue && isBehaviorEventAttribute(attrName))) {
+            addBehaviorEventListener(context, component, null, null, attrName, value, eventName, eventName, null, false, false);
+        } else if (hasValue) {
+            writer.writeAttribute(prefixAttribute(attrName, isXhtml), value, attrName);
         }
     }
 
@@ -1497,15 +1476,6 @@ public class RenderKitUtils {
         return keys.next();
     }
 
-    // Tests whether the specified Attribute matches to specified
-    // behavior event name. Used by renderPassThruAttributesOptimized.
-    private static boolean isBehaviorEventAttribute(Attribute attr, String behaviorEventName) {
-
-        String[] events = attr.getEvents();
-
-        return behaviorEventName != null && events != null && events.length > 0 && behaviorEventName.equals(events[0]);
-    }
-
     // Ensures that the user-specified DOM event handler script
     // is non-empty, and trimmed if necessary.
     private static String getNonEmptyUserHandler(Object handlerObject) {
@@ -1669,7 +1639,7 @@ public class RenderKitUtils {
      * render the submit script to make the link submit.
      */
     private static void addBehaviorEventListener(FacesContext context, UIComponent component, String clientId, Collection<ClientBehaviorContext.Parameter> params, String handlerName,
-            Object handlerValue, String behaviorEventName, String domEventName, String submitTarget, boolean needsSubmit, boolean includeExec, boolean flushPendingBehaviorEventListeners) throws IOException {
+            Object handlerValue, String behaviorEventName, String domEventName, String submitTarget, boolean needsSubmit, boolean includeExec) throws IOException {
 
         String userHandler = getNonEmptyUserHandler(handlerValue);
         List<ClientBehavior> behaviors = getClientBehaviors(component, behaviorEventName);
@@ -1704,16 +1674,8 @@ public class RenderKitUtils {
             assert false;
         }
 
-        if (flushPendingBehaviorEventListeners) {
-            flushPendingBehaviorEventListeners(context, component, clientId);
-        }
         if (handler != null) {
-            if (flushPendingBehaviorEventListeners) {
-                addEventListener(context, component, clientId, domEventName, handler);
-            }
-            else {
-                getPendingBehaviorEventListeners(component, false).computeIfAbsent(domEventName, $ -> new ArrayList<>(2)).add(handler);
-            }
+            addEventListener(context, component, domEventName, handler);
         }
     }
 
@@ -1734,21 +1696,33 @@ public class RenderKitUtils {
         return pendingBehaviorEventListeners;
     }
 
+    /**
+     * Emit all pending behavior event listeners for the given component as a single batched script.
+     * Each parked handler becomes one {@code mojarra.ael('clientId','event',['script'])} call. Insertion
+     * order across both events and handlers within each event is preserved.
+     */
     public static void flushPendingBehaviorEventListeners(FacesContext context, UIComponent component, String clientId) throws IOException {
-        for (var pendingEvent : getPendingBehaviorEventListeners(component, true).entrySet()) {
-            for (var pendingEventListener : pendingEvent.getValue()) {
-                addEventListener(context, component, clientId, pendingEvent.getKey(), pendingEventListener);
+        var pending = getPendingBehaviorEventListeners(component, true);
+
+        if (pending.isEmpty()) {
+            return;
+        }
+
+        String resolvedClientId = clientId != null ? clientId : component.getClientId(context);
+        StringBuilder script = new StringBuilder();
+
+        for (var pendingEvent : pending.entrySet()) {
+            String domEventName = pendingEvent.getKey();
+            for (String handler : pendingEvent.getValue()) {
+                if (script.length() > 0) {
+                    script.append(';');
+                }
+                script.append("mojarra.ael('").append(resolvedClientId).append("','").append(domEventName).append("',[");
+                appendJsStringLiteral(script, handler);
+                script.append("])");
             }
         }
-    }
 
-    public static void addEventListener(FacesContext context, UIComponent component, String clientId, String domEventName, String function) throws IOException {
-        StringBuilder script = new StringBuilder("mojarra.ael('")
-            .append(clientId != null ? clientId : component.getClientId(context))
-            .append("','")
-            .append(domEventName)
-            .append("',function(event){" + function + "})");
-        
         if (context.getPartialViewContext().isAjaxRequest()) {
             context.getPartialViewContext().getEvalScripts().add(script.toString());
         }
@@ -1756,6 +1730,42 @@ public class RenderKitUtils {
             renderFacesJsIfNecessary(context);
             renderScript(context, component, null, script.toString());
         }
+    }
+
+    /**
+     * Park a single event listener on the component's pending behavior listeners map. Emission is
+     * deferred until {@link #flushPendingBehaviorEventListeners(FacesContext, UIComponent, String)}
+     * runs, so multiple listeners on the same component coalesce into one {@code <script>} tag. The
+     * client id used in the emitted {@code mojarra.ael(...)} call is taken from the flush call, not
+     * captured here.
+     */
+    public static void addEventListener(FacesContext context, UIComponent component, String domEventName, String function) {
+        getPendingBehaviorEventListeners(component, false)
+            .computeIfAbsent(domEventName, $ -> new ArrayList<>(2))
+            .add(function);
+    }
+
+    /**
+     * Append {@code str} to {@code out} as a single-quoted JavaScript string literal, escaping the
+     * characters that would otherwise alter the string's contents (quote, backslash) or terminate
+     * a hosting {@code <script>} element ('{@code <}').
+     */
+    private static void appendJsStringLiteral(StringBuilder out, String str) {
+        out.append('\'');
+        for (int i = 0; i < str.length(); i++) {
+            char c = str.charAt(i);
+            switch (c) {
+                case '\\': out.append("\\\\"); break;
+                case '\'': out.append("\\'"); break;
+                case '\n': out.append("\\n"); break;
+                case '\r': out.append("\\r"); break;
+                case '<':  out.append("\\x3C"); break;
+                case '\u2028': out.append("\\u2028"); break;
+                case '\u2029': out.append("\\u2029"); break;
+                default: out.append(c);
+            }
+        }
+        out.append('\'');
     }
 
     public static void renderScript(FacesContext context, UIComponent component, String clientId, String script) throws IOException {

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/ButtonRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/ButtonRenderer.java
@@ -154,6 +154,7 @@ public class ButtonRenderer extends HtmlBasicRenderer {
         }
 
         RenderKitUtils.renderOnclickEventListener(context, component, params, null, false);
+        RenderKitUtils.flushPendingBehaviorEventListeners(context, component, null);
     }
 
     // --------------------------------------------------------- Private Methods

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/CommandLinkRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/CommandLinkRenderer.java
@@ -131,6 +131,8 @@ public class CommandLinkRenderer extends LinkRenderer {
             Collection<ClientBehaviorContext.Parameter> params = getBehaviorParameters(component);
             RenderKitUtils.renderOnclickEventListener(context, component, params, target, true);
         }
+
+        RenderKitUtils.flushPendingBehaviorEventListeners(context, component, null);
     }
 
     @Override

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/HeadRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/HeadRenderer.java
@@ -62,6 +62,7 @@ public class HeadRenderer extends HtmlBasicRenderer {
     public void encodeEnd(FacesContext context, UIComponent component) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         encodeHeadResources(context);
+        RenderKitUtils.flushPendingBehaviorEventListeners(context, component, null);
         writer.endElement("head");
     }
 

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/HtmlResponseWriter.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/HtmlResponseWriter.java
@@ -36,6 +36,7 @@ import org.glassfish.mojarra.RIConstants;
 import org.glassfish.mojarra.config.WebConfiguration;
 import org.glassfish.mojarra.config.WebConfiguration.BooleanWebContextInitParameter;
 import org.glassfish.mojarra.io.FastStringWriter;
+import org.glassfish.mojarra.renderkit.RenderKitUtils;
 import org.glassfish.mojarra.util.HtmlUtils;
 import org.glassfish.mojarra.util.MessageUtils;
 
@@ -143,6 +144,11 @@ public class HtmlResponseWriter extends ResponseWriter {
     private char[] cdataTextBuffer = new char[cdataTextBufferSize];
 
     private Map<String, Object> passthroughAttributes;
+
+    // Component associated with the most-recently-opened element, captured from startElement(name,
+    // component). Used to attribute deferred on* pass-through attributes to the correct component's
+    // pending-behavior-event-listeners map. May be null if startElement was called without a component.
+    private UIComponent currentComponent;
 
     // Internal buffer for to store the result of String.getChars() for
     // values passed to the writer as String to reduce the overhead
@@ -603,6 +609,7 @@ public class HtmlResponseWriter extends ResponseWriter {
             writingCdata = true;
         }
 
+        currentComponent = componentForElement;
         if (null != componentForElement) {
             Map<String, Object> passThroughAttrs = componentForElement.getPassThroughAttributes(false);
             if (null != passThroughAttrs && !passThroughAttrs.isEmpty()) {
@@ -1137,7 +1144,11 @@ public class HtmlResponseWriter extends ResponseWriter {
                 if ("styleClass".equals(key)) {
                     key = "class";
                 }
-                writeURIAttributeIgnoringPassThroughAttributes(destination, key, val, key, true);
+                if (currentComponent != null && RenderKitUtils.isBehaviorEventAttribute(key)) {
+                    RenderKitUtils.addEventListener(context, currentComponent, key.substring(2), val);
+                } else {
+                    writeURIAttributeIgnoringPassThroughAttributes(destination, key, val, key, true);
+                }
             }
         }
     }

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/OutcomeTargetButtonRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/OutcomeTargetButtonRenderer.java
@@ -104,17 +104,17 @@ public class OutcomeTargetButtonRenderer extends OutcomeTargetRenderer {
             context.getResponseWriter().endElement("input");
         }
 
-        RenderKitUtils.flushPendingBehaviorEventListeners(context, component, null);
-
         if (!Util.componentIsDisabled(component)) {
             NavigationCase navCase = getNavigationCase(context, component);
 
             if (navCase != null) {
                 String hrefVal = getEncodedTargetURL(context, component, navCase);
                 hrefVal += getFragment(component);
-                RenderKitUtils.addEventListener(context, component, null, HtmlDocumentElementEvent.click.name(), getOnclick(component, hrefVal));
+                RenderKitUtils.addEventListener(context, component, HtmlDocumentElementEvent.click.name(), getOnclick(component, hrefVal));
             }
         }
+
+        RenderKitUtils.flushPendingBehaviorEventListeners(context, component, null);
     }
 
     // ------------------------------------------------------- Protected Methods

--- a/impl/src/main/ts/mojarra.ts
+++ b/impl/src/main/ts/mojarra.ts
@@ -33,8 +33,8 @@ export interface MojarraNamespace {
     /** Register a window-load callback (used by command script with autorun=true). */
     l(callback: () => void): void;
 
-    /** Add an event listener to the element with the given id. */
-    ael(id: string, ev: string, fn: EventListenerOrEventListenerObject): void;
+    /** Add chained event listener to the element with the given id; if any script returns `false`, the remaining scripts are skipped and `event.preventDefault()` is called. */
+    ael(id: string, ev: string, scripts: string[]): void;
 }
 
 declare global {
@@ -106,6 +106,11 @@ mojarra.l = function l(callback) {
     }
 };
 
-mojarra.ael = function ael(id, ev, fn) {
-    document.getElementById(id)!.addEventListener(ev, fn);
+mojarra.ael = function ael(id, ev, scripts) {
+    const el = document.getElementById(id)!;
+    el.addEventListener(ev, function (event) {
+        if ((window.faces.util.chain as (...args: unknown[]) => unknown)(el, event, ...scripts) === false) {
+            event.preventDefault();
+        }
+    });
 };

--- a/impl/src/test/ts/spec/mojarra.test.ts
+++ b/impl/src/test/ts/spec/mojarra.test.ts
@@ -650,76 +650,116 @@ describe("mojarra.ab", () => {
 
 describe("mojarra.ael", () => {
     let div: HTMLDivElement;
+    const w = () => window as unknown as Record<string, unknown>;
 
     beforeEach(() => {
         div = document.createElement("div");
         div.id = "ael-test";
         document.body.appendChild(div);
+        w().__aelTrace = [];
     });
 
     afterEach(() => {
         div?.remove();
+        delete w().__aelTrace;
     });
 
-    test("attaches click event listener to element by id", () => {
-        let clicked = false;
-        (moj().ael as Function)("ael-test", "click", () => { clicked = true; });
+    test("attaches click event listener that runs a single script", () => {
+        (moj().ael as Function)("ael-test", "click", ["window.__aelTrace.push('clicked')"]);
         div.click();
-        expect(clicked).toBe(true);
+        expect(w().__aelTrace).toEqual(["clicked"]);
     });
 
     test("attaches non-click event listener", () => {
-        let focused = false;
-        (moj().ael as Function)("ael-test", "focus", () => { focused = true; });
+        (moj().ael as Function)("ael-test", "focus", ["window.__aelTrace.push('focused')"]);
         div.dispatchEvent(new Event("focus"));
-        expect(focused).toBe(true);
+        expect(w().__aelTrace).toEqual(["focused"]);
     });
 
-    test("passes event object to handler", () => {
-        let receivedEvent: Event | null = null;
-        (moj().ael as Function)("ael-test", "click", (e: Event) => { receivedEvent = e; });
+    test("exposes the DOM event to the script as 'event'", () => {
+        (moj().ael as Function)("ael-test", "click", ["window.__aelTrace.push(event.type)"]);
         div.click();
-        expect(receivedEvent).toBeInstanceOf(Event);
-        expect(receivedEvent!.type).toBe("click");
+        expect(w().__aelTrace).toEqual(["click"]);
     });
 
-    test("multiple listeners on same element and event", () => {
-        const order: number[] = [];
-        (moj().ael as Function)("ael-test", "click", () => { order.push(1); });
-        (moj().ael as Function)("ael-test", "click", () => { order.push(2); });
+    test("binds 'this' to the element when chain captures it", () => {
+        (moj().ael as Function)("ael-test", "click", ["window.__aelTrace.push(this.id)"]);
         div.click();
-        expect(order).toEqual([1, 2]);
+        expect(w().__aelTrace).toEqual(["ael-test"]);
     });
 
-    test("multiple listeners on same element for different events", () => {
-        let clicked = false;
-        let hovered = false;
-        (moj().ael as Function)("ael-test", "click", () => { clicked = true; });
-        (moj().ael as Function)("ael-test", "mouseover", () => { hovered = true; });
+    test("multiple scripts on same registration run in insertion order", () => {
+        (moj().ael as Function)("ael-test", "click", [
+            "window.__aelTrace.push('a')",
+            "window.__aelTrace.push('b')",
+            "window.__aelTrace.push('c')",
+        ]);
+        div.click();
+        expect(w().__aelTrace).toEqual(["a", "b", "c"]);
+    });
+
+    test("a script returning false short-circuits the remaining scripts", () => {
+        (moj().ael as Function)("ael-test", "click", [
+            "window.__aelTrace.push('a')",
+            "window.__aelTrace.push('b'); return false",
+            "window.__aelTrace.push('never')",
+        ]);
+        div.click();
+        expect(w().__aelTrace).toEqual(["a", "b"]);
+    });
+
+    test("a script returning false calls event.preventDefault()", () => {
+        (moj().ael as Function)("ael-test", "click", ["return false"]);
+        const ev = new Event("click", { cancelable: true });
+        div.dispatchEvent(ev);
+        expect(ev.defaultPrevented).toBe(true);
+    });
+
+    test("a script returning true does not call event.preventDefault()", () => {
+        (moj().ael as Function)("ael-test", "click", ["return true"]);
+        const ev = new Event("click", { cancelable: true });
+        div.dispatchEvent(ev);
+        expect(ev.defaultPrevented).toBe(false);
+    });
+
+    test("a script returning falsy non-false does not call event.preventDefault()", () => {
+        (moj().ael as Function)("ael-test", "click", ["return 0"]);
+        const ev = new Event("click", { cancelable: true });
+        div.dispatchEvent(ev);
+        expect(ev.defaultPrevented).toBe(false);
+    });
+
+    test("multiple registrations on same element and event chain independently", () => {
+        (moj().ael as Function)("ael-test", "click", ["window.__aelTrace.push(1)"]);
+        (moj().ael as Function)("ael-test", "click", ["window.__aelTrace.push(2)"]);
+        div.click();
+        expect(w().__aelTrace).toEqual([1, 2]);
+    });
+
+    test("registrations for different events are independent", () => {
+        (moj().ael as Function)("ael-test", "click", ["window.__aelTrace.push('c')"]);
+        (moj().ael as Function)("ael-test", "mouseover", ["window.__aelTrace.push('m')"]);
 
         div.click();
-        expect(clicked).toBe(true);
-        expect(hovered).toBe(false);
+        expect(w().__aelTrace).toEqual(["c"]);
 
         div.dispatchEvent(new Event("mouseover"));
-        expect(hovered).toBe(true);
+        expect(w().__aelTrace).toEqual(["c", "m"]);
     });
 
     test("throws when element id does not exist", () => {
-        expect(() => (moj().ael as Function)("nonexistent", "click", () => {})).toThrow();
+        expect(() => (moj().ael as Function)("nonexistent", "click", ["window.__aelTrace.push('never')"])).toThrow();
     });
 
-    test("listener not called before event fires", () => {
-        let called = false;
-        (moj().ael as Function)("ael-test", "click", () => { called = true; });
-        expect(called).toBe(false);
+    test("script is not run before the event fires", () => {
+        (moj().ael as Function)("ael-test", "click", ["window.__aelTrace.push('clicked')"]);
+        expect(w().__aelTrace).toEqual([]);
     });
 
     test("works with custom events", () => {
-        let detail: unknown = null;
-        (moj().ael as Function)("ael-test", "myCustomEvent", (e: CustomEvent) => { detail = e.detail; });
+        (moj().ael as Function)("ael-test", "myCustomEvent", ["window.__aelTrace.push(event.detail)"]);
         div.dispatchEvent(new CustomEvent("myCustomEvent", { detail: "payload" }));
-        expect(detail).toBe("payload");
+        expect(w().__aelTrace).toEqual(["payload"]);
     });
 
     test("works with input elements", () => {
@@ -727,12 +767,19 @@ describe("mojarra.ael", () => {
         input.id = "ael-input-test";
         document.body.appendChild(input);
 
-        let changed = false;
-        (moj().ael as Function)("ael-input-test", "change", () => { changed = true; });
+        (moj().ael as Function)("ael-input-test", "change", ["window.__aelTrace.push('changed')"]);
         input.dispatchEvent(new Event("change"));
-        expect(changed).toBe(true);
+        expect(w().__aelTrace).toEqual(["changed"]);
 
         input.remove();
+    });
+
+    test("empty scripts array attaches a no-op listener", () => {
+        (moj().ael as Function)("ael-test", "click", []);
+        const ev = new Event("click", { cancelable: true });
+        div.dispatchEvent(ev);
+        expect(ev.defaultPrevented).toBe(false);
+        expect(w().__aelTrace).toEqual([]);
     });
 });
 


### PR DESCRIPTION
#5739 

Requires https://github.com/jakartaee/faces/pull/2169 to have a green TCK