### PR TITLE
Update feature pack coords for WildFly 40 Final, EE 11 variant

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -230,8 +230,8 @@
             </activation>
             <properties>
                 <wildfly.dir>${maven.multiModuleProjectDirectory}/target/wildfly</wildfly.dir>
-                <wildfly.feature-pack.artifactId>wildfly-ee-10-feature-pack</wildfly.feature-pack.artifactId>
-                <wildfly.feature-pack.version>40.0.0.Beta1</wildfly.feature-pack.version>
+                <wildfly.feature-pack.artifactId>wildfly-ee-galleon-pack</wildfly.feature-pack.artifactId>
+                <wildfly.feature-pack.version>40.0.0.Final</wildfly.feature-pack.version>
             </properties>
             <dependencies>
                 <dependency>


### PR DESCRIPTION
For WildFly 40, we're creating two variants: EE 10 and EE 11. The Mojarra 4.1 branch should target the EE 11 variant. This PR updates the feature-pack coords to do that.