### PR TITLE
Address as many as possible build and compiler warnings

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -261,11 +261,16 @@
                 </includes>
             </resource>
         </resources>
-        <pluginManagement>
-            <plugins>
-            </plugins>
-        </pluginManagement>
+
         <plugins>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>3.5.0</version>
+				<configuration>
+					<propertiesEncoding>UTF-8</propertiesEncoding>
+				</configuration>
+			</plugin>
+
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.5</version>
@@ -278,7 +283,7 @@
                 </configuration>
             </plugin>
 
-            <!-- Bundles faces.ts via Rollup, minifies via Terser, and runs JavaScript unit tests via Jest. -->
+			<!-- Bundles faces.ts via Rollup, minifies via Terser, and runs JavaScript unit tests via Jest. -->
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
@@ -343,7 +348,7 @@
                 </executions>
             </plugin>
 
-            <!-- Creates the OSGi MANIFEST.MF file -->
+			<!-- Creates the OSGi MANIFEST.MF file -->
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -375,7 +380,6 @@
                         <Extension-Name>jakarta.faces</Extension-Name>
                         
                         <Export-Package>
-                            jakarta.faces.*,
                             org.glassfish.mojarra.*
                         </Export-Package>
                         
@@ -389,7 +393,6 @@
                             jakarta.enterprise.inject.*,
                             jakarta.enterprise.util.*,
                             jakarta.enterprise.context.*,
-                            jakarta.annotation.processing.*,
                             jakarta.annotation.*,
                             javax.crypto.*,
                             jakarta.websocket.*;resolution:=optional,
@@ -400,12 +403,10 @@
                             jakarta.persistence.*;resolution:=optional,
                             javax.xml.*,
                             org.w3c.dom.*,
-                            com.sun.enterprise.*;resolution:=optional,
-                            org.jboss.weld.*;resolution:=optional,
                             org.xml.sax.*,
                             javax.naming.*
                         </Import-Package>
-                        <!--
+						<!--
                             Allow Mojarra to load alternative FaceletConfigResourceProvider,
                             FacesConfigResourceProvider, and ApplicationConfigurationPopulator SPI
                             implementations. Mojarra provides default implementations, so each capability is marked as
@@ -426,7 +427,7 @@
                 </configuration>
             </plugin>
 
-            <!-- Adds the manifest file created by the org.apache.felix:maven-bundle-plugin -->
+			<!-- Adds the manifest file created by the org.apache.felix:maven-bundle-plugin -->
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
@@ -440,7 +441,7 @@
                 </configuration>
             </plugin>
 
-            <!-- Creates the source jar -->
+			<!-- Creates the source jar -->
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>
@@ -453,7 +454,7 @@
                 </executions>
             </plugin>
 
-            <!-- 
+			<!-- 
                Create Javadoc for API jar
             -->
             <plugin>
@@ -476,7 +477,7 @@
                 </executions>
             </plugin>
 
-            <!-- Check licenses of dependencies (Eclipse requirement) -->
+			<!-- Check licenses of dependencies (Eclipse requirement) -->
             <plugin>
                 <groupId>org.eclipse.dash</groupId>
                 <artifactId>license-tool-plugin</artifactId>
@@ -491,7 +492,7 @@
                 </executions>
             </plugin>
 
-            <!-- Generate a "consumer pom" for Maven Central release -->
+			<!-- Generate a "consumer pom" for Maven Central release -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/MetadataTargetImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/MetadataTargetImpl.java
@@ -51,7 +51,8 @@ public class MetadataTargetImpl extends MetadataTarget {
         return pd.get(name);
     }
 
-    @Override
+	@Override
+	@SuppressWarnings("unchecked")
     public boolean isTargetInstanceOf(Class type) {
         return type.isAssignableFrom(this.type);
     }

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/IterationStatusExpression.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/IterationStatusExpression.java
@@ -48,8 +48,8 @@ public final class IterationStatusExpression extends ValueExpression {
      */
     @Override
     @SuppressWarnings("unchecked")
-    public IterationStatus getValue(ELContext context) {
-        return status;
+    public <T> T getValue(ELContext context) {
+        return (T) status;
     }
 
     /*

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/MappedValueExpression.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/MappedValueExpression.java
@@ -80,11 +80,11 @@ public final class MappedValueExpression extends ValueExpression {
      */
     @Override
     @SuppressWarnings("unchecked")
-    public Object getValue(ELContext context) {
+    public <T> T getValue(ELContext context) {
         Object base = orig.getValue(context);
         if (base != null) {
             context.setPropertyResolved(true);
-            return new Entry((Map<Object, Object>) base, key);
+            return (T) new Entry((Map<Object, Object>) base, key);
 
         }
         return null;

--- a/impl/src/test/java/jakarta/faces/component/UIInputTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIInputTestCase.java
@@ -117,7 +117,7 @@ public class UIInputTestCase extends UIOutputTestCase {
     @Test
     public void testEventsGeneric() {
         UIInput input = (UIInput) component;
-        ValueChangeEvent event = new ValueChangeEvent(input, null, null);
+        ValueChangeEvent<?> event = new ValueChangeEvent<>(input, null, null);
 
         // Register three listeners
         input.addValueChangeListener(new ValueChangeListenerTestImpl("AP0"));
@@ -137,7 +137,7 @@ public class UIInputTestCase extends UIOutputTestCase {
         input.setRendererType(null);
         UIViewRoot root = facesContext.getApplication().getViewHandler().createView(facesContext, null);
         root.getChildren().add(input);
-        ValueChangeEvent event = null;
+        ValueChangeEvent<?> event = null;
 
         // Register three listeners
         input.addValueChangeListener(new ValueChangeListenerTestImpl("ARV"));
@@ -145,15 +145,15 @@ public class UIInputTestCase extends UIOutputTestCase {
         input.addValueChangeListener(new ValueChangeListenerTestImpl("AP"));
 
         ValueChangeListenerTestImpl.trace(null);
-        event = new ValueChangeEvent(input, null, null);
+        event = new ValueChangeEvent<>(input, null, null);
         event.setPhaseId(PhaseId.APPLY_REQUEST_VALUES);
         input.queueEvent(event);
 
-        event = new ValueChangeEvent(input, null, null);
+        event = new ValueChangeEvent<>(input, null, null);
         event.setPhaseId(PhaseId.PROCESS_VALIDATIONS);
         input.queueEvent(event);
 
-        event = new ValueChangeEvent(input, null, null);
+        event = new ValueChangeEvent<>(input, null, null);
         event.setPhaseId(PhaseId.INVOKE_APPLICATION);
         input.queueEvent(event);
 

--- a/impl/src/test/java/org/glassfish/mojarra/el/CompositeComponentAttributesELResolverTest.java
+++ b/impl/src/test/java/org/glassfish/mojarra/el/CompositeComponentAttributesELResolverTest.java
@@ -45,6 +45,7 @@ public class CompositeComponentAttributesELResolverTest {
     /**
      * Test issue #2508.
      */
+    @SuppressWarnings("unchecked")
     @Test
     public void testGetValue() throws Exception {
         ELContext elContext1 = Mockito.mock(ELContext.class);

--- a/impl/src/test/java/org/glassfish/mojarra/mock/MockApplication.java
+++ b/impl/src/test/java/org/glassfish/mojarra/mock/MockApplication.java
@@ -246,12 +246,13 @@ public class MockApplication extends Application {
         throw new UnsupportedOperationException();
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    public Converter createConverter(String converterId) {
+    public <T> Converter<T> createConverter(String converterId) {
         String converterClass = converters.get(converterId);
         try {
             Class<?> clazz = Class.forName(converterClass);
-            return ((Converter) clazz.getDeclaredConstructor().newInstance());
+            return (Converter<T>) clazz.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             throw new FacesException(e);
         }
@@ -291,12 +292,13 @@ public class MockApplication extends Application {
         validators.put(validatorId, validatorClass);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    public Validator createValidator(String validatorId) {
+    public <T> Validator<T> createValidator(String validatorId) {
         String validatorClass = validators.get(validatorId);
         try {
             Class<?> clazz = Class.forName(validatorClass);
-            return ((Validator) clazz.getDeclaredConstructor().newInstance());
+            return (Validator<T>) clazz.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             throw new FacesException(e);
         }
@@ -880,7 +882,7 @@ public class MockApplication extends Application {
         private Class<?> sourceClass;
         private Set<SystemEventListener> listeners;
         private Constructor<? extends SystemEvent> eventConstructor;
-        private Map<Class<?>, Constructor> constructorMap;
+        private Map<Class<?>, Constructor<? extends SystemEvent>> constructorMap;
 
         // -------------------------------------------------------- Constructors
         public EventInfo(Class<? extends SystemEvent> systemEvent,
@@ -935,6 +937,7 @@ public class MockApplication extends Application {
 
         }
 
+        @SuppressWarnings("unchecked")
         private Constructor<? extends SystemEvent> getEventConstructor(Class<?> source) {
 
             Constructor<? extends SystemEvent> ctor = null;

--- a/impl/src/test/java/org/glassfish/mojarra/mock/MockApplicationMap.java
+++ b/impl/src/test/java/org/glassfish/mojarra/mock/MockApplicationMap.java
@@ -64,11 +64,12 @@ final class MockApplicationMap implements Map<String, Object> {
     }
 
     @Override
-    public Set entrySet() {
-        Set<Object> set = new HashSet<>();
+    public Set<Map.Entry<String, Object>> entrySet() {
+        Set<Map.Entry<String, Object>> set = new HashSet<>();
         Enumeration<String> keys = context.getAttributeNames();
         while (keys.hasMoreElements()) {
-            set.add(context.getAttribute(keys.nextElement()));
+            String key = keys.nextElement();
+            set.add(Map.entry(key, context.getAttribute(key)));
         }
         return set;
     }

--- a/impl/src/test/java/org/glassfish/mojarra/mock/MockLifecycleFactory.java
+++ b/impl/src/test/java/org/glassfish/mojarra/mock/MockLifecycleFactory.java
@@ -44,8 +44,8 @@ public class MockLifecycleFactory extends LifecycleFactory {
     }
 
     @Override
-    public Iterator getLifecycleIds() {
-        ArrayList result = new ArrayList(1);
+    public Iterator<String> getLifecycleIds() {
+        ArrayList<String> result = new ArrayList<>(1);
         result.add(LifecycleFactory.DEFAULT_LIFECYCLE);
         return result.iterator();
     }

--- a/impl/src/test/java/org/glassfish/mojarra/mock/MockRenderKitFactory.java
+++ b/impl/src/test/java/org/glassfish/mojarra/mock/MockRenderKitFactory.java
@@ -35,7 +35,7 @@ public class MockRenderKitFactory extends RenderKitFactory {
     public MockRenderKitFactory() {
     }
 
-    private Map renderKits = new HashMap();
+    private Map<String, RenderKit> renderKits = new HashMap<>();
 
     @Override
     public void addRenderKit(String renderKitId, RenderKit renderKit) {
@@ -56,7 +56,7 @@ public class MockRenderKitFactory extends RenderKitFactory {
             throw new NullPointerException();
         }
         synchronized (renderKits) {
-            RenderKit renderKit = (RenderKit) renderKits.get(renderKitId);
+            RenderKit renderKit = renderKits.get(renderKitId);
             if (renderKit == null) {
                 throw new IllegalArgumentException(renderKitId);
             }
@@ -65,7 +65,7 @@ public class MockRenderKitFactory extends RenderKitFactory {
     }
 
     @Override
-    public Iterator getRenderKitIds() {
+    public Iterator<String> getRenderKitIds() {
         synchronized (renderKits) {
             return (renderKits.keySet().iterator());
         }

--- a/impl/src/test/java/org/glassfish/mojarra/mock/MockRequestMap.java
+++ b/impl/src/test/java/org/glassfish/mojarra/mock/MockRequestMap.java
@@ -64,11 +64,12 @@ final class MockRequestMap implements Map<String, Object> {
     }
 
     @Override
-    public Set entrySet() {
-        Set<Object> set = new HashSet<>();
+    public Set<Map.Entry<String, Object>> entrySet() {
+        Set<Map.Entry<String, Object>> set = new HashSet<>();
         Enumeration<String> keys = request.getAttributeNames();
         while (keys.hasMoreElements()) {
-            set.add(request.getAttribute(keys.nextElement()));
+            String key = keys.nextElement();
+            set.add(Map.entry(key, request.getAttribute(key)));
         }
         return set;
     }

--- a/impl/src/test/java/org/glassfish/mojarra/mock/MockSessionMap.java
+++ b/impl/src/test/java/org/glassfish/mojarra/mock/MockSessionMap.java
@@ -64,11 +64,12 @@ final class MockSessionMap implements Map<String, Object> {
     }
 
     @Override
-    public Set entrySet() {
-        Set<Object> set = new HashSet<>();
+    public Set<Map.Entry<String, Object>> entrySet() {
+        Set<Map.Entry<String, Object>> set = new HashSet<>();
         Enumeration<String> keys = session.getAttributeNames();
         while (keys.hasMoreElements()) {
-            set.add(session.getAttribute(keys.nextElement()));
+            String key = keys.nextElement();
+            set.add(Map.entry(key, session.getAttribute(key)));
         }
         return set;
     }

--- a/impl/src/test/java/org/glassfish/mojarra/renderkit/html_basic/HeadRendererTest.java
+++ b/impl/src/test/java/org/glassfish/mojarra/renderkit/html_basic/HeadRendererTest.java
@@ -105,7 +105,7 @@ public class HeadRendererTest {
 
         when(facesContext.getResponseWriter()).thenReturn(testResponseWriter);
         when(facesContext.getViewRoot()).thenReturn(viewRoot);
-        when(viewRoot.getComponentResources(facesContext, "head")).thenReturn(Collections.EMPTY_LIST);
+        when(viewRoot.getComponentResources(facesContext, "head")).thenReturn(Collections.emptyList());
 
         headRenderer.encodeEnd(facesContext, htmlHead);
         String html = writer.toString();

--- a/impl/src/test/java/org/glassfish/mojarra/webapp/ConfigBase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/webapp/ConfigBase.java
@@ -52,54 +52,54 @@ public class ConfigBase {
 
 
     // ------------------------------------------------------------ <component>
-    private Map components = null;
+    private Map<String, ConfigComponent> components = null;
 
     public void addComponent(ConfigComponent component) {
         if (components == null) {
-            components = new HashMap();
+            components = new HashMap<>();
         }
         components.put(component.getComponentType(), component);
     }
 
-    public Map getComponents() {
+    public Map<String, ConfigComponent> getComponents() {
         if (components == null) {
-            return (Collections.EMPTY_MAP);
+            return (Collections.emptyMap());
         } else {
             return (this.components);
         }
     }
 
     // ------------------------------------------------------------ <converter>
-    private Map converters = null;
+    private Map<String, ConfigConverter> converters = null;
 
     public void addConverter(ConfigConverter converter) {
         if (converters == null) {
-            converters = new HashMap();
+            converters = new HashMap<>();
         }
         converters.put(converter.getConverterId(), converter);
     }
 
-    public Map getConverters() {
+    public Map<String, ConfigConverter> getConverters() {
         if (converters == null) {
-            return (Collections.EMPTY_MAP);
+            return (Collections.emptyMap());
         } else {
             return (this.converters);
         }
     }
 
     // ------------------------------------------------------------ <validator>
-    private Map validators = null;
+    private Map<String, ConfigValidator> validators = null;
 
     public void addValidator(ConfigValidator validator) {
         if (validators == null) {
-            validators = new HashMap();
+            validators = new HashMap<>();
         }
         validators.put(validator.getValidatorId(), validator);
     }
 
-    public Map getValidators() {
+    public Map<String, ConfigValidator> getValidators() {
         if (validators == null) {
-            return (Collections.EMPTY_MAP);
+            return (Collections.emptyMap());
         } else {
             return (this.validators);
         }

--- a/impl/src/test/java/org/glassfish/mojarra/webapp/ConfigFeature.java
+++ b/impl/src/test/java/org/glassfish/mojarra/webapp/ConfigFeature.java
@@ -28,18 +28,18 @@ import java.util.Map;
  */
 public abstract class ConfigFeature {
 
-    private Map attributes = null;
+    private Map<String, ConfigAttribute> attributes = null;
 
     public void addAttribute(ConfigAttribute attribute) {
         if (attributes == null) {
-            attributes = new HashMap();
+            attributes = new HashMap<>();
         }
         attributes.put(attribute.getAttributeName(), attribute);
     }
 
-    public Map getAttributes() {
+    public Map<String, ConfigAttribute> getAttributes() {
         if (attributes == null) {
-            return (Collections.EMPTY_MAP);
+            return (Collections.emptyMap());
         } else {
             return (attributes);
         }
@@ -75,18 +75,18 @@ public abstract class ConfigFeature {
         this.largeIcon = largeIcon;
     }
 
-    private Map properties = null;
+    private Map<String, ConfigProperty> properties = null;
 
     public void addProperty(ConfigProperty property) {
         if (properties == null) {
-            properties = new HashMap();
+            properties = new HashMap<>();
         }
         properties.put(property.getPropertyName(), property);
     }
 
-    public Map getProperties() {
+    public Map<String, ConfigProperty> getProperties() {
         if (properties == null) {
-            return (Collections.EMPTY_MAP);
+            return (Collections.emptyMap());
         } else {
             return (properties);
         }


### PR DESCRIPTION
Address as many as possible build and compiler warnings when running `mvn clean install` on /impl; currently only deprecation warnings remain which are okay and should not be suppressed