### PR TITLE
Address all javac/ecj compiler warnings

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -271,7 +271,7 @@
 				</configuration>
 			</plugin>
 
-            <!-- Show all compiler warnings. -->
+            <!-- Show all compiler warnings except deprecation/removal (we are aware). -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.15.0</version>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -75,7 +75,7 @@
        <dependency>
            <groupId>jakarta.faces</groupId>
            <artifactId>jakarta.faces-api</artifactId>
-           <version>5.0.0-M2</version>
+           <version>5.0.0-SNAPSHOT</version>
        </dependency>
        
         <!-- Jakarta EE Dependencies -->
@@ -270,6 +270,15 @@
 					<propertiesEncoding>UTF-8</propertiesEncoding>
 				</configuration>
 			</plugin>
+
+            <!-- Show all compiler warnings. -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.15.0</version>
+                <configuration>
+                    <compilerArgument>-Xlint:all,-deprecation,-removal</compilerArgument>
+                </configuration>
+            </plugin>
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -466,7 +475,7 @@
                             <excludePackageNames>com</excludePackageNames>
                             <quiet>true</quiet>
 					        <additionalOptions>
-					            <additionalOption>-Xdoclint:none</additionalOption>
+					            <additionalOption>-Xdoclint:all,-missing</additionalOption>
 					        </additionalOptions>
 					        <failOnError>true</failOnError>
                         </configuration>

--- a/impl/src/main/java/org/glassfish/mojarra/RIConstants.java
+++ b/impl/src/main/java/org/glassfish/mojarra/RIConstants.java
@@ -47,7 +47,7 @@ public class RIConstants {
 
     public static final String NO_VALUE = "";
 
-    public static final Class<?>[] EMPTY_CLASS_ARGS = new Class[0];
+    public static final Class<?>[] EMPTY_CLASS_ARGS = new Class<?>[0];
     public static final Object[] EMPTY_METH_ARGS = new Object[0];
     public static final String[] EMPTY_STRING_ARRAY = new String[0];
 

--- a/impl/src/main/java/org/glassfish/mojarra/application/NavigationHandlerImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/NavigationHandlerImpl.java
@@ -233,7 +233,7 @@ public class NavigationHandlerImpl extends NavigationHandler {
                 String viewIdBefore = context.getViewRoot().getViewId();
                 viewIdBefore = null == viewIdBefore ? "" : viewIdBefore;
                 String viewIdAfter = caseStruct.navCase.getToViewId(context);
-                viewIdAfter = null == viewIdAfter ? "" : viewIdAfter; // NOPMD
+                viewIdAfter = null == viewIdAfter ? "" : viewIdAfter;
                 isUIViewActionBroadcastAndViewdsDiffer = !viewIdBefore.equals(viewIdAfter);
             }
 
@@ -245,14 +245,14 @@ public class NavigationHandlerImpl extends NavigationHandler {
                 // the necessary metadata is appended to the query string
 
                 // If at least one of newFlow and currentFlow is not null
-                if (caseStruct.newFlow != null || caseStruct.currentFlow != null) { // NOPMD
-                    if (!flowsEqual(caseStruct.newFlow, caseStruct.currentFlow)) { // NOPMD
-                        if (parameters == null) { // NOPMD
+                if (caseStruct.newFlow != null || caseStruct.currentFlow != null) {
+                    if (!flowsEqual(caseStruct.newFlow, caseStruct.currentFlow)) {
+                        if (parameters == null) {
                             parameters = new HashMap<>();
                         }
 
                         // If we are exiting all flows
-                        if (caseStruct.newFlow == null) { // NOPMD
+                        if (caseStruct.newFlow == null) {
                             parameters.put(TO_FLOW_DOCUMENT_ID_REQUEST_PARAM_NAME, List.of(NULL_FLOW));
                             parameters.put(FLOW_ID_REQUEST_PARAM_NAME, List.of(""));
                             FlowHandler flowHandler = context.getApplication().getFlowHandler();

--- a/impl/src/main/java/org/glassfish/mojarra/application/annotation/AnnotationManager.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/annotation/AnnotationManager.java
@@ -315,7 +315,7 @@ public class AnnotationManager {
      */
     private static final class ProcessAnnotationsTask implements Callable<Map<Class<? extends Annotation>, RuntimeAnnotationHandler>> {
 
-        @SuppressWarnings({ "unchecked" })
+        @SuppressWarnings("unchecked")
         private static final Map<Class<? extends Annotation>, RuntimeAnnotationHandler> EMPTY = Collections.EMPTY_MAP;
         private final Class<?> clazz;
         private final Scanner[] scanners;

--- a/impl/src/main/java/org/glassfish/mojarra/application/annotation/ResourceDependencyHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/annotation/ResourceDependencyHandler.java
@@ -103,7 +103,7 @@ class ResourceDependencyHandler implements RuntimeAnnotationHandler {
      * @param dep the {@link ResourceDependency} in question
      * @return <code>true</code> if the {@link ResourceDependency} has been processed, otherwise <code>false</code>
      */
-    @SuppressWarnings({ "unchecked" })
+    @SuppressWarnings("unchecked")
     private boolean hasBeenProcessed(FacesContext ctx, ResourceDependency dep) {
 
         Set<ResourceDependency> dependencies = (Set<ResourceDependency>) RequestStateManager.get(ctx, RequestStateManager.PROCESSED_RESOURCE_DEPENDENCIES);
@@ -143,7 +143,7 @@ class ResourceDependencyHandler implements RuntimeAnnotationHandler {
      * @param ctx the {@link FacesContext} for the current request
      * @param dep the {@link ResourceDependency}
      */
-    @SuppressWarnings({ "unchecked" })
+    @SuppressWarnings("unchecked")
     private void markProcssed(FacesContext ctx, ResourceDependency dep) {
 
         Set<ResourceDependency> dependencies = (Set<ResourceDependency>) RequestStateManager.get(ctx, RequestStateManager.PROCESSED_RESOURCE_DEPENDENCIES);

--- a/impl/src/main/java/org/glassfish/mojarra/application/resource/ResourceImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/resource/ResourceImpl.java
@@ -67,6 +67,8 @@ import org.glassfish.mojarra.util.MojarraVersion;
  */
 public class ResourceImpl extends Resource implements Externalizable {
 
+    private static final long serialVersionUID = 1L;
+
     // Log instance for this class
     private static final Logger LOGGER = FacesLogger.APPLICATION.getLogger();
 

--- a/impl/src/main/java/org/glassfish/mojarra/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/view/FaceletViewHandlingStrategy.java
@@ -542,7 +542,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
      * @see ViewHandlingStrategy#retargetAttachedObjects(jakarta.faces.context.FacesContext,
      * jakarta.faces.component.UIComponent, java.util.List)
      */
-    @SuppressWarnings({ "unchecked" })
+    @SuppressWarnings("unchecked")
     @Override
     public void retargetAttachedObjects(FacesContext context, UIComponent topLevelComponent, List<AttachedObjectHandler> handlers) {
         notNull("context", context);
@@ -1409,7 +1409,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
          */
         private static abstract class AbstractRetargetHandler implements MethodRetargetHandler {
 
-            protected static final Class<?>[] NO_ARGS = new Class[0];
+            protected static final Class<?>[] NO_ARGS = new Class<?>[0];
 
         } // END AbstractRetargetHandler
 
@@ -1579,7 +1579,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
                         String strValue = methodSignature.substring(i + 1, j);
                         if (0 < strValue.length()) {
                             String[] params = strValue.split(",");
-                            expectedParameters = new Class[params.length];
+                            expectedParameters = new Class<?>[params.length];
                             boolean exceptionThrown = false;
                             for (i = 0; i < params.length; i++) {
                                 try {

--- a/impl/src/main/java/org/glassfish/mojarra/application/view/ViewHandlingStrategyManager.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/view/ViewHandlingStrategyManager.java
@@ -40,7 +40,6 @@ public class ViewHandlingStrategyManager {
      * Iterate through the available {@link org.glassfish.mojarra.application.view.ViewHandlingStrategy} implementations. The first
      * one to return true from {@link org.glassfish.mojarra.application.view.ViewHandlingStrategy#handlesViewId(String)} will be the
      * {@link org.glassfish.mojarra.application.view.ViewHandlingStrategy} returned.
-     * <p>
      *
      * @param viewId the viewId to match a {@link org.glassfish.mojarra.application.view.ViewHandlingStrategy} to
      *

--- a/impl/src/main/java/org/glassfish/mojarra/cdi/CdiProducer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/cdi/CdiProducer.java
@@ -19,7 +19,6 @@ package org.glassfish.mojarra.cdi;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
-import static java.util.Collections.unmodifiableSet;
 
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
@@ -52,7 +51,7 @@ abstract class CdiProducer<T> implements Bean<T>, PassivationCapable, Serializab
     private String name;
     private Class<?> beanClass = Object.class;
     private Set<Type> types = singleton(Object.class);
-    private Set<Annotation> qualifiers = unmodifiableSet(asSet(new DefaultAnnotationLiteral(), new AnyAnnotationLiteral()));
+    private Set<Annotation> qualifiers = Set.of(new DefaultAnnotationLiteral(), new AnyAnnotationLiteral());
     private Class<? extends Annotation> scope = Dependent.class;
     private Function<CreationalContext<T>, T> create;
 
@@ -176,13 +175,13 @@ abstract class CdiProducer<T> implements Bean<T>, PassivationCapable, Serializab
     }
 
     protected CdiProducer<T> types(Type... types) {
-        this.types = asSet(types);
+        this.types = new HashSet<>(asList(types));
         this.types.add(getClass()); // Add producer class as well so it can at least be filtered from BeanManager#getBeans().
         return this;
     }
 
     protected CdiProducer<T> qualifiers(Annotation... qualifiers) {
-        this.qualifiers = asSet(qualifiers);
+        this.qualifiers = new HashSet<>(asList(qualifiers));
         return this;
     }
 
@@ -194,11 +193,6 @@ abstract class CdiProducer<T> implements Bean<T>, PassivationCapable, Serializab
     protected CdiProducer<T> addToId(Object object) {
         id = id + " " + object.toString();
         return this;
-    }
-
-    @SafeVarargs
-    private static <T> Set<T> asSet(T... a) {
-        return new HashSet<>(asList(a));
     }
 
 }

--- a/impl/src/main/java/org/glassfish/mojarra/component/validator/ComponentValidators.java
+++ b/impl/src/main/java/org/glassfish/mojarra/component/validator/ComponentValidators.java
@@ -98,7 +98,7 @@ public class ComponentValidators {
      * @param ctx the <code>FacesContext</code> for the current request
      * @param editableValueHolder the component receiving the <code>Validator</code>s
      */
-    @SuppressWarnings({ "unchecked" })
+    @SuppressWarnings("unchecked")
     public static void addDefaultValidatorsToComponent(FacesContext ctx, EditableValueHolder editableValueHolder) {
 
         if (ComponentSupport.isBuildingNewComponentTree(ctx)) {
@@ -125,7 +125,7 @@ public class ComponentValidators {
      * @param ctx the <code>FacesContext</code> for the current request
      * @param editableValueHolder the component receiving the <code>Validator</code>s
      */
-    @SuppressWarnings({ "unchecked" })
+    @SuppressWarnings("unchecked")
     public void addValidators(FacesContext ctx, EditableValueHolder editableValueHolder) {
 
         if (validatorStack == null || validatorStack.isEmpty()) {

--- a/impl/src/main/java/org/glassfish/mojarra/config/configprovider/MetaInfFacesConfigResourceProvider.java
+++ b/impl/src/main/java/org/glassfish/mojarra/config/configprovider/MetaInfFacesConfigResourceProvider.java
@@ -78,7 +78,6 @@ public class MetaInfFacesConfigResourceProvider implements ConfigurationResource
             duplicatePattern = Pattern.compile(duplicateJarPattern);
         }
         SortedMap<String, Set<URI>> sortedJarMap = new TreeMap<>();
-        // noinspection CollectionWithoutInitialCapacity
         List<URI> unsortedResourceList = new ArrayList<>();
 
         try {

--- a/impl/src/main/java/org/glassfish/mojarra/config/processor/ApplicationConfigProcessor.java
+++ b/impl/src/main/java/org/glassfish/mojarra/config/processor/ApplicationConfigProcessor.java
@@ -745,7 +745,6 @@ public class ApplicationConfigProcessor extends AbstractConfigProcessor {
                 try {
                     // If there is an eventClass, use it, otherwise use
                     // SystemEvent.class
-                    // noinspection unchecked
                     Class<? extends SystemEvent> eventClazz;
 
                     if (eventClass != null) {

--- a/impl/src/main/java/org/glassfish/mojarra/config/processor/FaceletTaglibConfigProcessor.java
+++ b/impl/src/main/java/org/glassfish/mojarra/config/processor/FaceletTaglibConfigProcessor.java
@@ -616,9 +616,9 @@ public class FaceletTaglibConfigProcessor extends AbstractConfigProcessor {
                     String[] ps = signature.substring(pos2 + 1, pos).trim().split(",");
                     Class<?>[] pc;
                     if (ps.length == 1 && "".equals(ps[0])) {
-                        pc = new Class[0];
+                        pc = new Class<?>[0];
                     } else {
-                        pc = new Class[ps.length];
+                        pc = new Class<?>[ps.length];
                         for (int i = 0; i < pc.length; i++) {
                             pc[i] = ReflectionUtil.forName(ps[i].trim());
                         }

--- a/impl/src/main/java/org/glassfish/mojarra/config/processor/FacesFlowDefinitionConfigProcessor.java
+++ b/impl/src/main/java/org/glassfish/mojarra/config/processor/FacesFlowDefinitionConfigProcessor.java
@@ -634,7 +634,7 @@ public class FacesFlowDefinitionConfigProcessor extends AbstractConfigProcessor 
                     }
                     methodCallBuilder.parameters(paramList);
                 }
-                Class<?>[] paramArray = new Class[paramTypes.size()];
+                Class<?>[] paramArray = new Class<?>[paramTypes.size()];
                 paramTypes.toArray(paramArray);
                 methodCallBuilder.expression(methodStr, paramArray);
             }

--- a/impl/src/main/java/org/glassfish/mojarra/context/SessionMap.java
+++ b/impl/src/main/java/org/glassfish/mojarra/context/SessionMap.java
@@ -78,7 +78,6 @@ public class SessionMap extends BaseContextMap<Object> {
                     LOGGER.log(Level.WARNING, "faces.context.extcontext.sessionmap.nonserializable", new Object[] { k, v.getClass().getName() });
                 }
             }
-            // noinspection NonSerializableObjectBoundToHttpSession
             session.setAttribute((String) k, v);
         }
     }
@@ -101,7 +100,6 @@ public class SessionMap extends BaseContextMap<Object> {
                 LOGGER.log(Level.WARNING, "faces.context.extcontext.sessionmap.nonserializable", new Object[] { key, value.getClass().getName() });
             }
         }
-        // noinspection NonSerializableObjectBoundToHttpSession
         boolean doSet = true;
         if (null != value && null != result) {
             int valCode = System.identityHashCode(value);

--- a/impl/src/main/java/org/glassfish/mojarra/el/CompositeComponentAttributesELResolver.java
+++ b/impl/src/main/java/org/glassfish/mojarra/el/CompositeComponentAttributesELResolver.java
@@ -224,7 +224,6 @@ public class CompositeComponentAttributesELResolver extends ELResolver {
     public Map<String, Object> getEvalMapFor(UIComponent c, FacesContext ctx) {
 
         Map<Object, Object> ctxAttributes = ctx.getAttributes();
-        // noinspection unchecked
         Map<UIComponent, Map<String, Object>> topMap = (Map<UIComponent, Map<String, Object>>) ctxAttributes.get(EVAL_MAP_KEY);
         Map<String, Object> evalMap = null;
         if (topMap == null) {

--- a/impl/src/main/java/org/glassfish/mojarra/ext/component/UIValidateWholeBean.java
+++ b/impl/src/main/java/org/glassfish/mojarra/ext/component/UIValidateWholeBean.java
@@ -65,11 +65,14 @@ public class UIValidateWholeBean extends UIInput implements PartialStateHolder {
         return getFamily();
     }
 
+    // ValueHolder/EditableValueHolder still declare these raw, so the overrides must match the raw erasure.
     @Override
+    @SuppressWarnings("rawtypes")
     public void setConverter(Converter converter) {
     }
 
     @Override
+    @SuppressWarnings("rawtypes")
     public final void addValidator(Validator validator) {
         if (validator instanceof WholeBeanValidator) {
             super.addValidator(validator);
@@ -164,7 +167,7 @@ public class UIValidateWholeBean extends UIInput implements PartialStateHolder {
     }
 
     private boolean isValidatorInstalled() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.ValidatorInstalled, false);
+        return getStateHelper().eval(PropertyKeys.ValidatorInstalled, false);
     }
 
     private void setValidatorInstalled(boolean newValue) {
@@ -193,7 +196,7 @@ public class UIValidateWholeBean extends UIInput implements PartialStateHolder {
             }
         }
 
-        cachedValidationGroups = validationGroupsList.toArray(new Class[validationGroupsList.size()]);
+        cachedValidationGroups = validationGroupsList.toArray(new Class<?>[validationGroupsList.size()]);
 
         return cachedValidationGroups;
     }

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/compiler/TextUnit.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/compiler/TextUnit.java
@@ -186,7 +186,7 @@ final class TextUnit extends CompilationUnit {
     }
 
     public void endTag() {
-        Tag tag = (Tag) tags.pop();
+        Tag tag = tags.pop();
 
         addInstruction(new EndElementInstruction(tag.getQName()));
 
@@ -230,7 +230,7 @@ final class TextUnit extends CompilationUnit {
 
             } catch (ELException e) {
                 if (tags.size() > 0) {
-                    throw new TagException((Tag) tags.peek(), e.getMessage());
+                    throw new TagException(tags.peek(), e.getMessage());
                 } else {
                     throw new ELException(alias + ": " + e.getMessage(), e.getCause());
                 }

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/compiler/UILeaf.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/compiler/UILeaf.java
@@ -164,7 +164,7 @@ public class UILeaf extends UIComponentBase implements UntargetableComponent {
     }
 
     @Override
-    protected FacesListener[] getFacesListeners(Class faces) {
+    protected FacesListener[] getFacesListeners(Class<? extends FacesListener> faces) {
         return null;
     }
 
@@ -199,7 +199,7 @@ public class UILeaf extends UIComponentBase implements UntargetableComponent {
     }
 
     @Override
-    protected Renderer getRenderer(FacesContext faces) {
+    protected <T extends UIComponent> Renderer<T> getRenderer(FacesContext faces) {
         return null;
     }
 

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/component/RepeatRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/component/RepeatRenderer.java
@@ -60,7 +60,7 @@ public class RepeatRenderer extends Renderer<UIRepeat> {
             Iterator<UIComponent> itr = component.getChildren().iterator();
             UIComponent c;
             while (itr.hasNext()) {
-                c = (UIComponent) itr.next();
+                c = itr.next();
                 c.encodeAll(context);
             }
 

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/component/UIRepeat.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/component/UIRepeat.java
@@ -274,7 +274,6 @@ public class UIRepeat extends UINamingContainer {
     }
 
     private void setDataModel(DataModel<?> model) {
-        // noinspection unchecked
         this.model = model;
     }
 
@@ -329,10 +328,8 @@ public class UIRepeat extends UINamingContainer {
                     effectiveEnd = s;
                 }
             } else if (val instanceof DataModel) {
-                // noinspection unchecked
                 model = (DataModel<Object>) val;
             } else if (val instanceof List) {
-                // noinspection unchecked
                 model = new ListDataModel<>((List<Object>) val);
             } else if (Object[].class.isAssignableFrom(val.getClass())) {
                 model = new ArrayDataModel<>((Object[]) val);
@@ -465,7 +462,7 @@ public class UIRepeat extends UINamingContainer {
 
         Iterator<UIComponent> itr = c.getFacetsAndChildren();
         while (itr.hasNext()) {
-            removeChildState(faces, (UIComponent) itr.next());
+            removeChildState(faces, itr.next());
         }
         if (childState != null) {
             childState.remove(c.getClientId(faces));
@@ -487,7 +484,7 @@ public class UIRepeat extends UINamingContainer {
         // continue hack
         Iterator<UIComponent> itr = c.getFacetsAndChildren();
         while (itr.hasNext()) {
-            saveChildState(faces, (UIComponent) itr.next());
+            saveChildState(faces, itr.next());
         }
     }
 
@@ -520,7 +517,7 @@ public class UIRepeat extends UINamingContainer {
         // continue hack
         Iterator<UIComponent> itr = c.getFacetsAndChildren();
         while (itr.hasNext()) {
-            restoreChildState(faces, (UIComponent) itr.next());
+            restoreChildState(faces, itr.next());
         }
     }
 
@@ -641,7 +638,6 @@ public class UIRepeat extends UINamingContainer {
         return getDataModel().isRowAvailable();
     }
 
-    @SuppressWarnings("unchecked")
     public void process(FacesContext faces, PhaseId phase) {
 
         // stop if not rendered
@@ -707,7 +703,7 @@ public class UIRepeat extends UINamingContainer {
                     } else {
                         itr = getChildren().iterator();
                         while (itr.hasNext()) {
-                            c = (UIComponent) itr.next();
+                            c = itr.next();
                             if (PhaseId.APPLY_REQUEST_VALUES.equals(phase)) {
                                 c.processDecodes(faces);
                             } else if (PhaseId.PROCESS_VALIDATIONS.equals(phase)) {
@@ -1141,7 +1137,6 @@ public class UIRepeat extends UINamingContainer {
         }
         Object[] state = (Object[]) object;
         super.restoreState(faces, state[0]);
-        // noinspection unchecked
         childState = (Map<String, SavedState>) state[1];
         begin = (Integer) state[2];
         end = (Integer) state[3];

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/el/DefaultFunctionMapper.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/el/DefaultFunctionMapper.java
@@ -179,19 +179,6 @@ public final class DefaultFunctionMapper extends FunctionMapper implements Exter
             return m;
         }
 
-        @SuppressWarnings("unused")
-        public boolean matches(String prefix, String localName) {
-            if (this.prefix != null) {
-                if (prefix == null) {
-                    return false;
-                }
-                if (!this.prefix.equals(prefix)) {
-                    return false;
-                }
-            }
-            return this.localName.equals(localName);
-        }
-
         /*
          * (non-Javadoc)
          *

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/impl/DefaultFacelet.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/impl/DefaultFacelet.java
@@ -327,6 +327,8 @@ final class DefaultFacelet extends Facelet implements XMLFrontMatterSaver {
     }
 
     private static class ApplyToken implements Externalizable {
+        private static final long serialVersionUID = 1L;
+
         public String alias;
 
         public long time;

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/impl/DefaultFaceletContext.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/impl/DefaultFaceletContext.java
@@ -296,7 +296,7 @@ final class DefaultFaceletContext extends FaceletContextImplBase {
         if (!clients.isEmpty()) {
             Iterator<TemplateManager> itr = clients.iterator();
             while (itr.hasNext()) {
-                if (itr.next().equals(client)) {
+                if (itr.next().wraps(client)) {
                     itr.remove();
                     return;
                 }
@@ -322,8 +322,7 @@ final class DefaultFaceletContext extends FaceletContextImplBase {
 
         for (int i = 0, size = clients.size(); i < size && !found; i++) {
             client = clients.get(i);
-            // noinspection EqualsBetweenInconvertibleTypes
-            if (client.equals(facelet)) {
+            if (client.wraps(facelet)) {
                 continue;
             }
             found = client.apply(this, parent, name);
@@ -358,10 +357,8 @@ final class DefaultFaceletContext extends FaceletContextImplBase {
             }
         }
 
-        @Override
-        public boolean equals(Object o) {
-            // System.out.println(this.owner.getAlias() + " == " +
-            // ((DefaultFacelet) o).getAlias());
+        // Returns true if the given facelet or template client is the one this manager wraps.
+        boolean wraps(Object o) {
             return owner == o || target == o;
         }
     }

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/AbstractTagLibrary.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/AbstractTagLibrary.java
@@ -178,7 +178,7 @@ public abstract class AbstractTagLibrary implements TagLibrary {
     }
 
     private static class HandlerFactory implements TagHandlerFactory {
-        private final static Class<?>[] CONSTRUCTOR_SIG = new Class[] { TagConfig.class };
+        private final static Class<?>[] CONSTRUCTOR_SIG = new Class<?>[] { TagConfig.class };
 
         protected final Class<?> handlerType;
 
@@ -304,7 +304,7 @@ public abstract class AbstractTagLibrary implements TagLibrary {
 
     private static class UserComponentHandlerFactory implements TagHandlerFactory {
 
-        private final static Class<?>[] CONS_SIG = new Class[] { ComponentConfig.class };
+        private final static Class<?>[] CONS_SIG = new Class<?>[] { ComponentConfig.class };
 
         protected final String componentType;
 
@@ -386,7 +386,7 @@ public abstract class AbstractTagLibrary implements TagLibrary {
     }
 
     private static class UserConverterHandlerFactory implements TagHandlerFactory {
-        private final static Class<?>[] CONS_SIG = new Class[] { ConverterConfig.class };
+        private final static Class<?>[] CONS_SIG = new Class<?>[] { ConverterConfig.class };
 
         protected final String converterId;
 
@@ -418,7 +418,7 @@ public abstract class AbstractTagLibrary implements TagLibrary {
     }
 
     private static class UserValidatorHandlerFactory implements TagHandlerFactory {
-        private final static Class<?>[] CONS_SIG = new Class[] { ValidatorConfig.class };
+        private final static Class<?>[] CONS_SIG = new Class<?>[] { ValidatorConfig.class };
 
         protected final String validatorId;
 
@@ -450,7 +450,7 @@ public abstract class AbstractTagLibrary implements TagLibrary {
     }
 
     private static class UserBehaviorHandlerFactory implements TagHandlerFactory {
-        private final static Class<?>[] CONS_SIG = new Class[] { BehaviorConfig.class };
+        private final static Class<?>[] CONS_SIG = new Class<?>[] { BehaviorConfig.class };
 
         protected final String behaviorId;
 

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/MetaTagHandlerImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/MetaTagHandlerImpl.java
@@ -40,7 +40,7 @@ public abstract class MetaTagHandlerImpl extends MetaTagHandler {
      * @param type
      */
     @Override
-    protected MetaRuleset createMetaRuleset(Class type) {
+    protected MetaRuleset createMetaRuleset(Class<?> type) {
         Util.notNull("type", type);
         return new MetaRulesetImpl(tag, type);
     }

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/MetadataTargetImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/MetadataTargetImpl.java
@@ -52,8 +52,7 @@ public class MetadataTargetImpl extends MetadataTarget {
     }
 
 	@Override
-	@SuppressWarnings("unchecked")
-    public boolean isTargetInstanceOf(Class type) {
+    public boolean isTargetInstanceOf(Class<?> type) {
         return type.isAssignableFrom(this.type);
     }
 

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/TagAttributeImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/TagAttributeImpl.java
@@ -164,7 +164,7 @@ public class TagAttributeImpl extends TagAttribute {
      * @return a MethodExpression instance
      */
     @Override
-    public MethodExpression getMethodExpression(FaceletContext ctx, Class type, Class[] paramTypes) {
+    public MethodExpression getMethodExpression(FaceletContext ctx, Class<?> type, Class<?>[] paramTypes) {
 
         MethodExpression result;
 
@@ -274,8 +274,7 @@ public class TagAttributeImpl extends TagAttribute {
      * @return Object value of this attribute
      */
     @Override
-    @SuppressWarnings("unchecked")
-    public Object getObject(FaceletContext ctx, Class type) {
+    public Object getObject(FaceletContext ctx, Class<?> type) {
         if (literal) {
             if (String.class.equals(type)) {
                 return value;
@@ -306,7 +305,7 @@ public class TagAttributeImpl extends TagAttribute {
      * @return ValueExpression instance
      */
     @Override
-    public ValueExpression getValueExpression(FaceletContext ctx, Class type) {
+    public ValueExpression getValueExpression(FaceletContext ctx, Class<?> type) {
         return getValueExpression(ctx, value, type);
     }
 

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/UserTagHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/UserTagHandler.java
@@ -114,7 +114,7 @@ final class UserTagHandler extends TagHandlerImpl implements TemplateClient {
             if (handlers == null) {
                 return false;
             }
-            DefineHandler handler = (DefineHandler) handlers.get(name);
+            DefineHandler handler = handlers.get(name);
             if (handler != null) {
                 handler.applyDefinition(ctx, parent);
                 return true;

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/composite/BehaviorHolderAttachedObjectTargetImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/composite/BehaviorHolderAttachedObjectTargetImpl.java
@@ -28,18 +28,11 @@ public class BehaviorHolderAttachedObjectTargetImpl extends AttachedObjectTarget
 
     private boolean defaultEvent;
 
-    /**
-     * <p class="changed_added_2_0">
-     * </p>
-     */
     public BehaviorHolderAttachedObjectTargetImpl() {
 
     }
 
     /**
-     * <p class="changed_added_2_0">
-     * </p>
-     *
      * @return the event
      */
     public String getEvent() {
@@ -47,9 +40,6 @@ public class BehaviorHolderAttachedObjectTargetImpl extends AttachedObjectTarget
     }
 
     /**
-     * <p class="changed_added_2_0">
-     * </p>
-     *
      * @param event the event to set
      */
     public void setEvent(String event) {
@@ -57,9 +47,6 @@ public class BehaviorHolderAttachedObjectTargetImpl extends AttachedObjectTarget
     }
 
     /**
-     * <p class="changed_added_2_0">
-     * </p>
-     *
      * @return the defaultEvent
      */
     @Override
@@ -68,9 +55,6 @@ public class BehaviorHolderAttachedObjectTargetImpl extends AttachedObjectTarget
     }
 
     /**
-     * <p class="changed_added_2_0">
-     * </p>
-     *
      * @param defaultEvent the defaultEvent to set
      */
     public void setDefaultEvent(boolean defaultEvent) {

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/composite/BehaviorHolderWrapper.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/composite/BehaviorHolderWrapper.java
@@ -408,12 +408,12 @@ public class BehaviorHolderWrapper extends UIComponent implements ClientBehavior
     }
 
     @Override
-    protected FacesListener[] getFacesListeners(Class clazz) {
+    protected FacesListener[] getFacesListeners(Class<? extends FacesListener> clazz) {
         return new FacesListener[0];
     }
 
     @Override
-    protected Renderer getRenderer(FacesContext context) {
+    protected <T extends UIComponent> Renderer<T> getRenderer(FacesContext context) {
         return null;
     }
 

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/composite/CompositeAttributePropertyDescriptor.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/composite/CompositeAttributePropertyDescriptor.java
@@ -49,7 +49,7 @@ public class CompositeAttributePropertyDescriptor extends PropertyDescriptor {
 
                     setValue(attributeName, result);
                 } catch (ClassNotFoundException ex) {
-                    classStr = "java.lang." + classStr; // NOPMD
+                    classStr = "java.lang." + classStr;
                     boolean throwException = false;
                     try {
                         result = ReflectionUtil.forName(classStr);

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/composite/CompositeComponentBeanInfo.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/composite/CompositeComponentBeanInfo.java
@@ -32,6 +32,8 @@ import jakarta.faces.FacesException;
 
 public class CompositeComponentBeanInfo extends SimpleBeanInfo implements BeanInfo, Externalizable {
 
+    private static final long serialVersionUID = 1L;
+
     private BeanDescriptor descriptor = null;
 
     @Override
@@ -87,7 +89,7 @@ public class CompositeComponentBeanInfo extends SimpleBeanInfo implements BeanIn
 
             try {
                 String name = (String) in.readObject();
-                CompositeAttributePropertyDescriptor pd = new CompositeAttributePropertyDescriptor(name, null, null); // NOPMD
+                CompositeAttributePropertyDescriptor pd = new CompositeAttributePropertyDescriptor(name, null, null);
 
                 Object type = in.readObject();
                 if (type != null) {

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/composite/CompositeLibrary.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/composite/CompositeLibrary.java
@@ -16,7 +16,6 @@
 
 package org.glassfish.mojarra.facelets.tag.composite;
 
-import static org.glassfish.mojarra.util.Util.unmodifiableSet;
 
 import java.util.Set;
 
@@ -32,7 +31,7 @@ public final class CompositeLibrary extends AbstractTagLibrary {
     private final static String JcpNamespace = "http://xmlns.jcp.org/jsf/composite";
     private final static String JakartaNamespace = "jakarta.faces.composite";
 
-    public final static Set<String> NAMESPACES = unmodifiableSet(JakartaNamespace, JcpNamespace, SunNamespace);
+    public final static Set<String> NAMESPACES = Set.of(JakartaNamespace, JcpNamespace, SunNamespace);
     public final static String DEFAULT_NAMESPACE = JakartaNamespace;
 
     public CompositeLibrary(String namespace) {

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/composite/DeclareFacetHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/composite/DeclareFacetHandler.java
@@ -47,7 +47,7 @@ public class DeclareFacetHandler extends TagHandlerImpl {
 
     }
 
-    @SuppressWarnings({ "unchecked" })
+    @SuppressWarnings("unchecked")
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
         // only process if it's been created

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/composite/InterfaceHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/composite/InterfaceHandler.java
@@ -171,7 +171,7 @@ public class InterfaceHandler extends TagHandlerImpl {
         }
     }
 
-    @SuppressWarnings({ "unchecked" })
+    @SuppressWarnings("unchecked")
     private void imbueComponentWithMetadata(FaceletContext ctx, UIComponent parent) {
         // only process if it's been created
         if (null == parent || null == (parent = parent.getParent()) || !ComponentHandler.isNew(parent)) {

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/ActionSourceRule.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/ActionSourceRule.java
@@ -35,10 +35,10 @@ import jakarta.faces.view.facelets.TagAttribute;
  */
 final class ActionSourceRule extends MetaRule {
 
-    public final static Class<?>[] ACTION_SIG = new Class[0];
+    public final static Class<?>[] ACTION_SIG = new Class<?>[0];
 
-    public final static Class<?>[] ACTION_LISTENER_SIG = new Class[] { ActionEvent.class };
-    public final static Class<?>[] ACTION_LISTENER_ZEROARG_SIG = new Class[] {};
+    public final static Class<?>[] ACTION_LISTENER_SIG = new Class<?>[] { ActionEvent.class };
+    public final static Class<?>[] ACTION_LISTENER_ZEROARG_SIG = new Class<?>[] {};
 
     final static class ActionMapper2 extends Metadata {
 

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/BehaviorTagHandlerDelegateImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/BehaviorTagHandlerDelegateImpl.java
@@ -132,7 +132,7 @@ class BehaviorTagHandlerDelegateImpl extends TagHandlerDelegate implements Attac
     }
 
     @Override
-    public MetaRuleset createMetaRuleset(Class type) {
+    public MetaRuleset createMetaRuleset(Class<?> type) {
         Util.notNull("type", type);
         MetaRuleset m = new MetaRulesetImpl(owner.getTag(), type);
         m = m.ignore("event");

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/ComponentRule.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/ComponentRule.java
@@ -59,7 +59,7 @@ final class ComponentRule extends MetaRule {
 
         private final Class<?> type;
 
-        public ValueExpressionMetadata(String name, Class type, TagAttribute attr) {
+        public ValueExpressionMetadata(String name, Class<?> type, TagAttribute attr) {
             this.name = name;
             this.attr = attr;
             this.type = type;

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
@@ -261,7 +261,7 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
     }
 
     @Override
-    public MetaRuleset createMetaRuleset(Class type) {
+    public MetaRuleset createMetaRuleset(Class<?> type) {
         Util.notNull("type", type);
         MetaRuleset m = new MetaRulesetImpl(owner.getTag(), type);
 

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/CompositeComponentTagHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/CompositeComponentTagHandler.java
@@ -215,7 +215,7 @@ public class CompositeComponentTagHandler extends ComponentHandler implements Cr
      *
      */
     @Override
-    protected MetaRuleset createMetaRuleset(Class type) {
+    protected MetaRuleset createMetaRuleset(Class<?> type) {
 
         Util.notNull("type", type);
         FacesContext context = FacesContext.getCurrentInstance();
@@ -275,7 +275,7 @@ public class CompositeComponentTagHandler extends ComponentHandler implements Cr
      */
     private static final String ATTACHED_OBJECT_HANDLERS_KEY = "jakarta.faces.view.AttachedObjectHandlers";
 
-    @SuppressWarnings({ "unchecked" })
+    @SuppressWarnings("unchecked")
     public static List<AttachedObjectHandler> getAttachedObjectHandlers(UIComponent component, boolean create) {
         Map<String, Object> attrs = component.getAttributes();
         List<AttachedObjectHandler> result = (List<AttachedObjectHandler>) attrs.get(ATTACHED_OBJECT_HANDLERS_KEY);

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/ConverterTagHandlerDelegateImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/ConverterTagHandlerDelegateImpl.java
@@ -69,7 +69,7 @@ public class ConverterTagHandlerDelegateImpl extends TagHandlerDelegate implemen
     }
 
     @Override
-    public MetaRuleset createMetaRuleset(Class type) {
+    public MetaRuleset createMetaRuleset(Class<?> type) {
         Util.notNull("type", type);
         MetaRuleset m = new MetaRulesetImpl(owner.getTag(), type);
 

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/PassThroughAttributeLibrary.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/PassThroughAttributeLibrary.java
@@ -16,7 +16,6 @@
 
 package org.glassfish.mojarra.facelets.tag.faces;
 
-import static org.glassfish.mojarra.util.Util.unmodifiableSet;
 
 import java.util.Set;
 
@@ -27,7 +26,7 @@ public final class PassThroughAttributeLibrary extends AbstractTagLibrary {
     private final static String JcpNamespace = "http://xmlns.jcp.org/jsf/passthrough";
     private final static String JakartaNamespace = "jakarta.faces.passthrough";
 
-    public final static Set<String> NAMESPACES = unmodifiableSet(JakartaNamespace, JcpNamespace);
+    public final static Set<String> NAMESPACES = Set.of(JakartaNamespace, JcpNamespace);
     public final static String DEFAULT_NAMESPACE = JakartaNamespace;
 
     public PassThroughAttributeLibrary(String namespace) {

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/PassThroughElementLibrary.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/PassThroughElementLibrary.java
@@ -16,7 +16,6 @@
 
 package org.glassfish.mojarra.facelets.tag.faces;
 
-import static org.glassfish.mojarra.util.Util.unmodifiableSet;
 
 import java.util.Set;
 
@@ -27,7 +26,7 @@ public final class PassThroughElementLibrary extends AbstractTagLibrary {
     private final static String JcpNamespace = "http://xmlns.jcp.org/jsf";
     private final static String JakartaNamespace = "jakarta.faces";
 
-    public final static Set<String> NAMESPACES = unmodifiableSet(JakartaNamespace, JcpNamespace);
+    public final static Set<String> NAMESPACES = Set.of(JakartaNamespace, JcpNamespace);
     public final static String DEFAULT_NAMESPACE = JakartaNamespace;
 
     public PassThroughElementLibrary(String namespace) {

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/ValidatorTagHandlerDelegateImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/ValidatorTagHandlerDelegateImpl.java
@@ -70,7 +70,7 @@ public class ValidatorTagHandlerDelegateImpl extends TagHandlerDelegate implemen
     }
 
     @Override
-    public MetaRuleset createMetaRuleset(Class type) {
+    public MetaRuleset createMetaRuleset(Class<?> type) {
 
         Util.notNull("type", type);
         MetaRuleset m = new MetaRulesetImpl(owner.getTag(), type);
@@ -81,7 +81,7 @@ public class ValidatorTagHandlerDelegateImpl extends TagHandlerDelegate implemen
 
     // -------------------------------------- Methods from AttachedObjectHandler
 
-    @SuppressWarnings({ "unchecked" })
+    @SuppressWarnings("unchecked")
     @Override
     public void applyAttachedObject(FacesContext context, UIComponent parent) {
 

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/core/ConvertDateTimeHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/core/ConvertDateTimeHandler.java
@@ -138,7 +138,7 @@ public final class ConvertDateTimeHandler extends ConverterHandler {
     }
 
     @Override
-    public MetaRuleset createMetaRuleset(Class type) {
+    public MetaRuleset createMetaRuleset(Class<?> type) {
         return super.createMetaRuleset(type).ignoreAll();
     }
 }

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/core/ConvertDelegateHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/core/ConvertDelegateHandler.java
@@ -56,7 +56,7 @@ public final class ConvertDelegateHandler extends ConverterHandler {
     }
 
     @Override
-    protected MetaRuleset createMetaRuleset(Class type) {
+    protected MetaRuleset createMetaRuleset(Class<?> type) {
         return super.createMetaRuleset(type).ignoreAll();
     }
 }

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/core/ConvertNumberHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/core/ConvertNumberHandler.java
@@ -74,7 +74,7 @@ public final class ConvertNumberHandler extends ConverterHandler {
     }
 
     @Override
-    public MetaRuleset createMetaRuleset(Class type) {
+    public MetaRuleset createMetaRuleset(Class<?> type) {
         return super.createMetaRuleset(type).ignore("locale");
     }
 

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/core/CoreLibrary.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/core/CoreLibrary.java
@@ -16,7 +16,6 @@
 
 package org.glassfish.mojarra.facelets.tag.faces.core;
 
-import static org.glassfish.mojarra.util.Util.unmodifiableSet;
 
 import java.util.Set;
 
@@ -57,7 +56,7 @@ public final class CoreLibrary extends AbstractTagLibrary {
     private final static String JcpNamespace = "http://xmlns.jcp.org/jsf/core";
     private final static String JakartaNamespace = "jakarta.faces.core";
 
-    public final static Set<String> NAMESPACES = unmodifiableSet(JakartaNamespace, JcpNamespace, SunNamespace);
+    public final static Set<String> NAMESPACES = Set.of(JakartaNamespace, JcpNamespace, SunNamespace);
     public final static String DEFAULT_NAMESPACE = JakartaNamespace;
 
     public CoreLibrary(String namespace) {

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/core/ValidateDelegateHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/core/ValidateDelegateHandler.java
@@ -51,7 +51,7 @@ public final class ValidateDelegateHandler extends ValidatorHandler {
     }
 
     @Override
-    protected MetaRuleset createMetaRuleset(Class type) {
+    protected MetaRuleset createMetaRuleset(Class<?> type) {
         return super.createMetaRuleset(type).ignoreAll();
     }
 

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/html/HtmlComponentHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/html/HtmlComponentHandler.java
@@ -34,7 +34,7 @@ public class HtmlComponentHandler extends ComponentHandler {
     }
 
     @Override
-    protected MetaRuleset createMetaRuleset(Class type) {
+    protected MetaRuleset createMetaRuleset(Class<?> type) {
         return super.createMetaRuleset(type).alias("class", "styleClass");
     }
 

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/html/HtmlLibrary.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/html/HtmlLibrary.java
@@ -16,7 +16,6 @@
 
 package org.glassfish.mojarra.facelets.tag.faces.html;
 
-import static org.glassfish.mojarra.util.Util.unmodifiableSet;
 
 import java.util.Set;
 
@@ -62,7 +61,7 @@ public final class HtmlLibrary extends AbstractHtmlLibrary {
     private final static String JcpNamespace = "http://xmlns.jcp.org/jsf/html";
     private final static String JakartaNamespace = "jakarta.faces.html";
 
-    public final static Set<String> NAMESPACES = unmodifiableSet(JakartaNamespace, JcpNamespace, SunNamespace);
+    public final static Set<String> NAMESPACES = Set.of(JakartaNamespace, JcpNamespace, SunNamespace);
     public final static String DEFAULT_NAMESPACE = JakartaNamespace;
 
     public HtmlLibrary(String namespace) {

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/ChooseHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/ChooseHandler.java
@@ -47,7 +47,7 @@ public final class ChooseHandler extends TagHandlerImpl {
         if (whenList.isEmpty()) {
             throw new TagException(tag, "Choose Tag must have one or more When Tags");
         }
-        when = (ChooseWhenHandler[]) whenList.toArray(new ChooseWhenHandler[whenList.size()]);
+        when = whenList.toArray(new ChooseWhenHandler[whenList.size()]);
 
         Iterator<ChooseOtherwiseHandler> itr2 = this.findNextByType(ChooseOtherwiseHandler.class);
         if (itr2.hasNext()) {

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/JstlCoreLibrary.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/JstlCoreLibrary.java
@@ -16,7 +16,6 @@
 
 package org.glassfish.mojarra.facelets.tag.jstl.core;
 
-import static org.glassfish.mojarra.util.Util.unmodifiableSet;
 
 import java.util.Set;
 
@@ -34,7 +33,7 @@ public final class JstlCoreLibrary extends AbstractTagLibrary {
     private final static String JcpNamespace = "http://xmlns.jcp.org/jsp/jstl/core";
     private final static String JakartaNamespace = "jakarta.tags.core";
 
-    public final static Set<String> NAMESPACES = unmodifiableSet(JakartaNamespace, JcpNamespace, FaceletsNamespace, SunNamespace);
+    public final static Set<String> NAMESPACES = Set.of(JakartaNamespace, JcpNamespace, FaceletsNamespace, SunNamespace);
     public final static String DEFAULT_NAMESPACE = JakartaNamespace;
 
     /**

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/SetHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/SetHandler.java
@@ -64,7 +64,7 @@ public class SetHandler extends TagHandlerImpl {
 
         Iterator<TextHandler> iter = TagHandlerImpl.findNextByType(nextHandler, TextHandler.class);
         while (iter.hasNext()) {
-            TextHandler text = (TextHandler) iter.next();
+            TextHandler text = iter.next();
             bodyValue.append(text.getText(ctx));
         }
 

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/ui/RepeatHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/ui/RepeatHandler.java
@@ -43,7 +43,7 @@ public class RepeatHandler extends ComponentHandler {
     }
 
     @Override
-    protected MetaRuleset createMetaRuleset(Class type) {
+    protected MetaRuleset createMetaRuleset(Class<?> type) {
         MetaRuleset meta = super.createMetaRuleset(type);
         String myNamespace = tag.getNamespace();
 

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/ui/UILibrary.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/ui/UILibrary.java
@@ -16,7 +16,6 @@
 
 package org.glassfish.mojarra.facelets.tag.ui;
 
-import static org.glassfish.mojarra.util.Util.unmodifiableSet;
 
 import java.util.Set;
 
@@ -32,7 +31,7 @@ public final class UILibrary extends AbstractTagLibrary {
     private final static String JcpNamespace = "http://xmlns.jcp.org/jsf/facelets";
     private final static String JakartaNamespace = "jakarta.faces.facelets";
 
-    public final static Set<String> NAMESPACES = unmodifiableSet(JakartaNamespace, JcpNamespace, SunNamespace);
+    public final static Set<String> NAMESPACES = Set.of(JakartaNamespace, JcpNamespace, SunNamespace);
     public final static String DEFAULT_NAMESPACE = JakartaNamespace;
 
     public UILibrary(String namespace) {

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/util/DevTools.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/util/DevTools.java
@@ -16,7 +16,6 @@
 
 package org.glassfish.mojarra.facelets.util;
 
-import static org.glassfish.mojarra.util.Util.unmodifiableSet;
 
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
@@ -68,7 +67,7 @@ public final class DevTools {
     private final static String JcpNamespace = "http://xmlns.jcp.org/mojarra/private/functions";
     private final static String JakartaNamespace = "mojarra.private.functions";
 
-    public final static Set<String> NAMESPACES = unmodifiableSet(JakartaNamespace, JcpNamespace, SunNamespace);
+    public final static Set<String> NAMESPACES = Set.of(JakartaNamespace, JcpNamespace, SunNamespace);
     public final static String DEFAULT_NAMESPACE = JakartaNamespace;
 
     private static final Logger LOGGER = Logger.getLogger(DevTools.class.getPackage().getName());

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/util/FunctionLibrary.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/util/FunctionLibrary.java
@@ -16,7 +16,6 @@
 
 package org.glassfish.mojarra.facelets.util;
 
-import static org.glassfish.mojarra.util.Util.unmodifiableSet;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -44,7 +43,7 @@ public class FunctionLibrary implements TagLibrary {
     private final static String JcpNamespace = "http://xmlns.jcp.org/jsp/jstl/functions";
     private final static String JakartaNamespace = "jakarta.tags.functions";
 
-    public final static Set<String> NAMESPACES = unmodifiableSet(JakartaNamespace, JcpNamespace, SunNamespace);
+    public final static Set<String> NAMESPACES = Set.of(JakartaNamespace, JcpNamespace, SunNamespace);
     public final static String DEFAULT_NAMESPACE = JakartaNamespace;
 
     private String _namespace;

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/util/ReflectionUtil.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/util/ReflectionUtil.java
@@ -82,7 +82,7 @@ public class ReflectionUtil {
         if (s == null) {
             return null;
         }
-        Class<?>[] c = new Class[s.length];
+        Class<?>[] c = new Class<?>[s.length];
         for (int i = 0; i < s.length; i++) {
             c[i] = forName(s[i]);
         }

--- a/impl/src/main/java/org/glassfish/mojarra/flow/MethodCallNodeImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/flow/MethodCallNodeImpl.java
@@ -56,9 +56,9 @@ public class MethodCallNodeImpl extends MethodCallNode implements Serializable {
         parameters = Collections.unmodifiableList(_parameters);
 
         ExpressionFactory ef = context.getApplication().getExpressionFactory();
-        Class<?>[] paramTypes = new Class[0];
+        Class<?>[] paramTypes = new Class<?>[0];
         if (0 < parameters.size()) {
-            paramTypes = new Class[parameters.size()];
+            paramTypes = new Class<?>[parameters.size()];
             int i = 0;
             for (Parameter cur : parameters) {
                 if (null != cur.getName()) {

--- a/impl/src/main/java/org/glassfish/mojarra/flow/builder/MethodCallBuilderImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/flow/builder/MethodCallBuilderImpl.java
@@ -31,7 +31,7 @@ public class MethodCallBuilderImpl extends MethodCallBuilder {
     private FlowBuilderImpl root;
     private String methodCallId;
     private MethodCallNodeImpl methodCallNode;
-    private static final Class<?>[] EMPTY_ARGS = new Class[0];
+    private static final Class<?>[] EMPTY_ARGS = new Class<?>[0];
 
     public MethodCallBuilderImpl(FlowBuilderImpl root, String id) {
         this.root = root;
@@ -64,7 +64,7 @@ public class MethodCallBuilderImpl extends MethodCallBuilder {
     }
 
     @Override
-    public MethodCallBuilder expression(String methodExpression, Class[] paramTypes) {
+    public MethodCallBuilder expression(String methodExpression, Class<?>[] paramTypes) {
         ELContext elc = root.getELContext();
         MethodExpression me = root.getExpressionFactory().createMethodExpression(elc, methodExpression, null, paramTypes);
         methodCallNode.setMethodExpression(me);

--- a/impl/src/main/java/org/glassfish/mojarra/lifecycle/RestoreViewPhase.java
+++ b/impl/src/main/java/org/glassfish/mojarra/lifecycle/RestoreViewPhase.java
@@ -381,7 +381,6 @@ public class RestoreViewPhase extends Phase {
             root.visitTree(visitContext, (context, target) -> {
                 postRestoreStateEvent.setComponent(target);
                 target.processEvent(postRestoreStateEvent);
-                // noinspection ReturnInsideFinallyBlock
                 return VisitResult.ACCEPT;
             });
         } catch (AbortProcessingException e) {

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/AttributeManager.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/AttributeManager.java
@@ -19,7 +19,6 @@
 package org.glassfish.mojarra.renderkit;
 
 import static org.glassfish.mojarra.renderkit.Attribute.attr;
-import static org.glassfish.mojarra.util.CollectionsUtils.ar;
 
 import java.util.Map;
 
@@ -38,6 +37,10 @@ public class AttributeManager {
         SELECTBOOLEANCHECKBOX, SELECTMANYCHECKBOX, SELECTMANYLISTBOX,
         SELECTMANYMENU, SELECTONELISTBOX, SELECTONEMENU, SELECTONERADIO,
         OUTPUTBODY, OUTPUTDOCTYPE, OUTPUTHEAD;
+    }
+
+    private static Attribute[] ar(Attribute... attributes) {
+        return attributes;
     }
 
     private static final Map<Key, Attribute[]> ATTRIBUTE_LOOKUP = CollectionsUtils.<Key, Attribute[]>map()

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/ClientSideStateHelper.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/ClientSideStateHelper.java
@@ -338,7 +338,6 @@ public class ClientSideStateHelper extends StateHelper {
 
             }
 
-            // noinspection NonSerializableObjectPassedToObjectStream
             oos.writeObject(stateToWrite[0]);
 
             if (debugSerializedState) {
@@ -354,7 +353,6 @@ public class ClientSideStateHelper extends StateHelper {
 
             }
 
-            // noinspection NonSerializableObjectPassedToObjectStream
             oos.writeObject(stateToWrite[1]);
 
             oos.flush();

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/RenderKitImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/RenderKitImpl.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import jakarta.faces.component.UIComponent;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseStream;
 import jakarta.faces.context.ResponseWriter;
@@ -90,7 +91,7 @@ public class RenderKitImpl extends RenderKit {
     }
 
     @Override
-    public void addRenderer(String family, String rendererType, Renderer renderer) {
+    public void addRenderer(String family, String rendererType, Renderer<?> renderer) {
 
         Util.notNull("family", family);
         Util.notNull("rendererType", rendererType);
@@ -111,7 +112,8 @@ public class RenderKitImpl extends RenderKit {
     }
 
     @Override
-    public Renderer getRenderer(String family, String rendererType) {
+    @SuppressWarnings("unchecked")
+    public <T extends UIComponent> Renderer<T> getRenderer(String family, String rendererType) {
 
         Util.notNull("family", family);
         Util.notNull("rendererType", rendererType);
@@ -119,7 +121,7 @@ public class RenderKitImpl extends RenderKit {
         assert rendererFamilies != null;
 
         HashMap<String, Renderer<?>> renderers = rendererFamilies.get(family);
-        return renderers != null ? renderers.get(rendererType) : null;
+        return renderers != null ? (Renderer<T>) renderers.get(rendererType) : null;
 
     }
 

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/RenderKitUtils.java
@@ -1103,7 +1103,6 @@ public class RenderKitUtils {
         return false;
     }
 
-    @SuppressWarnings("unchecked")
     public static void renderUnhandledMessages(FacesContext ctx) {
 
         if (ctx.isProjectStage(ProjectStage.Development)) {

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/SelectItemsIterator.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/SelectItemsIterator.java
@@ -408,6 +408,8 @@ public final class SelectItemsIterator<T extends SelectItem> implements Iterator
          */
         private static final class GenericObjectSelectItem extends SelectItem {
 
+            private static final long serialVersionUID = 1L;
+
             private static final String ITEM_VALUE = "itemValue";
             private static final String ITEM_LABEL = "itemLabel";
             private static final String ITEM_DESCRIPTION = "itemDescription";

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/ServerSideStateHelper.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/ServerSideStateHelper.java
@@ -264,7 +264,6 @@ public class ServerSideStateHelper extends StateHelper {
             return null;
         }
 
-        // noinspection SynchronizationOnLocalVariableOrMethodParameter
         synchronized (getMutex(sessionObj)) {
             @SuppressWarnings("unchecked")
             Map<String, Map<String, Object[]>> logicalMap = (Map<String, Map<String, Object[]>>) externalCtx.getSessionMap().get(LOGICAL_VIEW_MAP);
@@ -274,7 +273,7 @@ public class ServerSideStateHelper extends StateHelper {
                     RequestStateManager.set(ctx, RequestStateManager.LOGICAL_VIEW_MAP, idInLogicalMap);
 
                     Object[] restoredState = new Object[2];
-                    Object[] state = (Object[]) actualMap.get(idInActualMap);
+                    Object[] state = actualMap.get(idInActualMap);
                     if (state != null) {
                         restoredState[0] = state[0];
                         restoredState[1] = state[1];

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/BodyRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/BodyRenderer.java
@@ -75,7 +75,7 @@ public class BodyRenderer extends HtmlBasicRenderer {
         UIViewRoot viewRoot = context.getViewRoot();
         ListIterator<UIComponent> iter = viewRoot.getComponentResources(context, "body").listIterator();
         while (iter.hasNext()) {
-            UIComponent resource = (UIComponent) iter.next();
+            UIComponent resource = iter.next();
             resource.encodeAll(context);
         }
         RenderKitUtils.renderUnhandledMessages(context);

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/MessageRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/MessageRenderer.java
@@ -117,7 +117,7 @@ public class MessageRenderer extends HtmlBasicRenderer {
             } // otherwise, return without rendering
             return;
         }
-        FacesMessage curMessage = (FacesMessage) messageIter.next();
+        FacesMessage curMessage = messageIter.next();
         if (curMessage.isRendered() && !message.isRedisplay()) {
             return;
         }

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/MessagesRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/MessagesRenderer.java
@@ -124,7 +124,7 @@ public class MessagesRenderer extends HtmlBasicRenderer {
         RenderKitUtils.renderPassThruAttributes(context, writer, component, ATTRIBUTES);
 
         while (messageIter.hasNext()) {
-            FacesMessage curMessage = (FacesMessage) messageIter.next();
+            FacesMessage curMessage = messageIter.next();
             if (curMessage.isRendered() && !messages.isRedisplay()) {
                 continue;
             }

--- a/impl/src/main/java/org/glassfish/mojarra/spi/InjectionProviderFactory.java
+++ b/impl/src/main/java/org/glassfish/mojarra/spi/InjectionProviderFactory.java
@@ -358,7 +358,6 @@ public class InjectionProviderFactory {
      * not specified or is invalid.
      * </p>
      */
-    @SuppressWarnings("deprecation")
     private static final class NoopInjectionProvider implements InjectionProvider, AnnotationScanner {
 
         /**

--- a/impl/src/main/java/org/glassfish/mojarra/util/CollectionsUtils.java
+++ b/impl/src/main/java/org/glassfish/mojarra/util/CollectionsUtils.java
@@ -16,15 +16,12 @@
 
 package org.glassfish.mojarra.util;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableMap;
 
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import jakarta.faces.model.SelectItem;
@@ -37,20 +34,6 @@ public class CollectionsUtils {
 
     private CollectionsUtils() {
         // this class contains static methods only.
-    }
-
-    @SafeVarargs
-    public static <T> Set<T> asSet(T... a) {
-        return new HashSet<>(asList(a));
-    }
-
-    @SafeVarargs
-    public static <T> T[] ar(T... ts) {
-        return ts;
-    }
-
-    public static <T> T[] ar() {
-        return null;
     }
 
     public static <T, V> ConstMap<T, V> map() {

--- a/impl/src/main/java/org/glassfish/mojarra/util/MostlySingletonSet.java
+++ b/impl/src/main/java/org/glassfish/mojarra/util/MostlySingletonSet.java
@@ -59,12 +59,11 @@ public class MostlySingletonSet<E> implements Set<E>, Serializable {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public boolean addAll(Collection<? extends E> c) {
         boolean result = true;
 
         if (null == inner && 1 == c.size()) {
-            inner = (Set<E>) Collections.singleton(c.iterator().next());
+            inner = Collections.singleton(c.iterator().next());
         } else {
             // If we need to transition from one to more-than-one
             if (1 == inner.size()) {

--- a/impl/src/main/java/org/glassfish/mojarra/util/MultiKeyConcurrentHashMap.java
+++ b/impl/src/main/java/org/glassfish/mojarra/util/MultiKeyConcurrentHashMap.java
@@ -130,7 +130,6 @@ public class MultiKeyConcurrentHashMap<K, V> {
      * @return the segment
      */
     final Segment<K, V> segmentFor(int hash) {
-        // noinspection unchecked
         return segments[hash >>> segmentShift & segmentMask];
     }
 
@@ -247,7 +246,6 @@ public class MultiKeyConcurrentHashMap<K, V> {
          */
         HashEntry<K, V> getFirst(int hash) {
             HashEntry[] tab = table;
-            // noinspection unchecked
             return tab[hash & tab.length - 1];
         }
 
@@ -306,7 +304,7 @@ public class MultiKeyConcurrentHashMap<K, V> {
                 HashEntry[] tab = table;
                 int len = tab.length;
                 for (int i = 0; i < len; i++) {
-                    for (// noinspection unchecked
+                    for (
                             HashEntry<K, V> e = tab[i]; e != null; e = e.next) {
                         V v = e.value;
                         if (v == null) // recheck
@@ -372,7 +370,6 @@ public class MultiKeyConcurrentHashMap<K, V> {
                 }
                 HashEntry[] tab = table;
                 int index = hash & tab.length - 1;
-                // noinspection unchecked
                 HashEntry<K, V> first = tab[index];
                 HashEntry<K, V> e = first;
                 while (e != null && (e.hash != hash || key1 != null && !key1.equals(e.key1) || key2 != null && !key2.equals(e.key2)
@@ -420,7 +417,6 @@ public class MultiKeyConcurrentHashMap<K, V> {
             for (int i = 0; i < oldCapacity; i++) {
                 // We need to guarantee that any existing reads of old Map can
                 // proceed. So we cannot yet null out each bin.
-                // noinspection unchecked
                 HashEntry<K, V> e = oldTable[i];
 
                 if (e != null) {
@@ -446,7 +442,6 @@ public class MultiKeyConcurrentHashMap<K, V> {
                         // Clone all remaining nodes
                         for (HashEntry<K, V> p = e; p != lastRun; p = p.next) {
                             int k = p.hash & sizeMask;
-                            // noinspection unchecked
                             HashEntry<K, V> n = newTable[k];
                             newTable[k] = new HashEntry<>(p.key1, p.key2, p.key3, p.key4, p.hash, n, p.value);
                         }
@@ -465,7 +460,6 @@ public class MultiKeyConcurrentHashMap<K, V> {
                 int c = count - 1;
                 HashEntry[] tab = table;
                 int index = hash & tab.length - 1;
-                // noinspection unchecked
                 HashEntry<K, V> first = tab[index];
                 HashEntry<K, V> e = first;
                 while (e != null && (e.hash != hash || key1 != null && !key1.equals(e.key1) || key2 != null && !key2.equals(e.key2)

--- a/impl/src/main/java/org/glassfish/mojarra/util/ReflectionUtils.java
+++ b/impl/src/main/java/org/glassfish/mojarra/util/ReflectionUtils.java
@@ -148,7 +148,7 @@ public final class ReflectionUtils {
                 }
 
             }
-        } catch (Exception e) { // NOPMD
+        } catch (Exception e) {
             throw new IllegalStateException(e);
         }
     }

--- a/impl/src/main/java/org/glassfish/mojarra/util/Util.java
+++ b/impl/src/main/java/org/glassfish/mojarra/util/Util.java
@@ -54,7 +54,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1031,7 +1030,6 @@ public class Util {
      * </p>
      * If no mapping can be determined, it most likely means that this particular request wasn't dispatched through the
      * {@link jakarta.faces.webapp.FacesServlet}.
-     * <p>
      *
      * @param context the {@link FacesContext} of the current request
      *
@@ -1566,11 +1564,6 @@ public class Util {
         } else {
             return (Stream<T>) Stream.of(object);
         }
-    }
-
-    @SafeVarargs
-    public static <E> Set<E> unmodifiableSet(E... elements) {
-        return Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(elements)));
     }
 
 

--- a/impl/src/main/java/org/glassfish/mojarra/util/copier/Copier.java
+++ b/impl/src/main/java/org/glassfish/mojarra/util/copier/Copier.java
@@ -31,7 +31,6 @@ public interface Copier {
 
     /**
      * Return an object that's logically a copy of the given object.
-     * <p>
      *
      * @param object the object to be copied
      * @return a copy of the given object

--- a/impl/src/test/java/jakarta/faces/component/StateHolderSaverTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/StateHolderSaverTestCase.java
@@ -16,13 +16,12 @@
 
 package jakarta.faces.component;
 
-import org.glassfish.mojarra.component.UIComponentBaseTestCase;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.faces.convert.IntegerConverter;
 
+import org.glassfish.mojarra.component.UIComponentBaseTestCase;
 import org.junit.jupiter.api.Test;
 
 public class StateHolderSaverTestCase extends UIComponentBaseTestCase {

--- a/impl/src/test/java/jakarta/faces/component/UICommandTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UICommandTestCase.java
@@ -16,11 +16,6 @@
 
 package jakarta.faces.component;
 
-import org.glassfish.mojarra.component.*;
-
-import org.glassfish.mojarra.component.UIComponentBaseTestCase;
-
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -37,6 +32,10 @@ import jakarta.faces.render.RenderKit;
 import jakarta.faces.render.RenderKitFactory;
 import jakarta.faces.render.Renderer;
 
+import org.glassfish.mojarra.component.ActionListenerTestImpl;
+import org.glassfish.mojarra.component.CommandActionListenerTestImpl;
+import org.glassfish.mojarra.component.CommandTestImpl;
+import org.glassfish.mojarra.component.UIComponentBaseTestCase;
 import org.glassfish.mojarra.mock.MockExternalContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -243,6 +242,7 @@ public class UICommandTestCase extends UIComponentBaseTestCase {
         ActionListener[] listeners = command.getActionListeners();
         assertEquals(2, listeners.length);
         ActionListenerTestImpl[] taListeners = (ActionListenerTestImpl[]) command.getFacesListeners(ActionListenerTestImpl.class);
+        assertEquals(2, taListeners.length);
     }
 
     // --------------------------------------------------------- Support Methods
@@ -281,7 +281,7 @@ public class UICommandTestCase extends UIComponentBaseTestCase {
 
     // --------------------------------------------------------- Private Classes
     // "Button" Renderer
-    class ButtonRenderer extends Renderer {
+    class ButtonRenderer extends Renderer<UIComponent> {
 
         @Override
         public void decode(FacesContext context, UIComponent component) {

--- a/impl/src/test/java/jakarta/faces/component/UIComponentBaseAttachedStateTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIComponentBaseAttachedStateTestCase.java
@@ -16,9 +16,6 @@
 
 package jakarta.faces.component;
 
-import org.glassfish.mojarra.component.*;
-
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -36,6 +33,7 @@ import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.FacesListener;
 import jakarta.faces.event.ValueChangeListener;
 
+import org.glassfish.mojarra.component.ValueChangeListenerTestImpl;
 import org.glassfish.mojarra.mock.MockExternalContext;
 import org.glassfish.mojarra.mock.MockFacesContext;
 import org.glassfish.mojarra.mock.MockHttpServletRequest;
@@ -80,8 +78,8 @@ public class UIComponentBaseAttachedStateTestCase {
 
     @Test
     public void testAttachedObjectsSet() throws Exception {
-        Set<ValueChangeListener> attachedObjects = new HashSet<>();
-        ValueChangeListener toAdd = new ValueChangeListenerTestImpl();
+        Set<ValueChangeListener<?>> attachedObjects = new HashSet<>();
+        ValueChangeListener<?> toAdd = new ValueChangeListenerTestImpl();
         attachedObjects.add(toAdd);
         toAdd = new ValueChangeListenerTestImpl();
         attachedObjects.add(toAdd);
@@ -89,15 +87,15 @@ public class UIComponentBaseAttachedStateTestCase {
         attachedObjects.add(toAdd);
         Object result = UIComponentBase.saveAttachedState(facesContext, attachedObjects);
         @SuppressWarnings("unchecked")
-        Set<ValueChangeListener> returnedAttachedObjects = (Set<ValueChangeListener>) UIComponentBase
+        Set<ValueChangeListener<?>> returnedAttachedObjects = (Set<ValueChangeListener<?>>) UIComponentBase
                 .restoreAttachedState(facesContext, result);
         assertNotNull(returnedAttachedObjects);
     }
 
     @Test
     public void testAttachedObjectsStack() throws Exception {
-        Stack<ValueChangeListener> attachedObjects = new Stack<>();
-        ValueChangeListener toAdd = new ValueChangeListenerTestImpl();
+        Stack<ValueChangeListener<?>> attachedObjects = new Stack<>();
+        ValueChangeListener<?> toAdd = new ValueChangeListenerTestImpl();
         attachedObjects.add(toAdd);
         toAdd = new ValueChangeListenerTestImpl();
         attachedObjects.add(toAdd);
@@ -105,15 +103,15 @@ public class UIComponentBaseAttachedStateTestCase {
         attachedObjects.add(toAdd);
         Object result = UIComponentBase.saveAttachedState(facesContext, attachedObjects);
         @SuppressWarnings("unchecked")
-        Stack<ValueChangeListener> returnedAttachedObjects = (Stack<ValueChangeListener>) UIComponentBase
+        Stack<ValueChangeListener<?>> returnedAttachedObjects = (Stack<ValueChangeListener<?>>) UIComponentBase
                 .restoreAttachedState(facesContext, result);
         assertNotNull(returnedAttachedObjects);
     }
 
     @Test
     public void testAttachedObjectsMap() throws Exception {
-        Map<String, ValueChangeListener> attachedObjects = new HashMap<>();
-        ValueChangeListener toAdd = new ValueChangeListenerTestImpl();
+        Map<String, ValueChangeListener<?>> attachedObjects = new HashMap<>();
+        ValueChangeListener<?> toAdd = new ValueChangeListenerTestImpl();
         attachedObjects.put("one", toAdd);
         toAdd = new ValueChangeListenerTestImpl();
         attachedObjects.put("two", toAdd);
@@ -121,7 +119,7 @@ public class UIComponentBaseAttachedStateTestCase {
         attachedObjects.put("three", toAdd);
         Object result = UIComponentBase.saveAttachedState(facesContext, attachedObjects);
         @SuppressWarnings("unchecked")
-        Map<String, ValueChangeListener> returnedAttachedObjects = (Map<String, ValueChangeListener>) UIComponentBase
+        Map<String, ValueChangeListener<?>> returnedAttachedObjects = (Map<String, ValueChangeListener<?>>) UIComponentBase
                 .restoreAttachedState(facesContext, result);
         assertNotNull(returnedAttachedObjects);
     }
@@ -129,17 +127,17 @@ public class UIComponentBaseAttachedStateTestCase {
     // Regression test for bug #907
     @SuppressWarnings("unchecked")
     public void testAttachedObjectsCount() throws Exception {
-        Set<ValueChangeListener> returnedAttachedObjects = null, attachedObjects = new HashSet<>();
-        ValueChangeListener toAdd = new ValueChangeListenerTestImpl();
+        Set<ValueChangeListener<?>> returnedAttachedObjects = null, attachedObjects = new HashSet<>();
+        ValueChangeListener<?> toAdd = new ValueChangeListenerTestImpl();
         attachedObjects.add(toAdd);
         toAdd = new ValueChangeListenerTestImpl();
         attachedObjects.add(toAdd);
         toAdd = new ValueChangeListenerTestImpl();
         attachedObjects.add(toAdd);
         Object result = UIComponentBase.saveAttachedState(facesContext, attachedObjects);
-        returnedAttachedObjects = (Set<ValueChangeListener>) UIComponentBase.restoreAttachedState(facesContext, result);
+        returnedAttachedObjects = (Set<ValueChangeListener<?>>) UIComponentBase.restoreAttachedState(facesContext, result);
         int firstSize = returnedAttachedObjects.size();
-        returnedAttachedObjects = (Set<ValueChangeListener>) UIComponentBase.restoreAttachedState(facesContext, result);
+        returnedAttachedObjects = (Set<ValueChangeListener<?>>) UIComponentBase.restoreAttachedState(facesContext, result);
         int secondSize = returnedAttachedObjects.size();
         assertEquals(firstSize, secondSize);
     }

--- a/impl/src/test/java/jakarta/faces/component/UIInputTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIInputTestCase.java
@@ -16,11 +16,6 @@
 
 package jakarta.faces.component;
 
-import org.glassfish.mojarra.component.*;
-
-import org.glassfish.mojarra.component.UIOutputTestCase;
-
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -35,6 +30,9 @@ import jakarta.faces.event.ValueChangeEvent;
 import jakarta.faces.event.ValueChangeListener;
 import jakarta.faces.validator.Validator;
 
+import org.glassfish.mojarra.component.InputTestImpl;
+import org.glassfish.mojarra.component.UIOutputTestCase;
+import org.glassfish.mojarra.component.ValueChangeListenerTestImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -175,7 +173,7 @@ public class UIInputTestCase extends UIOutputTestCase {
         input.addValueChangeListener(new ValueChangeListenerTestImpl("PV1"));
         input.addValueChangeListener(new ValueChangeListenerTestImpl("PV2"));
 
-        ValueChangeListener listeners[] = input.getValueChangeListeners();
+        ValueChangeListener<?> listeners[] = input.getValueChangeListeners();
         assertEquals(5, listeners.length);
         input.removeValueChangeListener(listeners[2]);
         listeners = input.getValueChangeListeners();
@@ -188,7 +186,7 @@ public class UIInputTestCase extends UIOutputTestCase {
         InputTestImpl input = new InputTestImpl();
 
         // No listeners added, should be empty
-        ValueChangeListener listeners[] = input.getValueChangeListeners();
+        ValueChangeListener<?> listeners[] = input.getValueChangeListeners();
         assertEquals(0, listeners.length);
     }
 
@@ -210,7 +208,6 @@ public class UIInputTestCase extends UIOutputTestCase {
     @Test
     public void testPropertiesInvalid() throws Exception {
         super.testPropertiesInvalid();
-        UIInput input = (UIInput) component;
     }
 
     // Test validation of a required field
@@ -261,7 +258,7 @@ public class UIInputTestCase extends UIOutputTestCase {
 
         command.addValueChangeListener(ta1);
         command.addValueChangeListener(ta2);
-        ValueChangeListener[] listeners = command.getValueChangeListeners();
+        ValueChangeListener<?>[] listeners = command.getValueChangeListeners();
         assertEquals(2, listeners.length);
         ValueChangeListenerTestImpl[] taListeners = (ValueChangeListenerTestImpl[]) command.getFacesListeners(ValueChangeListenerTestImpl.class);
         assertTrue(taListeners != null);
@@ -293,8 +290,8 @@ public class UIInputTestCase extends UIOutputTestCase {
 
     protected boolean listenersAreEqual(FacesContext context, UIInput comp1, UIInput comp2) {
 
-        ValueChangeListener list1[] = comp1.getValueChangeListeners();
-        ValueChangeListener list2[] = comp2.getValueChangeListeners();
+        ValueChangeListener<?> list1[] = comp1.getValueChangeListeners();
+        ValueChangeListener<?> list2[] = comp2.getValueChangeListeners();
         assertNotNull(list1);
         assertNotNull(list2);
         assertEquals(list1.length, list2.length);
@@ -310,8 +307,8 @@ public class UIInputTestCase extends UIOutputTestCase {
 
     protected boolean validatorsAreEqual(FacesContext context, UIInput comp1, UIInput comp2) {
 
-        Validator list1[] = comp1.getValidators();
-        Validator list2[] = comp2.getValidators();
+        Validator<?> list1[] = comp1.getValidators();
+        Validator<?> list2[] = comp2.getValidators();
         assertNotNull(list1);
         assertNotNull(list2);
         assertEquals(list1.length, list2.length);

--- a/impl/src/test/java/jakarta/faces/component/UIOutputAttachedObjectStateTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIOutputAttachedObjectStateTestCase.java
@@ -146,7 +146,7 @@ public class UIOutputAttachedObjectStateTestCase {
         output = new UIOutput();
         assertNull(output.getConverter());
         output.restoreState(facesContext, state);
-        Converter c = output.getConverter();
+        Converter<?> c = output.getConverter();
         assertNotNull(c);
         assertTrue(c instanceof DateTimeConverter);
         converter = (DateTimeConverter) c;

--- a/impl/src/test/java/jakarta/faces/component/UISelectOneTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UISelectOneTestCase.java
@@ -16,9 +16,6 @@
 
 package jakarta.faces.component;
 
-import org.glassfish.mojarra.component.*;
-
-
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -34,6 +31,7 @@ import jakarta.faces.application.FacesMessage;
 import jakarta.faces.model.SelectItem;
 import jakarta.faces.model.SelectItemGroup;
 
+import org.glassfish.mojarra.component.UISelectItemSub;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/impl/src/test/java/jakarta/faces/component/UIViewRootTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIViewRootTestCase.java
@@ -16,11 +16,6 @@
 
 package jakarta.faces.component;
 
-import org.glassfish.mojarra.component.*;
-
-import org.glassfish.mojarra.component.UIComponentBaseTestCase;
-
-
 import static java.util.Collections.emptyMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -46,6 +41,9 @@ import jakarta.faces.event.PostRestoreStateEvent;
 import jakarta.faces.render.RenderKit;
 import jakarta.faces.render.RenderKitFactory;
 
+import org.glassfish.mojarra.component.EventTestImpl;
+import org.glassfish.mojarra.component.ListenerTestImpl;
+import org.glassfish.mojarra.component.UIComponentBaseTestCase;
 import org.glassfish.mojarra.mock.MockRenderKit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/impl/src/test/java/org/glassfish/mojarra/application/FactoryFinderTestCase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/application/FactoryFinderTestCase.java
@@ -17,10 +17,6 @@
 
 package org.glassfish.mojarra.application;
 
-import jakarta.faces.FactoryFinder;
-
-import jakarta.faces.component.*;
-
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -29,6 +25,7 @@ import java.io.PrintWriter;
 import java.lang.reflect.Method;
 
 import jakarta.enterprise.inject.spi.CDI;
+import jakarta.faces.FactoryFinder;
 import jakarta.faces.application.Application;
 import jakarta.faces.application.ApplicationFactory;
 import jakarta.faces.context.FacesContext;

--- a/impl/src/test/java/org/glassfish/mojarra/application/FactoryFinderTestCase2.java
+++ b/impl/src/test/java/org/glassfish/mojarra/application/FactoryFinderTestCase2.java
@@ -16,11 +16,9 @@
 
 package org.glassfish.mojarra.application;
 
-import jakarta.faces.FactoryFinder;
-
-import jakarta.faces.component.*;
-
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.faces.FactoryFinder;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/impl/src/test/java/org/glassfish/mojarra/application/WebappLifecycleListenerTestCase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/application/WebappLifecycleListenerTestCase.java
@@ -51,6 +51,8 @@ public class WebappLifecycleListenerTestCase extends JUnitFacesTestCaseBase {
 
         // Create a request event. Make it cause an exception inside the lifecycleListener.requestDestroyed(event) call.
         ServletRequestEvent event = new ServletRequestEvent(servletContext, new MockHttpServletRequest()) {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public ServletRequest getServletRequest() {
                 // This is just a convenient place to throw the exception for testing purposes. In the real impl the

--- a/impl/src/test/java/org/glassfish/mojarra/application/resource/ResourceImplTest.java
+++ b/impl/src/test/java/org/glassfish/mojarra/application/resource/ResourceImplTest.java
@@ -29,13 +29,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.InputStream;
 import java.net.URL;
 
+import jakarta.faces.context.FacesContext;
+
 import org.glassfish.mojarra.junit.JUnitFacesTestCaseBase;
 import org.glassfish.mojarra.mock.MockApplication;
 import org.glassfish.mojarra.mock.MockFacesMappingSupport;
 import org.glassfish.mojarra.util.MojarraVersion;
 import org.junit.jupiter.api.Test;
-
-import jakarta.faces.context.FacesContext;
 
 public class ResourceImplTest extends JUnitFacesTestCaseBase {
 

--- a/impl/src/test/java/org/glassfish/mojarra/application/view/MultiViewHandlerFragmentTest.java
+++ b/impl/src/test/java/org/glassfish/mojarra/application/view/MultiViewHandlerFragmentTest.java
@@ -274,7 +274,7 @@ class MultiViewHandlerFragmentTest extends JUnitFacesTestCaseBase {
      */
     @Test
     void getRedirectURL_withSpecialCharsInFragment_passedThroughVerbatim() {
-        String result = handler.getRedirectURL(testContext, VIEW_ID, null, "id:main", false);
+        handler.getRedirectURL(testContext, VIEW_ID, null, "id:main", false);
 
         ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
         verify(testExternalContext).encodeRedirectURL(urlCaptor.capture(), any());

--- a/impl/src/test/java/org/glassfish/mojarra/application/view/MultiViewHandlerTest.java
+++ b/impl/src/test/java/org/glassfish/mojarra/application/view/MultiViewHandlerTest.java
@@ -22,12 +22,12 @@ import static jakarta.servlet.http.MappingMatch.PATH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import jakarta.faces.FactoryFinder;
+
 import org.glassfish.mojarra.junit.JUnitFacesTestCaseBase;
 import org.glassfish.mojarra.mock.MockFacesMappingSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import jakarta.faces.FactoryFinder;
 
 public class MultiViewHandlerTest extends JUnitFacesTestCaseBase {
 

--- a/impl/src/test/java/org/glassfish/mojarra/component/ActionListenerTestImpl.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/ActionListenerTestImpl.java
@@ -16,8 +16,7 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
-
+import jakarta.faces.component.StateHolder;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.ActionEvent;
 import jakarta.faces.event.ActionListener;
@@ -62,6 +61,11 @@ public class ActionListenerTestImpl implements ActionListener, StateHolder {
             idsAreEqual = id.equals(other.id);
         }
         return idsAreEqual;
+    }
+
+    @Override
+    public int hashCode() {
+        return id == null ? 0 : id.hashCode();
     }
 
     // ---------------------------------------------------- Static Trace Methods

--- a/impl/src/test/java/org/glassfish/mojarra/component/CommandActionListenerTestImpl.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/CommandActionListenerTestImpl.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
-
 import jakarta.faces.event.ActionEvent;
 import jakarta.faces.event.ActionListener;
 

--- a/impl/src/test/java/org/glassfish/mojarra/component/CommandTestImpl.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/CommandTestImpl.java
@@ -16,7 +16,7 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
+import jakarta.faces.component.UICommand;
 
 /**
  * <p>

--- a/impl/src/test/java/org/glassfish/mojarra/component/ComponentTestImpl.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/ComponentTestImpl.java
@@ -16,10 +16,9 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
-
 import java.io.IOException;
 
+import jakarta.faces.component.UIComponentBase;
 import jakarta.faces.context.FacesContext;
 
 /**

--- a/impl/src/test/java/org/glassfish/mojarra/component/DataBeanTestImpl.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/DataBeanTestImpl.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
-
 import java.io.Serializable;
 
 // Test JavaBean for DataModel Tests

--- a/impl/src/test/java/org/glassfish/mojarra/component/EventTestImpl.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/EventTestImpl.java
@@ -16,8 +16,7 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
-
+import jakarta.faces.component.UIComponent;
 import jakarta.faces.event.FacesEvent;
 import jakarta.faces.event.FacesListener;
 

--- a/impl/src/test/java/org/glassfish/mojarra/component/InputTestImpl.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/InputTestImpl.java
@@ -16,7 +16,7 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
+import jakarta.faces.component.UIInput;
 
 /**
  * <p>

--- a/impl/src/test/java/org/glassfish/mojarra/component/InputValidatorTestImpl.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/InputValidatorTestImpl.java
@@ -16,8 +16,7 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
-
+import jakarta.faces.component.UIComponent;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.validator.Validator;
 

--- a/impl/src/test/java/org/glassfish/mojarra/component/InputValueChangeListenerTestImpl.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/InputValueChangeListenerTestImpl.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
-
 import jakarta.faces.event.ValueChangeEvent;
 import jakarta.faces.event.ValueChangeListener;
 
@@ -26,7 +24,7 @@ import jakarta.faces.event.ValueChangeListener;
  * Test implementation of {@link ValueChangeListener}.
  * </p>
  */
-public class InputValueChangeListenerTestImpl implements ValueChangeListener {
+public class InputValueChangeListenerTestImpl implements ValueChangeListener<Object> {
 
     protected String valueChangeListenerId = null;
 
@@ -35,7 +33,7 @@ public class InputValueChangeListenerTestImpl implements ValueChangeListener {
     }
 
     @Override
-    public void processValueChange(ValueChangeEvent event) {
+    public void processValueChange(ValueChangeEvent<Object> event) {
         trace(valueChangeListenerId);
     }
 

--- a/impl/src/test/java/org/glassfish/mojarra/component/ListenerTestImpl.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/ListenerTestImpl.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
-
 import jakarta.faces.event.AbortProcessingException;
 import jakarta.faces.event.FacesListener;
 

--- a/impl/src/test/java/org/glassfish/mojarra/component/NamingContainerTestCase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/NamingContainerTestCase.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
-
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -26,6 +24,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import jakarta.faces.FactoryFinder;
+import jakarta.faces.component.UIForm;
+import jakarta.faces.component.UINamingContainer;
+import jakarta.faces.component.UIPanel;
+import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.render.RenderKit;
 import jakarta.faces.render.RenderKitFactory;
 
@@ -37,7 +39,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * <p>
- * Unit tests for the {@link NamingContainer} functionality of all the standard component classes.
+ * Unit tests for the {@link jakarta.faces.component.NamingContainer} functionality of all the standard component classes.
  * </p>
  */
 public class NamingContainerTestCase extends JUnitFacesTestCaseBase {

--- a/impl/src/test/java/org/glassfish/mojarra/component/NamingContainerTestImpl.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/NamingContainerTestImpl.java
@@ -16,11 +16,12 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UINamingContainer;
 
 /**
  * <p>
- * Test {@link NamingContainer} implementation with tracing.
+ * Test {@link jakarta.faces.component.NamingContainer} implementation with tracing.
  * </p>
  */
 public class NamingContainerTestImpl extends UINamingContainer {

--- a/impl/src/test/java/org/glassfish/mojarra/component/SearchExpressionHandlerTest.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/SearchExpressionHandlerTest.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -32,6 +30,14 @@ import java.util.Set;
 
 import jakarta.faces.FacesException;
 import jakarta.faces.FactoryFinder;
+import jakarta.faces.component.ContextCallback;
+import jakarta.faces.component.UICommand;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIForm;
+import jakarta.faces.component.UINamingContainer;
+import jakarta.faces.component.UIOutput;
+import jakarta.faces.component.UIPanel;
+import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.component.search.ComponentNotFoundException;
 import jakarta.faces.component.search.SearchExpressionContext;
 import jakarta.faces.component.search.SearchExpressionHandler;

--- a/impl/src/test/java/org/glassfish/mojarra/component/SelectManyTestImpl.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/SelectManyTestImpl.java
@@ -16,7 +16,7 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
+import jakarta.faces.component.UISelectMany;
 
 /**
  * <p>

--- a/impl/src/test/java/org/glassfish/mojarra/component/UIColumnTestCase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/UIColumnTestCase.java
@@ -16,7 +16,8 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
+import jakarta.faces.component.UIColumn;
+import jakarta.faces.component.UIComponent;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/impl/src/test/java/org/glassfish/mojarra/component/UIComponentBaseBehaviorTestCase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/UIComponentBaseBehaviorTestCase.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -30,6 +28,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIComponentBase;
+import jakarta.faces.component.UIInput;
 import jakarta.faces.component.behavior.ClientBehavior;
 import jakarta.faces.component.behavior.ClientBehaviorContext;
 import jakarta.faces.component.behavior.ClientBehaviorHint;
@@ -229,7 +230,6 @@ public class UIComponentBaseBehaviorTestCase extends UIComponentTestCase {
         Map<String, List<ClientBehavior>> behaviors = holder.getClientBehaviors();
         assertTrue(behaviors.isEmpty());
         assertFalse(behaviors.containsKey(ONCLICK));
-        assertFalse(behaviors.containsValue(new TestBehavior()));
         assertEquals(0, behaviors.entrySet().size());
         holder.addClientBehavior(ONCLICK, new TestBehavior());
         holder.addClientBehavior(ONCLICK, new TestBehavior());

--- a/impl/src/test/java/org/glassfish/mojarra/component/UIComponentBaseTestCase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/UIComponentBaseTestCase.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -34,6 +32,13 @@ import java.util.List;
 import java.util.Map;
 
 import jakarta.faces.FacesException;
+import jakarta.faces.component.ContextCallback;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIComponentBase;
+import jakarta.faces.component.UIForm;
+import jakarta.faces.component.UIInput;
+import jakarta.faces.component.UIPanel;
+import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.AbortProcessingException;
 import jakarta.faces.event.ComponentSystemEvent;

--- a/impl/src/test/java/org/glassfish/mojarra/component/UIComponentTestCase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/UIComponentTestCase.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -36,6 +34,13 @@ import java.util.Map;
 import java.util.Set;
 
 import jakarta.faces.FactoryFinder;
+import jakarta.faces.component.UIColumn;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIData;
+import jakarta.faces.component.UIForm;
+import jakarta.faces.component.UIInput;
+import jakarta.faces.component.UIOutput;
+import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.AbortProcessingException;
 import jakarta.faces.event.ComponentSystemEvent;

--- a/impl/src/test/java/org/glassfish/mojarra/component/UIGraphicTestCase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/UIGraphicTestCase.java
@@ -16,10 +16,11 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIGraphic;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/impl/src/test/java/org/glassfish/mojarra/component/UIOutputTestCase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/UIOutputTestCase.java
@@ -16,7 +16,8 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIOutput;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/impl/src/test/java/org/glassfish/mojarra/component/UIPanelTestCase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/UIPanelTestCase.java
@@ -16,7 +16,8 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIPanel;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/impl/src/test/java/org/glassfish/mojarra/component/UIParameterTestCase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/UIParameterTestCase.java
@@ -16,10 +16,11 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIParameter;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/impl/src/test/java/org/glassfish/mojarra/component/UISelectBooleanTestCase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/UISelectBooleanTestCase.java
@@ -16,12 +16,12 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.UIInputTestCase;
-
-import jakarta.faces.component.*;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIInputTestCase;
+import jakarta.faces.component.UISelectBoolean;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/impl/src/test/java/org/glassfish/mojarra/component/UISelectItemSub.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/UISelectItemSub.java
@@ -16,7 +16,7 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
+import jakarta.faces.component.UISelectItem;
 
 public class UISelectItemSub extends UISelectItem {
 

--- a/impl/src/test/java/org/glassfish/mojarra/component/UISelectItemTestCase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/UISelectItemTestCase.java
@@ -16,13 +16,13 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UISelectItem;
 import jakarta.faces.model.SelectItem;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/impl/src/test/java/org/glassfish/mojarra/component/UISelectItemsTestCase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/UISelectItemsTestCase.java
@@ -16,11 +16,11 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UISelectItems;
 import jakarta.faces.model.SelectItem;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/impl/src/test/java/org/glassfish/mojarra/component/UISelectManyTestCase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/UISelectManyTestCase.java
@@ -16,10 +16,6 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.UIInputTestCase;
-
-import jakarta.faces.component.*;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -38,6 +34,14 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 
 import jakarta.faces.application.FacesMessage;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIInput;
+import jakarta.faces.component.UIInputTestCase;
+import jakarta.faces.component.UIParameter;
+import jakarta.faces.component.UISelectItem;
+import jakarta.faces.component.UISelectItems;
+import jakarta.faces.component.UISelectMany;
+import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.model.ListDataModel;
 import jakarta.faces.model.SelectItem;
 import jakarta.faces.model.SelectItemGroup;

--- a/impl/src/test/java/org/glassfish/mojarra/component/UIViewRootTest.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/UIViewRootTest.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
@@ -28,11 +26,11 @@ import java.util.Map;
 
 import jakarta.faces.application.Application;
 import jakarta.faces.application.ProjectStage;
+import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.PostConstructViewMapEvent;
 import jakarta.faces.event.PreDestroyViewMapEvent;
-import jakarta.servlet.http.HttpSession;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -44,7 +42,6 @@ public class UIViewRootTest {
         FacesContext facesContext = Mockito.mock(FacesContext.class);
         Application application = Mockito.mock(Application.class);
         ExternalContext externalContext = Mockito.mock(ExternalContext.class);
-        HttpSession httpSession = Mockito.mock(HttpSession.class);
 
         setFacesContext(facesContext);
 
@@ -66,7 +63,6 @@ public class UIViewRootTest {
         FacesContext facesContext = Mockito.mock(FacesContext.class);
         Application application = Mockito.mock(Application.class);
         ExternalContext externalContext = Mockito.mock(ExternalContext.class);
-        HttpSession httpSession = Mockito.mock(HttpSession.class);
 
         setFacesContext(facesContext);
 
@@ -97,7 +93,6 @@ public class UIViewRootTest {
         FacesContext facesContext = Mockito.mock(FacesContext.class);
         Application application = Mockito.mock(Application.class);
         ExternalContext externalContext = Mockito.mock(ExternalContext.class);
-        HttpSession httpSession = Mockito.mock(HttpSession.class);
         HashMap<Object, Object> attributes = new HashMap<>();
         HashMap<String, Object> sessionMap = new HashMap<>();
 

--- a/impl/src/test/java/org/glassfish/mojarra/component/ValueChangeListenerTestImpl.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/ValueChangeListenerTestImpl.java
@@ -16,8 +16,7 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
-
+import jakarta.faces.component.StateHolder;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.ValueChangeEvent;
 import jakarta.faces.event.ValueChangeListener;
@@ -27,7 +26,7 @@ import jakarta.faces.event.ValueChangeListener;
  * Test {@link ValueChangeListener} implementation.
  * </p>
  */
-public class ValueChangeListenerTestImpl implements ValueChangeListener, StateHolder {
+public class ValueChangeListenerTestImpl implements ValueChangeListener<Object>, StateHolder {
 
     // ------------------------------------------------------------ Constructors
     /**
@@ -49,7 +48,7 @@ public class ValueChangeListenerTestImpl implements ValueChangeListener, StateHo
     }
 
     @Override
-    public void processValueChange(ValueChangeEvent event) {
+    public void processValueChange(ValueChangeEvent<Object> event) {
         trace(getId());
     }
 

--- a/impl/src/test/java/org/glassfish/mojarra/component/ValueHolderTestCaseBase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/ValueHolderTestCaseBase.java
@@ -16,14 +16,15 @@
 
 package org.glassfish.mojarra.component;
 
-import jakarta.faces.component.*;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIOutput;
+import jakarta.faces.component.ValueHolder;
 import jakarta.faces.component.html.HtmlInputText;
 import jakarta.faces.convert.LongConverter;
 import jakarta.faces.convert.NumberConverter;

--- a/impl/src/test/java/org/glassfish/mojarra/config/DigesterFactory.java
+++ b/impl/src/test/java/org/glassfish/mojarra/config/DigesterFactory.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.config;
 
-import jakarta.faces.component.*;
-
 import java.net.URL;
 import java.util.HashMap;
 import java.util.logging.Level;

--- a/impl/src/test/java/org/glassfish/mojarra/config/FacesConfigOrderingTestCase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/config/FacesConfigOrderingTestCase.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.config;
 
-import jakarta.faces.component.*;
-
 import static org.glassfish.mojarra.util.Util.createLocalDocumentBuilderFactory;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/impl/src/test/java/org/glassfish/mojarra/facelets/component/UIRepeatTest.java
+++ b/impl/src/test/java/org/glassfish/mojarra/facelets/component/UIRepeatTest.java
@@ -62,7 +62,7 @@ public class UIRepeatTest {
 		if (uiRepeatHasErrorMessages == null) {
 			Class<?> uiRepeatClass = Class.forName(UIRepeat.class.getName());
 			uiRepeatHasErrorMessages = uiRepeatClass.getDeclaredMethod(
-					"hasErrorMessages", new Class[] { FacesContext.class });
+					"hasErrorMessages", new Class<?>[] { FacesContext.class });
 			uiRepeatHasErrorMessages.setAccessible(true);
 		}
 		return (Boolean)uiRepeatHasErrorMessages.invoke(new UIRepeat(),

--- a/impl/src/test/java/org/glassfish/mojarra/mock/MockApplication.java
+++ b/impl/src/test/java/org/glassfish/mojarra/mock/MockApplication.java
@@ -109,6 +109,12 @@ public class MockApplication extends Application {
                     processActionCalled = false;
                     return result;
                 }
+
+                // Constant hash is consistent with the identity-detecting equals above.
+                @Override
+                public int hashCode() {
+                    return 1;
+                }
             };
         }
 

--- a/impl/src/test/java/org/glassfish/mojarra/mock/MockFacesContextFactoryExtender.java
+++ b/impl/src/test/java/org/glassfish/mojarra/mock/MockFacesContextFactoryExtender.java
@@ -19,8 +19,6 @@ package org.glassfish.mojarra.mock;
 import jakarta.faces.FactoryFinder;
 import jakarta.faces.context.FacesContextFactory;
 
-import org.glassfish.mojarra.mock.MockFacesContextFactory;
-
 public class MockFacesContextFactoryExtender extends MockFacesContextFactory {
 
     public MockFacesContextFactoryExtender() {

--- a/impl/src/test/java/org/glassfish/mojarra/mock/MockFacesContextFactoryExtender2.java
+++ b/impl/src/test/java/org/glassfish/mojarra/mock/MockFacesContextFactoryExtender2.java
@@ -19,8 +19,6 @@ package org.glassfish.mojarra.mock;
 import jakarta.faces.FactoryFinder;
 import jakarta.faces.context.FacesContextFactory;
 
-import org.glassfish.mojarra.mock.MockFacesContextFactory;
-
 public class MockFacesContextFactoryExtender2 extends MockFacesContextFactory {
 
     public MockFacesContextFactoryExtender2() {

--- a/impl/src/test/java/org/glassfish/mojarra/mock/MockRenderKit.java
+++ b/impl/src/test/java/org/glassfish/mojarra/mock/MockRenderKit.java
@@ -52,12 +52,12 @@ public class MockRenderKit extends RenderKit {
         responseStateManager = new MockResponseStateManager();
     }
 
-    private Map<String, Renderer> renderers = new HashMap<>();
+    private Map<String, Renderer<?>> renderers = new HashMap<>();
     private ResponseStateManager responseStateManager = null;
 
     @Override
     public void addRenderer(String family, String rendererType,
-            Renderer renderer) {
+            Renderer<?> renderer) {
         if ((family == null) || (rendererType == null) || (renderer == null)) {
             throw new NullPointerException();
         }
@@ -65,11 +65,12 @@ public class MockRenderKit extends RenderKit {
     }
 
     @Override
-    public Renderer getRenderer(String family, String rendererType) {
+    @SuppressWarnings("unchecked")
+    public <T extends UIComponent> Renderer<T> getRenderer(String family, String rendererType) {
         if ((family == null) || (rendererType == null)) {
             throw new NullPointerException();
         }
-        return (renderers.get(family + "|" + rendererType));
+        return (Renderer<T>) renderers.get(family + "|" + rendererType);
     }
 
     @Override

--- a/impl/src/test/java/org/glassfish/mojarra/webapp/ComponentTestImpl.java
+++ b/impl/src/test/java/org/glassfish/mojarra/webapp/ComponentTestImpl.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.webapp;
 
-import jakarta.faces.component.*;
-
 import java.io.IOException;
 
 import jakarta.el.ValueExpression;

--- a/impl/src/test/java/org/glassfish/mojarra/webapp/ConfigAttribute.java
+++ b/impl/src/test/java/org/glassfish/mojarra/webapp/ConfigAttribute.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.webapp;
 
-import jakarta.faces.component.*;
-
 /**
  * <p>
  * Config Bean for an Attribute.</p>

--- a/impl/src/test/java/org/glassfish/mojarra/webapp/ConfigBase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/webapp/ConfigBase.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.webapp;
 
-import jakarta.faces.component.*;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/impl/src/test/java/org/glassfish/mojarra/webapp/ConfigComponent.java
+++ b/impl/src/test/java/org/glassfish/mojarra/webapp/ConfigComponent.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.webapp;
 
-import jakarta.faces.component.*;
-
 /**
  * <p>
  * Config Bean for an Component.</p>

--- a/impl/src/test/java/org/glassfish/mojarra/webapp/ConfigConverter.java
+++ b/impl/src/test/java/org/glassfish/mojarra/webapp/ConfigConverter.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.webapp;
 
-import jakarta.faces.component.*;
-
 /**
  * <p>
  * Config Bean for a Converter.</p>

--- a/impl/src/test/java/org/glassfish/mojarra/webapp/ConfigFeature.java
+++ b/impl/src/test/java/org/glassfish/mojarra/webapp/ConfigFeature.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.webapp;
 
-import jakarta.faces.component.*;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/impl/src/test/java/org/glassfish/mojarra/webapp/ConfigFileTestCase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/webapp/ConfigFileTestCase.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.webapp;
 
-import jakarta.faces.component.*;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -106,7 +104,7 @@ public class ConfigFileTestCase {
         assertEquals("First", cc1.getConverterId());
         assertEquals("com.mycompany.MyFirstConverter", cc1.getConverterClass());
         assertEquals(1, cc1.getAttributes().size());
-        ConfigAttribute cc1a1 = (ConfigAttribute) cc1.getAttributes().get("attr1");
+        ConfigAttribute cc1a1 = cc1.getAttributes().get("attr1");
         assertNotNull(cc1a1);
         assertEquals("First Converter Attribute 1 Description", cc1a1.getDescription());
         assertEquals("First Converter Attribute 1 Display Name", cc1a1.getDisplayName());
@@ -125,7 +123,7 @@ public class ConfigFileTestCase {
         assertEquals("com.mycompany.MySecondConverter", cc2.getConverterClass());
         assertEquals(0, cc2.getAttributes().size());
         assertEquals(1, cc2.getProperties().size());
-        ConfigProperty cc2p1 = (ConfigProperty) cc2.getProperties().get("prop1");
+        ConfigProperty cc2p1 = cc2.getProperties().get("prop1");
         assertNotNull(cc2p1);
         assertEquals("Second Converter Property 1 Description", cc2p1.getDescription());
         assertEquals("Second Converter Property 1 Display Name", cc2p1.getDisplayName());
@@ -146,7 +144,7 @@ public class ConfigFileTestCase {
         assertEquals("First", cv1.getValidatorId());
         assertEquals("com.mycompany.MyFirstValidator", cv1.getValidatorClass());
         assertEquals(1, cv1.getAttributes().size());
-        ConfigAttribute cv1a1 = (ConfigAttribute) cv1.getAttributes().get("attr1");
+        ConfigAttribute cv1a1 = cv1.getAttributes().get("attr1");
         assertNotNull(cv1a1);
         assertEquals("First Validator Attribute 1 Description", cv1a1.getDescription());
         assertEquals("First Validator Attribute 1 Display Name", cv1a1.getDisplayName());
@@ -165,7 +163,7 @@ public class ConfigFileTestCase {
         assertEquals("com.mycompany.MySecondValidator", cv2.getValidatorClass());
         assertEquals(0, cv2.getAttributes().size());
         assertEquals(1, cv2.getProperties().size());
-        ConfigProperty cv2p1 = (ConfigProperty) cv2.getProperties().get("prop1");
+        ConfigProperty cv2p1 = cv2.getProperties().get("prop1");
         assertNotNull(cv2p1);
         assertEquals("Second Validator Property 1 Description", cv2p1.getDescription());
         assertEquals("Second Validator Property 1 Display Name", cv2p1.getDisplayName());

--- a/impl/src/test/java/org/glassfish/mojarra/webapp/ConfigProperty.java
+++ b/impl/src/test/java/org/glassfish/mojarra/webapp/ConfigProperty.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.webapp;
 
-import jakarta.faces.component.*;
-
 /**
  * <p>
  * Config Bean for an Property.</p>

--- a/impl/src/test/java/org/glassfish/mojarra/webapp/ConfigValidator.java
+++ b/impl/src/test/java/org/glassfish/mojarra/webapp/ConfigValidator.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.mojarra.webapp;
 
-import jakarta.faces.component.*;
-
 /**
  * <p>
  * Config Bean for a Validator.</p>

--- a/impl/src/test/java/org/glassfish/mojarra/webapp/FacesServletTestCase.java
+++ b/impl/src/test/java/org/glassfish/mojarra/webapp/FacesServletTestCase.java
@@ -16,16 +16,13 @@
 
 package org.glassfish.mojarra.webapp;
 
-import jakarta.faces.webapp.FacesServlet;
-
-import jakarta.faces.component.*;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import jakarta.faces.FactoryFinder;
 import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.render.RenderKit;
 import jakarta.faces.render.RenderKitFactory;
+import jakarta.faces.webapp.FacesServlet;
 import jakarta.servlet.http.HttpServletResponse;
 
 import org.glassfish.mojarra.junit.JUnitFacesTestCaseBase;

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 
    <build>
         <plugins>
-            <!-- Sets minimal Maven version to 3.9.6 and minimal Java version to 17 -->
+            <!-- Sets minimal Maven version and Java version. -->
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>
@@ -72,7 +72,7 @@
                                     <version>3.9.6</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>[17,)</version>
+                                    <version>[${maven.compiler.release},)</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>
@@ -80,16 +80,6 @@
                 </executions>
             </plugin>
             
-            <!-- Restricts the Java version to 17 - API remains at Java 17 for now. -->
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.15.0</version>
-                <configuration>
-                    <release>17</release>
-                    <compilerArgument>-Xlint:unchecked</compilerArgument>
-                </configuration>
-            </plugin>
-
             <!-- Only impl is published to Maven Central, via central-publishing-maven-plugin in
                  impl/pom.xml's central-release profile. Disable the default maven-deploy-plugin
                  here so the parent pom (and any sibling module that lacks its own publishing


### PR DESCRIPTION
  ## Summary

  Expands on #5747 to get `/impl` to a fully warning-free state under **both** `javac -Xlint:all` and the Eclipse compiler (ECJ), in main and test sources. Deprecation / marked-for-removal warnings are intentionally left in place and excluded from the lint via `-Xlint:all,-deprecation,-removal`.

  ## Motivation

  `-Xlint:all` and ECJ surface far more than the previous lint config did (unused imports, raw types, redundant casts, missing `serialVersionUID`, generic-varargs heap pollution, `equals`/`hashCode`, javadoc HTML). Most of the raw-type
  noise stems from the Jakarta Faces API having generified several signatures (`Class<?>`, `Renderer<T>`, `Validator<T>`, `Converter<T>`, `ValueChangeListener<T>`, `MetaRuleset createMetaRuleset(Class<?>)`, …).

  ## Changes

  - **Bump `jakarta.faces-api` 5.0.0-M2 → 5.0.0-SNAPSHOT** so the impl compiles against the updated API with among others generified `getRenderer()`.
  - **Compiler config:** enable `-Xlint:all,-deprecation,-removal` in `maven-compiler-plugin`; move the Java-version floor in the enforcer to `[${maven.compiler.release},)`.
  - **Raw types → generics** (~58 sites): method-override signatures and `new Class<?>[]` arrays aligned with the generified API; heterogeneous lookups (e.g. `RenderKitImpl.getRenderer`) use a localized `@SuppressWarnings("unchecked")`
  cast.
  - **Removed redundant casts** that the generified API/iterators made unnecessary.
  - **Added `serialVersionUID`** to `Externalizable`/`Serializable` classes that lacked it.
  - **Generic-varargs heap pollution:** deleted dead helpers (`CollectionsUtils.asSet`, `ar()`), relocated `ar(T...)` into its sole caller (`AttributeManager`) as a non-generic `Attribute[]`, and modernized
  `Util.unmodifiableSet`/`CdiProducer` call sites to `Set.of(...)` (immutable) or `new HashSet<>(asList(...))` (mutable).
  - **`equals`/`hashCode`:** renamed `DefaultFaceletContext.TemplateManager.equals` to a non-override `wraps(Object)` (it was a deliberate identity check, never used in a hash structure); added consistent `hashCode()` to test helpers.
  - **Suppression hygiene:** removed redundant/stale `@SuppressWarnings` and a dead private method; removed legacy IDE/tool comments (`// NOPMD` ×8, `// noinspection` ×20) now superseded by standard annotations or inert (no PMD in the
  build).
  - **Removed unused imports** flagged by ECJ.
  - **Javadoc:** fixed empty `<p>` HTML warnings (`-Xdoclint:all,-missing` is now clean).
  - **Test sources** brought to the same standard (raw types, redundant casts, unused locals/imports/mocks, a missing `serialVersionUID`, and a type-mismatched `containsValue` assertion that always passed).

  ## Verification

  - `mvn clean install` on `/impl`: **0 non-deprecation warnings** from javac.
  - ECJ assessment run: **0 non-deprecation warnings** (main + test).
  - `mvn javadoc:jar` (`-Xdoclint:all,-missing`): clean.
  - Tests green: **870 Java + 393 JS**, 0 failures
  - TCK green.
