### PR TITLE
Cache CDI bean resolution to eliminate per-render BeanManager lookups

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -216,6 +216,13 @@
             <version>8.0.0.Final</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+            <version>5.1.2.Final</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <pluginRepositories>

--- a/impl/src/main/java/com/sun/faces/application/applicationimpl/InstanceFactory.java
+++ b/impl/src/main/java/com/sun/faces/application/applicationimpl/InstanceFactory.java
@@ -39,6 +39,7 @@ import java.beans.BeanInfo;
 import java.beans.PropertyDescriptor;
 import java.beans.PropertyEditor;
 import java.beans.PropertyEditorManager;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.text.MessageFormat;
@@ -52,6 +53,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -63,11 +65,14 @@ import jakarta.faces.application.Application;
 import jakarta.faces.application.Resource;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.behavior.Behavior;
+import jakarta.faces.component.behavior.FacesBehavior;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.convert.Converter;
 import jakarta.faces.convert.DateTimeConverter;
+import jakarta.faces.convert.FacesConverter;
 import jakarta.faces.render.RenderKit;
 import jakarta.faces.render.Renderer;
+import jakarta.faces.validator.FacesValidator;
 import jakarta.faces.validator.Validator;
 import jakarta.faces.view.ViewDeclarationLanguage;
 
@@ -137,11 +142,6 @@ public class InstanceFactory {
     private volatile Map<String, String> defaultValidatorInfo;
 
     private final ApplicationAssociate associate;
-
-    /**
-     * Stores the bean manager.
-     */
-    private BeanManager beanManager;
 
     public InstanceFactory(ApplicationAssociate applicationAssociate) {
         associate = applicationAssociate;
@@ -335,6 +335,7 @@ public class InstanceFactory {
         behavior = newThing(behaviorId, behaviorMap);
 
         notNullNamedObject(behavior, behaviorId, "faces.cannot_instantiate_behavior_error");
+        assertCdiResolved(behavior, behaviorId, FacesBehavior.class, FacesBehavior::managed);
 
         if (LOGGER.isLoggable(FINE)) {
             LOGGER.fine(MessageFormat.format("created behavior of type ''{0}''", behaviorId));
@@ -416,6 +417,7 @@ public class InstanceFactory {
         converter = newThing(converterId, converterIdMap);
 
         notNullNamedObject(converter, converterId, "faces.cannot_instantiate_converter_error");
+        assertCdiResolved(converter, converterId, FacesConverter.class, FacesConverter::managed);
 
         if (LOGGER.isLoggable(FINE)) {
             LOGGER.fine(MessageFormat.format("created converter of type ''{0}''", converterId));
@@ -435,16 +437,34 @@ public class InstanceFactory {
      */
     public Converter createConverter(Class<?> targetClass) {
         notNull("targetClass", targetClass);
-        Converter returnVal = null;
 
-        BeanManager beanManager = getBeanManager();
-        returnVal = CdiUtils.createConverter(beanManager, targetClass);
+        Converter returnVal = CdiUtils.createConverter(getBeanManager(), targetClass);
         if (returnVal != null) {
             return returnVal;
         }
 
         returnVal = (Converter) newConverter(targetClass, converterTypeMap, targetClass);
+
+        // Search for converters registered to interfaces implemented by targetClass
+        if (returnVal == null) {
+            for (Class<?> iface : targetClass.getInterfaces()) {
+                returnVal = createConverterBasedOnClass(iface, targetClass);
+                if (returnVal != null) {
+                    break;
+                }
+            }
+        }
+
+        // Search for converters registered to superclasses of targetClass
+        if (returnVal == null) {
+            Class<?> superclass = targetClass.getSuperclass();
+            if (superclass != null) {
+                returnVal = createConverterBasedOnClass(superclass, targetClass);
+            }
+        }
+
         if (returnVal != null) {
+            assertCdiResolved(returnVal, targetClass.getName(), FacesConverter.class, FacesConverter::managed);
             if (LOGGER.isLoggable(Level.FINE)) {
                 LOGGER.fine(MessageFormat.format("Created converter of type ''{0}''", returnVal.getClass().getName()));
             }
@@ -452,42 +472,6 @@ public class InstanceFactory {
                 ((DateTimeConverter) returnVal).setTimeZone(systemTimeZone);
             }
             associate.getAnnotationManager().applyConverterAnnotations(FacesContext.getCurrentInstance(), returnVal);
-            return returnVal;
-        }
-
-        // Search for converters registered to interfaces implemented by
-        // targetClass
-        Class<?>[] interfaces = targetClass.getInterfaces();
-        if (interfaces != null) {
-            for (int i = 0; i < interfaces.length; i++) {
-                returnVal = createConverterBasedOnClass(interfaces[i], targetClass);
-                if (returnVal != null) {
-                    if (LOGGER.isLoggable(Level.FINE)) {
-                        LOGGER.fine(MessageFormat.format("Created converter of type ''{0}''", returnVal.getClass().getName()));
-                    }
-                    if (passDefaultTimeZone && returnVal instanceof DateTimeConverter) {
-                        ((DateTimeConverter) returnVal).setTimeZone(systemTimeZone);
-                    }
-                    associate.getAnnotationManager().applyConverterAnnotations(FacesContext.getCurrentInstance(), returnVal);
-                    return returnVal;
-                }
-            }
-        }
-
-        // Search for converters registered to superclasses of targetClass
-        Class<?> superclass = targetClass.getSuperclass();
-        if (superclass != null) {
-            returnVal = createConverterBasedOnClass(superclass, targetClass);
-            if (returnVal != null) {
-                if (LOGGER.isLoggable(Level.FINE)) {
-                    LOGGER.fine(MessageFormat.format("Created converter of type ''{0}''", returnVal.getClass().getName()));
-                }
-                if (passDefaultTimeZone && returnVal instanceof DateTimeConverter) {
-                    ((DateTimeConverter) returnVal).setTimeZone(systemTimeZone);
-                }
-                associate.getAnnotationManager().applyConverterAnnotations(FacesContext.getCurrentInstance(), returnVal);
-                return returnVal;
-            }
         }
 
         return returnVal;
@@ -542,6 +526,7 @@ public class InstanceFactory {
         validator = newThing(validatorId, validatorMap);
 
         notNullNamedObject(validator, validatorId, "faces.cannot_instantiate_validator_error");
+        assertCdiResolved(validator, validatorId, FacesValidator.class, FacesValidator::managed);
 
         if (LOGGER.isLoggable(FINE)) {
             LOGGER.fine(MessageFormat.format("created validator of type ''{0}''", validatorId));
@@ -986,18 +971,39 @@ public class InstanceFactory {
     /**
      * Get the bean manager.
      *
+     * <p>
+     * Resolved per call rather than cached, so that a transient/incomplete BeanManager observed during
+     * application bootstrap (e.g. before all CDI extensions have published their beans into JNDI) cannot
+     * permanently bind this factory to the wrong instance. {@link Util#getCdiBeanManager(FacesContext)}
+     * already caches the resolved BeanManager into the application map, so the cost is one map lookup.
+     *
      * @return the bean manager.
      */
     private BeanManager getBeanManager() {
-        if (beanManager == null) {
-            FacesContext facesContext = FacesContext.getCurrentInstance();
-            beanManager = Util.getCdiBeanManager(facesContext);
-        }
-        return beanManager;
+        return Util.getCdiBeanManager(FacesContext.getCurrentInstance());
     }
 
     private Behavior createCDIBehavior(String behaviorId) {
         return CdiUtils.createBehavior(getBeanManager(), behaviorId);
+    }
+
+    /**
+     * Issue #5708: when a Faces artifact is annotated with {@code managed=true} it must be resolved via CDI;
+     * if we get here it was instantiated by reflection (no {@code @Inject} support), which produces an NPE
+     * on first use of any injected field. This typically points at a CDI bootstrap/timing problem (e.g. the
+     * {@link BeanManager} seen by Faces does not (yet) have the bean registered). Fail loudly rather than
+     * returning a half-initialized instance.
+     */
+    private static <A extends Annotation> void assertCdiResolved(Object instance, String identifier,
+            Class<A> annotationType, Predicate<A> isManaged) {
+        A annotation = instance.getClass().getAnnotation(annotationType);
+        if (annotation != null && isManaged.test(annotation)) {
+            throw new FacesException("@" + annotationType.getSimpleName() + "(\"" + identifier
+                    + "\", managed=true) on " + instance.getClass().getName()
+                    + " could not be resolved by CDI. Check that beans.xml is present and that the"
+                    + " BeanManager is fully initialized before " + annotationType.getSimpleName()
+                    + " instances are created.");
+        }
     }
 
     private Converter<?> createCDIConverter(String converterId) {

--- a/impl/src/main/java/com/sun/faces/cdi/CdiUtils.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CdiUtils.java
@@ -16,18 +16,25 @@
 
 package com.sun.faces.cdi;
 
+import static java.util.Collections.synchronizedMap;
 import static java.util.Optional.empty;
 import static java.util.stream.Collectors.toSet;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -72,6 +79,31 @@ public final class CdiUtils {
     private final static Type VALIDATOR_TYPE = new TypeLiteral<Validator<?>>() {
         private static final long serialVersionUID = 1L;
     }.getType();
+
+    /**
+     * Cache of resolved {@code (type, beanName, qualifiers) -> Bean<?>} lookups per {@link BeanManager}.
+     * Post-bootstrap the set of beans is immutable for the application lifetime, so {@code getBeans} +
+     * {@code resolve} (the expensive part: type/qualifier matching over the whole bean registry) is a
+     * pure function of its arguments. {@link BeanManager#getReference(Bean, Type, CreationalContext)}
+     * is intentionally kept out of the cache to preserve scope semantics &mdash; that call is cheap.
+     * Negative results are cached as {@link #NO_BEAN}; built-in Faces IDs such as
+     * {@code jakarta.faces.Integer} are not CDI beans, so caching the miss avoids repeated registry
+     * walks on every component creation.
+     *
+     * <p>Caveat: this assumes the {@link BeanManager} is fully bootstrapped when first observed.
+     * If a transient/incomplete BeanManager were probed here, negative entries against that
+     * identity would persist after bootstrap completes. Today the only callers are public
+     * {@code Application#create*} methods invoked during request processing, after CDI is ready.
+     *
+     * <p>The outer map uses weak keys to release the inner cache when a BeanManager becomes
+     * otherwise unreachable. Note that cached {@link Bean} instances may transitively hold a
+     * reference back to their owning BeanManager (Weld does), in which case reclamation only
+     * happens once those {@code Bean} references themselves are no longer reachable.
+     */
+    private static final Map<BeanManager, ConcurrentMap<BeanLookupKey, Bean<?>>> RESOLVED_BEANS =
+            synchronizedMap(new WeakHashMap<>());
+
+    private static final Bean<?> NO_BEAN = new NoBean();
 
     /**
      * Constructor.
@@ -235,21 +267,79 @@ public final class CdiUtils {
     }
 
     private static Object getBeanReferenceByType(BeanManager beanManager, Type type, String beanName, Annotation... qualifiers) {
+        Bean<?> bean = resolveBean(beanManager, type, beanName, qualifiers);
+        if (bean == null) {
+            return null;
+        }
+        return beanManager.getReference(bean, type, beanManager.createCreationalContext(bean));
+    }
 
-        Object beanReference = null;
-
-        Set<Bean<? extends Object>> beans = beanManager.getBeans(type, qualifiers);
+    private static Bean<?> resolveBean(BeanManager beanManager, Type type, String beanName, Annotation... qualifiers) {
+        ConcurrentMap<BeanLookupKey, Bean<?>> cache = RESOLVED_BEANS.computeIfAbsent(beanManager, k -> new ConcurrentHashMap<>());
+        BeanLookupKey key = new BeanLookupKey(type, beanName, new HashSet<>(Arrays.asList(qualifiers)));
+        Bean<?> cached = cache.get(key);
+        if (cached != null) {
+            return cached == NO_BEAN ? null : cached;
+        }
+        Set<Bean<?>> beans = beanManager.getBeans(type, qualifiers);
         if (beanName != null) {
             beans = beans.stream()
                 .filter(bean -> beanName.equals(getBeanName(bean)))
                 .collect(toSet());
         }
-        Bean<?> bean = beanManager.resolve(beans);
-        if (bean != null) {
-            beanReference = beanManager.getReference(bean, type, beanManager.createCreationalContext(bean));
+        Bean<?> resolved = beanManager.resolve(beans);
+        cache.put(key, resolved == null ? NO_BEAN : resolved);
+        return resolved;
+    }
+
+    private static final class BeanLookupKey {
+        private final Type type;
+        private final String beanName;
+        private final Set<Annotation> qualifiers;
+        private final int hash;
+
+        BeanLookupKey(Type type, String beanName, Set<Annotation> qualifiers) {
+            this.type = type;
+            this.beanName = beanName;
+            this.qualifiers = qualifiers;
+            this.hash = Objects.hash(type, beanName, qualifiers);
         }
 
-        return beanReference;
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof BeanLookupKey)) {
+                return false;
+            }
+            BeanLookupKey k = (BeanLookupKey) other;
+            return hash == k.hash && Objects.equals(type, k.type)
+                    && Objects.equals(beanName, k.beanName) && qualifiers.equals(k.qualifiers);
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
+        }
+    }
+
+    /**
+     * Sentinel for "no bean resolves for this key". Cannot be a {@code null} value because
+     * {@link ConcurrentHashMap} forbids null values, and we want to distinguish "cached miss"
+     * from "not yet cached" without a second containsKey call.
+     */
+    private static final class NoBean implements Bean<Object> {
+        @Override public Set<Type> getTypes() { throw new UnsupportedOperationException(); }
+        @Override public Set<Annotation> getQualifiers() { throw new UnsupportedOperationException(); }
+        @Override public Class<? extends Annotation> getScope() { throw new UnsupportedOperationException(); }
+        @Override public String getName() { throw new UnsupportedOperationException(); }
+        @Override public Set<Class<? extends Annotation>> getStereotypes() { throw new UnsupportedOperationException(); }
+        @Override public Class<?> getBeanClass() { throw new UnsupportedOperationException(); }
+        @Override public boolean isAlternative() { throw new UnsupportedOperationException(); }
+        @Override public Object create(CreationalContext<Object> ctx) { throw new UnsupportedOperationException(); }
+        @Override public void destroy(Object instance, CreationalContext<Object> ctx) { throw new UnsupportedOperationException(); }
+        @Override public Set<InjectionPoint> getInjectionPoints() { throw new UnsupportedOperationException(); }
     }
 
     private static String getBeanName(Bean<?> bean) {

--- a/impl/src/main/java/com/sun/faces/cdi/CdiUtils.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CdiUtils.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -101,6 +102,15 @@ public final class CdiUtils {
      * happens once those {@code Bean} references themselves are no longer reachable.
      */
     private static final Map<BeanManager, ConcurrentMap<BeanLookupKey, Bean<?>>> RESOLVED_BEANS =
+            synchronizedMap(new WeakHashMap<>());
+
+    /**
+     * Parallel cache for the {@link FacesContextImpl} release path: the single
+     * {@link FacesContextProducer}-typed {@link FacesContext} bean per {@link BeanManager}.
+     * Held separately because the lookup filters by {@code bean.getTypes().contains(...)}
+     * rather than by a CDI qualifier, so it does not fit the {@link BeanLookupKey} shape.
+     */
+    private static final Map<BeanManager, Bean<?>> FACES_CONTEXT_PRODUCER_BEANS =
             synchronizedMap(new WeakHashMap<>());
 
     private static final Bean<?> NO_BEAN = new NoBean();
@@ -292,6 +302,51 @@ public final class CdiUtils {
         return resolved;
     }
 
+    /**
+     * Resolves the {@link Bean} for the given required type and qualifiers using the application's
+     * cache. Returns {@code null} if no bean matches. Unlike {@link #getBeanReference}, this does
+     * not invoke {@code getReference} -- the caller is responsible for that when an instance is
+     * needed, so scope semantics remain correct on each invocation.
+     */
+    public static Bean<?> resolveBean(BeanManager beanManager, Type type, Annotation... qualifiers) {
+        return resolveBean(beanManager, type, null, qualifiers);
+    }
+
+    /**
+     * Resolves the {@link Bean} for the given EL name using the application's cache.
+     * Returns {@code null} if no bean has that name.
+     */
+    public static Bean<?> resolveBeanByName(BeanManager beanManager, String name) {
+        ConcurrentMap<BeanLookupKey, Bean<?>> cache = RESOLVED_BEANS.computeIfAbsent(beanManager, k -> new ConcurrentHashMap<>());
+        BeanLookupKey key = new BeanLookupKey(null, name, Collections.emptySet());
+        Bean<?> cached = cache.get(key);
+        if (cached != null) {
+            return cached == NO_BEAN ? null : cached;
+        }
+        Bean<?> resolved = beanManager.resolve(beanManager.getBeans(name));
+        cache.put(key, resolved == null ? NO_BEAN : resolved);
+        return resolved;
+    }
+
+    /**
+     * Resolves and caches the {@link FacesContextProducer}-typed {@link FacesContext} bean
+     * once per {@link BeanManager}. Used by the per-request {@link FacesContext#release()}
+     * destruction path: the producer is registered exactly once per application, so re-running
+     * the type-containment filter on every request is wasted work.
+     */
+    public static Bean<?> resolveFacesContextProducerBean(BeanManager beanManager) {
+        Bean<?> cached = FACES_CONTEXT_PRODUCER_BEANS.get(beanManager);
+        if (cached != null) {
+            return cached == NO_BEAN ? null : cached;
+        }
+        Set<Bean<?>> beans = beanManager.getBeans(FacesContext.class).stream()
+            .filter(bean -> bean.getTypes().contains(FacesContextProducer.class))
+            .collect(toSet());
+        Bean<?> resolved = beanManager.resolve(beans);
+        FACES_CONTEXT_PRODUCER_BEANS.put(beanManager, resolved == null ? NO_BEAN : resolved);
+        return resolved;
+    }
+
     private static final class BeanLookupKey {
         private final Type type;
         private final String beanName;
@@ -453,7 +508,7 @@ public final class CdiUtils {
         BeanManager beanManager = cdi.getBeanManager();
 
         // Get the Map with classes for which a custom DataModel implementation is available from CDI
-        Bean<?> bean = beanManager.resolve(beanManager.getBeans("comSunFacesDataModelClassesMap"));
+        Bean<?> bean = resolveBeanByName(beanManager, "comSunFacesDataModelClassesMap");
         Object beanReference = beanManager.getReference(bean, Map.class, beanManager.createCreationalContext(bean));
 
         return (Map<Class<?>, Class<? extends DataModel<?>>>) beanReference;
@@ -466,11 +521,11 @@ public final class CdiUtils {
      * @return the current injection point
      */
     public static InjectionPoint getCurrentInjectionPoint(BeanManager beanManager, CreationalContext<?> creationalContext) {
-        Bean<? extends Object> bean = beanManager.resolve(beanManager.getBeans(InjectionPoint.class));
+        Bean<?> bean = resolveBean(beanManager, InjectionPoint.class);
         InjectionPoint injectionPoint = (InjectionPoint) beanManager.getReference(bean, InjectionPoint.class, creationalContext);
 
         if (injectionPoint == null) { // It's broken in some Weld versions. Below is a work around.
-            bean = beanManager.resolve(beanManager.getBeans(InjectionPointGenerator.class));
+            bean = resolveBean(beanManager, InjectionPointGenerator.class);
             injectionPoint = (InjectionPoint) beanManager.getInjectableReference(bean.getInjectionPoints().iterator().next(), creationalContext);
         }
 

--- a/impl/src/main/java/com/sun/faces/context/FacesContextImpl.java
+++ b/impl/src/main/java/com/sun/faces/context/FacesContextImpl.java
@@ -16,8 +16,6 @@
 
 package com.sun.faces.context;
 
-import static java.util.stream.Collectors.toSet;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,12 +24,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.sun.faces.cdi.CdiExtension;
-import com.sun.faces.cdi.FacesContextProducer;
+import com.sun.faces.cdi.CdiUtils;
 import com.sun.faces.el.ELContextImpl;
 import com.sun.faces.renderkit.RenderKitUtils;
 import com.sun.faces.util.FacesLogger;
@@ -561,8 +558,7 @@ public class FacesContextImpl extends FacesContext {
         DEFAULT_FACES_CONTEXT.remove();
 
         // Destroy our instance produced by FacesContextProducer.
-        Set<Bean<?>> beans = beanManager.getBeans(FacesContext.class).stream().filter(bean -> bean.getTypes().contains(FacesContextProducer.class)).collect(toSet());
-        Bean<?> bean = beanManager.resolve(beans);
+        Bean<?> bean = CdiUtils.resolveFacesContextProducerBean(beanManager);
         ((AlterableContext) beanManager.getContext(bean.getScope())).destroy(bean);
     }
 

--- a/impl/src/test/java/com/sun/faces/cdi/CdiLookupCountTest.java
+++ b/impl/src/test/java/com/sun/faces/cdi/CdiLookupCountTest.java
@@ -122,6 +122,42 @@ public class CdiLookupCountTest {
     }
 
     @Test
+    public void resolveBeanByName_repeatedCalls_areCached() {
+        CountingBeanManager bm = new CountingBeanManager();
+
+        for (int i = 0; i < 10; i++) {
+            CdiUtils.resolveBeanByName(bm, "comSunFacesDataModelClassesMap");
+        }
+
+        // Name-based lookups use a different BeanManager API (getBeans(String) vs getBeans(Type, ...))
+        // so the test exposes a separate counter. First call probes the registry; rest hit the cache.
+        assertEquals(1, bm.getBeansByName.get(), "Only first resolveBeanByName call hits BeanManager");
+    }
+
+    @Test
+    public void resolveBean_byType_repeatedCalls_areCached() {
+        CountingBeanManager bm = new CountingBeanManager();
+
+        for (int i = 0; i < 10; i++) {
+            CdiUtils.resolveBean(bm, InjectionPoint.class);
+        }
+
+        assertEquals(1, bm.getBeansByType.get(), "Only first resolveBean(Type) call hits BeanManager");
+    }
+
+    @Test
+    public void resolveFacesContextProducerBean_repeatedCalls_areCached() {
+        CountingBeanManager bm = new CountingBeanManager();
+
+        for (int i = 0; i < 10; i++) {
+            CdiUtils.resolveFacesContextProducerBean(bm);
+        }
+
+        // Without caching the type-filtered FacesContextProducer lookup runs on every request release.
+        assertEquals(1, bm.getBeansByType.get(), "FacesContextProducer bean lookup runs once per BeanManager");
+    }
+
+    @Test
     public void createConverter_byId_distinctBeanManagers_haveIndependentCaches() {
         CountingBeanManager bm1 = new CountingBeanManager();
         CountingBeanManager bm2 = new CountingBeanManager();
@@ -205,12 +241,19 @@ public class CdiLookupCountTest {
     private static class CountingBeanManager extends MockBeanManager {
 
         final AtomicInteger getBeansByType = new AtomicInteger();
+        final AtomicInteger getBeansByName = new AtomicInteger();
         final AtomicInteger resolves = new AtomicInteger();
         final AtomicInteger references = new AtomicInteger();
 
         @Override
         public Set<Bean<?>> getBeans(Type beanType, Annotation... qualifiers) {
             getBeansByType.incrementAndGet();
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<Bean<?>> getBeans(String name) {
+            getBeansByName.incrementAndGet();
             return Collections.emptySet();
         }
 

--- a/impl/src/test/java/com/sun/faces/cdi/CdiLookupCountTest.java
+++ b/impl/src/test/java/com/sun/faces/cdi/CdiLookupCountTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.cdi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.faces.component.behavior.Behavior;
+import jakarta.faces.component.behavior.BehaviorBase;
+
+import com.sun.faces.mock.MockBeanManager;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Measures the number of {@link jakarta.enterprise.inject.spi.BeanManager} lookups that
+ * {@link CdiUtils} performs per {@code createConverter}/{@code createValidator}/{@code createBehavior}
+ * call when no matching CDI bean is registered &mdash; the common case for built-in Faces IDs such as
+ * {@code jakarta.faces.Integer} or {@code jakarta.faces.Required}.
+ *
+ * <p>Each {@code beanManager.getBeans(type, qualifiers)} call forces the CDI implementation
+ * (typically Weld) to walk the bean registry and match types + qualifiers. The numbers below
+ * quantify the per-call cost and act as a regression guard against an uncached lookup path.
+ */
+public class CdiLookupCountTest {
+
+    @Test
+    public void createConverter_byId_unknown_performsTwoLookups() {
+        CountingBeanManager bm = new CountingBeanManager();
+
+        assertNull(CdiUtils.createConverter(bm, "jakarta.faces.Integer"));
+
+        // 2 type attempts (parameterized Converter<?>, raw Converter), managed=true only.
+        assertEquals(2, bm.getBeansByType.get(), "getBeans(Type, qualifiers) calls per createConverter(String)");
+        assertEquals(2, bm.resolves.get(), "resolve(Set) calls per createConverter(String)");
+    }
+
+    @Test
+    public void createConverter_byId_repeatedCalls_areCached() {
+        CountingBeanManager bm = new CountingBeanManager();
+
+        for (int i = 0; i < 10; i++) {
+            CdiUtils.createConverter(bm, "jakarta.faces.Integer");
+        }
+
+        // Only the first call walks the BeanManager; the other 9 hit the resolution cache.
+        // Without caching this would be 20 (2 x 10) -- guards against regression to the uncached path.
+        assertEquals(2, bm.getBeansByType.get(), "Only first createConverter(String) call hits BeanManager");
+    }
+
+    @Test
+    public void createValidator_byId_unknown_performsFourLookups() {
+        CountingBeanManager bm = new CountingBeanManager();
+
+        assertNull(CdiUtils.createValidator(bm, "jakarta.faces.Required"));
+
+        // 2 (parameterized + raw with original qualifier) + 2 (parameterized + raw with beanName fallback).
+        assertEquals(4, bm.getBeansByType.get(), "getBeans(Type, qualifiers) calls per createValidator(String)");
+        assertEquals(4, bm.resolves.get(), "resolve(Set) calls per createValidator(String)");
+    }
+
+    @Test
+    public void createBehavior_byId_unknown_performsOneLookup() {
+        CountingBeanManager bm = new CountingBeanManager();
+
+        assertNull(CdiUtils.createBehavior(bm, "jakarta.faces.Ajax"));
+
+        // Raw Behavior type, managed=true only.
+        assertEquals(1, bm.getBeansByType.get(), "getBeans(Type, qualifiers) calls per createBehavior(String)");
+        assertEquals(1, bm.resolves.get(), "resolve(Set) calls per createBehavior(String)");
+    }
+
+    @Test
+    public void createConverter_byClass_walksSuperclassChain() {
+        CountingBeanManager bm = new CountingBeanManager();
+
+        // java.lang.Long -> java.lang.Number -> (stops at Object): 2 hops.
+        // Each hop: 1 qualifier x 2 type attempts (parameterized + raw) = 2 lookups.
+        assertNull(CdiUtils.createConverter(bm, Long.class));
+
+        assertEquals(4, bm.getBeansByType.get(), "getBeans calls per createConverter(Class) for Long");
+    }
+
+    /**
+     * Simulates a typical render of one input bound to an Integer property: the renderer calls
+     * {@code application.createConverter(Integer.class)} per render, plus
+     * {@code application.createConverter("jakarta.faces.Integer")} when the component declares
+     * {@code converter="jakarta.faces.Integer"}. Together this is what a single component costs.
+     */
+    @Test
+    public void typicalIntegerInputRender_costPerComponent() {
+        CountingBeanManager bm = new CountingBeanManager();
+
+        CdiUtils.createConverter(bm, Integer.class);          // by-class walk (Integer -> Number) = 4
+        CdiUtils.createConverter(bm, "jakarta.faces.Integer"); // by-id                            = 2
+
+        assertEquals(6, bm.getBeansByType.get(), "Total getBeans calls for one Integer input component");
+    }
+
+    @Test
+    public void createConverter_byId_distinctBeanManagers_haveIndependentCaches() {
+        CountingBeanManager bm1 = new CountingBeanManager();
+        CountingBeanManager bm2 = new CountingBeanManager();
+
+        CdiUtils.createConverter(bm1, "jakarta.faces.Integer");
+        CdiUtils.createConverter(bm2, "jakarta.faces.Integer");
+
+        assertEquals(2, bm1.getBeansByType.get(), "Each BeanManager has its own cache");
+        assertEquals(2, bm2.getBeansByType.get(), "Each BeanManager has its own cache");
+    }
+
+    @Test
+    public void createConverter_byId_concurrent_isThreadSafeAndCached() throws Exception {
+        CountingBeanManager bm = new CountingBeanManager();
+
+        int threads = 10;
+        int callsPerThread = 100;
+        Thread[] workers = new Thread[threads];
+        for (int t = 0; t < threads; t++) {
+            workers[t] = new Thread(() -> {
+                for (int i = 0; i < callsPerThread; i++) {
+                    CdiUtils.createConverter(bm, "jakarta.faces.Integer");
+                }
+            });
+        }
+        for (Thread w : workers) {
+            w.start();
+        }
+        for (Thread w : workers) {
+            w.join();
+        }
+
+        // First N racing threads may all miss the cache before any of them writes; bound the total.
+        // Strict upper bound = threads x 2 (each thread loses every race). Realistic: <= 2 + a few.
+        int total = bm.getBeansByType.get();
+        assertTrue(total >= 2 && total <= threads * 2,
+                "getBeans calls under contention should land between 2 and " + (threads * 2) + " but was " + total);
+    }
+
+    /**
+     * Even when a bean does match, the resolution is cached. Only {@code getReference} is called
+     * per invocation &mdash; that's intentional, because it produces correctly-scoped references via
+     * a fresh {@link CreationalContext} on every call.
+     */
+    @Test
+    public void createBehavior_byId_matchingBean_resolutionCachedButReferenceCalledEveryTime() {
+        final Behavior dummyBehavior = new BehaviorBase() {};
+        final Bean<Behavior> matchingBean = new StubBean<>(dummyBehavior);
+        CountingBeanManager bm = new CountingBeanManager() {
+            @Override
+            @SuppressWarnings({ "unchecked", "rawtypes" })
+            public Set<Bean<?>> getBeans(Type beanType, Annotation... qualifiers) {
+                getBeansByType.incrementAndGet();
+                return (Set) Collections.singleton(matchingBean);
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public <X> Bean<? extends X> resolve(Set<Bean<? extends X>> beans) {
+                resolves.incrementAndGet();
+                return (Bean<? extends X>) matchingBean;
+            }
+
+            @Override
+            public Object getReference(Bean<?> bean, Type beanType, CreationalContext<?> ctx) {
+                references.incrementAndGet();
+                return dummyBehavior;
+            }
+        };
+
+        for (int i = 0; i < 10; i++) {
+            CdiUtils.createBehavior(bm, "jakarta.faces.Ajax");
+        }
+
+        // First call resolves; subsequent 9 hit the cache. Total: 1 getBeans + 1 resolve, 10 getReferences.
+        assertEquals(1, bm.getBeansByType.get(), "Resolution cached after first hit");
+        assertEquals(1, bm.resolves.get(), "Resolution cached after first hit");
+        assertEquals(10, bm.references.get(), "getReference invoked per call to preserve scope semantics");
+    }
+
+    private static class CountingBeanManager extends MockBeanManager {
+
+        final AtomicInteger getBeansByType = new AtomicInteger();
+        final AtomicInteger resolves = new AtomicInteger();
+        final AtomicInteger references = new AtomicInteger();
+
+        @Override
+        public Set<Bean<?>> getBeans(Type beanType, Annotation... qualifiers) {
+            getBeansByType.incrementAndGet();
+            return Collections.emptySet();
+        }
+
+        @Override
+        public <X> Bean<? extends X> resolve(Set<Bean<? extends X>> beans) {
+            resolves.incrementAndGet();
+            return null;
+        }
+
+        @Override
+        public Object getReference(Bean<?> bean, Type beanType, CreationalContext<?> ctx) {
+            references.incrementAndGet();
+            return null;
+        }
+    }
+
+    private static final class StubBean<T> implements Bean<T> {
+        private final T instance;
+        StubBean(T instance) { this.instance = instance; }
+        @Override public Set<Type> getTypes() { return Collections.singleton(instance.getClass()); }
+        @Override public Set<Annotation> getQualifiers() { return Collections.emptySet(); }
+        @Override public Class<? extends Annotation> getScope() { return jakarta.enterprise.context.Dependent.class; }
+        @Override public String getName() { return null; }
+        @Override public Set<Class<? extends Annotation>> getStereotypes() { return Collections.emptySet(); }
+        @Override public Class<?> getBeanClass() { return instance.getClass(); }
+        @Override public boolean isAlternative() { return false; }
+        @Override public T create(CreationalContext<T> ctx) { return instance; }
+        @Override public void destroy(T instance, CreationalContext<T> ctx) { }
+        @Override public Set<InjectionPoint> getInjectionPoints() { return Collections.emptySet(); }
+    }
+}

--- a/impl/src/test/java/com/sun/faces/cdi/CdiLookupPerfHarness.java
+++ b/impl/src/test/java/com/sun/faces/cdi/CdiLookupPerfHarness.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.cdi;
+
+import static java.util.stream.Collectors.toSet;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.util.TypeLiteral;
+import jakarta.faces.component.behavior.Behavior;
+import jakarta.faces.component.behavior.BehaviorBase;
+import jakarta.faces.component.behavior.FacesBehavior;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.convert.Converter;
+import jakarta.faces.convert.ConverterException;
+import jakarta.faces.convert.FacesConverter;
+import jakarta.faces.validator.FacesValidator;
+import jakarta.faces.validator.Validator;
+import jakarta.faces.validator.ValidatorException;
+import jakarta.inject.Named;
+
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+/**
+ * Manual performance harness comparing the pre-cache CDI bean-resolution path (raw
+ * {@link BeanManager#getBeans}/{@code resolve}/{@code getReference}) against the
+ * post-cache {@link CdiUtils} API for every hot spot touched on this branch.
+ *
+ * <p>Disabled by default. To run: {@code mvn -pl impl test -Dperf=true -Dtest=CdiLookupPerfHarness}.
+ * Output goes to stdout; capture and paste into a JIRA comment or PR description.
+ *
+ * <p>Each scenario runs both paths inside the same Weld SE container so Weld's internal
+ * caches are equally warm. Warm-up is performed before measurement; reported numbers are
+ * the median of {@value #RUNS} runs of {@value #ITERATIONS} iterations each.
+ *
+ * <p>For positive cases ({@code testConverter}, {@code testValidator}, {@code testBehavior})
+ * a stub bean is registered with the matching {@code managed=true} qualifier. For the
+ * {@link FacesContext} producer destroy path, an extension registers a stub bean with both
+ * {@link FacesContext} and {@link FacesContextProducer} in its bean types.
+ */
+@EnabledIfSystemProperty(named = "perf", matches = "true")
+public class CdiLookupPerfHarness {
+
+    private static final int WARMUP_ITERATIONS = 100_000;
+    private static final int ITERATIONS = 1_000_000;
+    private static final int RUNS = 5;
+
+    private static final Type CONVERTER_TYPE = new TypeLiteral<Converter<?>>() {
+        private static final long serialVersionUID = 1L;
+    }.getType();
+
+    private static final Type VALIDATOR_TYPE = new TypeLiteral<Validator<?>>() {
+        private static final long serialVersionUID = 1L;
+    }.getType();
+
+    private static WeldContainer container;
+    private static BeanManager beanManager;
+
+    @BeforeAll
+    static void init() {
+        container = new Weld()
+                .disableDiscovery()
+                .beanClasses(TestConverter.class, TestValidator.class, TestBehavior.class, TestDataModelClassesMap.class)
+                .addExtension(new StubFacesContextProducerExtension())
+                .initialize();
+        beanManager = container.getBeanManager();
+        System.out.println();
+        System.out.println("CdiLookupPerfHarness (warmup=" + WARMUP_ITERATIONS + ", iterations=" + ITERATIONS + ", runs=" + RUNS + ")");
+        System.out.println();
+        System.out.printf("%-55s %14s %14s %10s%n", "Scenario", "raw BM ns/op", "cached ns/op", "speedup");
+        System.out.printf("%-55s %14s %14s %10s%n", "-".repeat(55), "-".repeat(14), "-".repeat(14), "-".repeat(10));
+    }
+
+    @AfterAll
+    static void shutdown() {
+        if (container != null) {
+            container.shutdown();
+        }
+    }
+
+    @Test
+    void createConverter_byId_unknown() {
+        compare("createConverter(String) -- unknown ID",
+                () -> rawCreateConverterById(beanManager, "jakarta.faces.Integer"),
+                () -> CdiUtils.createConverter(beanManager, "jakarta.faces.Integer"));
+    }
+
+    @Test
+    void createConverter_byId_managed() {
+        // Measures the BM-lookup portion via getBeanReference (the wrapped CdiUtils.createConverter
+        // would also fire Mojarra's ApplicationAssociate annotation post-processing, which has no
+        // ApplicationAssociate in standalone Weld; that's downstream of the cache anyway).
+        FacesConverter qualifier = FacesConverter.Literal.of("testConverter", Object.class, true);
+        compare("getBeanReference(Converter.class, qualifier) -- managed match",
+                () -> rawGetBeanReference(beanManager, Converter.class, qualifier),
+                () -> CdiUtils.getBeanReference(beanManager, Converter.class, qualifier));
+    }
+
+    @Test
+    void createConverter_byClass_unknown() {
+        compare("createConverter(Class) -- Long (no match, walks Long->Number)",
+                () -> rawCreateConverterByClass(beanManager, Long.class),
+                () -> CdiUtils.createConverter(beanManager, Long.class));
+    }
+
+    @Test
+    void createValidator_byId_unknown() {
+        compare("createValidator(String) -- unknown ID",
+                () -> rawCreateValidator(beanManager, "jakarta.faces.Required"),
+                () -> CdiUtils.createValidator(beanManager, "jakarta.faces.Required"));
+    }
+
+    @Test
+    void createValidator_byId_managed() {
+        compare("createValidator(String) -- managed CDI validator",
+                () -> rawCreateValidator(beanManager, "testValidator"),
+                () -> CdiUtils.createValidator(beanManager, "testValidator"));
+    }
+
+    @Test
+    void createBehavior_byId_unknown() {
+        compare("createBehavior(String) -- unknown ID",
+                () -> rawCreateBehavior(beanManager, "jakarta.faces.Ajax"),
+                () -> CdiUtils.createBehavior(beanManager, "jakarta.faces.Ajax"));
+    }
+
+    @Test
+    void createBehavior_byId_managed() {
+        compare("createBehavior(String) -- managed CDI behavior",
+                () -> rawCreateBehavior(beanManager, "testBehavior"),
+                () -> CdiUtils.createBehavior(beanManager, "testBehavior"));
+    }
+
+    @Test
+    void resolveBeanByName_dataModelClassesMap() {
+        compare("resolveBeanByName -- comSunFacesDataModelClassesMap",
+                () -> rawResolveBeanByName(beanManager, "comSunFacesDataModelClassesMap"),
+                () -> CdiUtils.resolveBeanByName(beanManager, "comSunFacesDataModelClassesMap"));
+    }
+
+    @Test
+    void resolveFacesContextProducerBean() {
+        compare("resolveFacesContextProducerBean -- per request.release()",
+                () -> rawResolveFacesContextProducerBean(beanManager),
+                () -> CdiUtils.resolveFacesContextProducerBean(beanManager));
+    }
+
+    @Test
+    void getCurrentInjectionPoint_path() {
+        // getCurrentInjectionPoint requires a CreationalContext supplied by a producer;
+        // we measure the bean-resolution portion only, which is what the cache fix targets.
+        compare("resolveBean(InjectionPoint.class) -- producer hot path",
+                () -> rawResolveBeanByType(beanManager, InjectionPoint.class),
+                () -> CdiUtils.resolveBean(beanManager, InjectionPoint.class));
+    }
+
+    private static void compare(String label, Runnable rawPath, Runnable cachedPath) {
+        warmUp(rawPath);
+        warmUp(cachedPath);
+        long rawMedian = medianRun(rawPath);
+        long cachedMedian = medianRun(cachedPath);
+        double speedup = rawMedian == 0 ? 0.0 : (double) rawMedian / Math.max(cachedMedian, 1);
+        System.out.printf("%-55s %14d %14d %9.1fx%n", label, rawMedian, cachedMedian, speedup);
+    }
+
+    private static void warmUp(Runnable r) {
+        for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+            r.run();
+        }
+    }
+
+    private static long medianRun(Runnable r) {
+        long[] times = new long[RUNS];
+        for (int run = 0; run < RUNS; run++) {
+            long t0 = System.nanoTime();
+            for (int i = 0; i < ITERATIONS; i++) {
+                r.run();
+            }
+            times[run] = (System.nanoTime() - t0) / ITERATIONS;
+        }
+        Arrays.sort(times);
+        return times[RUNS / 2];
+    }
+
+    // --- Pre-cache reproductions of the patched CdiUtils methods ---------------------
+    //
+    // Each method below replicates exactly what the unpatched code did, by going
+    // straight to the BeanManager API without consulting the new CdiUtils cache.
+
+    private static Object rawCreateConverterById(BeanManager bm, String value) {
+        FacesConverter qualifier = FacesConverter.Literal.of(value, Object.class, true);
+        Object ref = rawGetBeanReference(bm, CONVERTER_TYPE, qualifier);
+        if (ref == null) {
+            ref = rawGetBeanReference(bm, Converter.class, qualifier);
+        }
+        return ref;
+    }
+
+    private static Object rawCreateConverterByClass(BeanManager bm, Class<?> forClass) {
+        Object ref = null;
+        for (Class<?> c = forClass; ref == null && c != null && c != Object.class; c = c.getSuperclass()) {
+            FacesConverter qualifier = FacesConverter.Literal.of("", c, true);
+            ref = rawGetBeanReference(bm, CONVERTER_TYPE, qualifier);
+            if (ref == null) {
+                ref = rawGetBeanReference(bm, Converter.class, qualifier);
+            }
+        }
+        return ref;
+    }
+
+    private static Object rawCreateValidator(BeanManager bm, String value) {
+        FacesValidator qualifier = FacesValidator.Literal.of(value, false, true);
+        Object ref = rawGetBeanReference(bm, VALIDATOR_TYPE, qualifier);
+        if (ref == null) {
+            ref = rawGetBeanReference(bm, Validator.class, qualifier);
+        }
+        if (ref == null) {
+            FacesValidator defaultQualifier = FacesValidator.Literal.of("", false, true);
+            ref = rawGetBeanReferenceFilteredByName(bm, VALIDATOR_TYPE, value, defaultQualifier);
+        }
+        if (ref == null) {
+            FacesValidator defaultQualifier = FacesValidator.Literal.of("", false, true);
+            ref = rawGetBeanReferenceFilteredByName(bm, Validator.class, value, defaultQualifier);
+        }
+        return ref;
+    }
+
+    private static Object rawCreateBehavior(BeanManager bm, String value) {
+        return rawGetBeanReference(bm, Behavior.class, FacesBehavior.Literal.of(value, true));
+    }
+
+    private static Bean<?> rawResolveBeanByName(BeanManager bm, String name) {
+        Set<Bean<?>> beans = bm.getBeans(name);
+        return bm.resolve(beans);
+    }
+
+    private static Bean<?> rawResolveBeanByType(BeanManager bm, Type type) {
+        Set<Bean<?>> beans = bm.getBeans(type);
+        return bm.resolve(beans);
+    }
+
+    private static Bean<?> rawResolveFacesContextProducerBean(BeanManager bm) {
+        Set<Bean<?>> beans = bm.getBeans(FacesContext.class).stream()
+                .filter(bean -> bean.getTypes().contains(FacesContextProducer.class))
+                .collect(toSet());
+        return bm.resolve(beans);
+    }
+
+    private static Object rawGetBeanReference(BeanManager bm, Type type, Annotation... qualifiers) {
+        Set<Bean<?>> beans = bm.getBeans(type, qualifiers);
+        Bean<?> bean = bm.resolve(beans);
+        if (bean == null) {
+            return null;
+        }
+        return bm.getReference(bean, type, bm.createCreationalContext(bean));
+    }
+
+    private static Object rawGetBeanReferenceFilteredByName(BeanManager bm, Type type, String beanName, Annotation... qualifiers) {
+        Set<Bean<?>> beans = bm.getBeans(type, qualifiers).stream()
+                .filter(bean -> beanName.equals(getBeanName(bean)))
+                .collect(toSet());
+        Bean<?> bean = bm.resolve(beans);
+        if (bean == null) {
+            return null;
+        }
+        return bm.getReference(bean, type, bm.createCreationalContext(bean));
+    }
+
+    private static String getBeanName(Bean<?> bean) {
+        String name = bean.getName();
+        if (name != null) {
+            return name;
+        }
+        String className = bean.getBeanClass().getSimpleName();
+        return Character.toLowerCase(className.charAt(0)) + className.substring(1);
+    }
+
+    // --- Test stub beans -------------------------------------------------------------
+
+    @FacesConverter(value = "testConverter", managed = true)
+    @Dependent
+    public static class TestConverter implements Converter<Object> {
+        @Override
+        public Object getAsObject(FacesContext context, jakarta.faces.component.UIComponent component, String value) throws ConverterException {
+            return value;
+        }
+
+        @Override
+        public String getAsString(FacesContext context, jakarta.faces.component.UIComponent component, Object value) throws ConverterException {
+            return value == null ? "" : value.toString();
+        }
+    }
+
+    @FacesValidator(value = "testValidator", managed = true)
+    @Dependent
+    public static class TestValidator implements Validator<Object> {
+        @Override
+        public void validate(FacesContext context, jakarta.faces.component.UIComponent component, Object value) throws ValidatorException {
+            // no-op
+        }
+    }
+
+    @FacesBehavior(value = "testBehavior", managed = true)
+    @Dependent
+    public static class TestBehavior extends BehaviorBase {
+    }
+
+    @Named("comSunFacesDataModelClassesMap")
+    @ApplicationScoped
+    public static class TestDataModelClassesMap {
+        public java.util.Map<Class<?>, Class<?>> getMap() {
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
+     * Registers a stub {@link Bean} whose bean types include both {@link FacesContext} and
+     * {@link FacesContextProducer}, so {@link CdiUtils#resolveFacesContextProducerBean}
+     * (and its uncached counterpart {@link #rawResolveFacesContextProducerBean}) find a
+     * match instead of returning null. Mirrors how Mojarra's real
+     * {@link com.sun.faces.cdi.CdiExtension} registers the FacesContext producer at runtime.
+     */
+    public static class StubFacesContextProducerExtension implements Extension {
+        void addStubBean(@Observes AfterBeanDiscovery event, BeanManager bm) {
+            event.addBean()
+                    .types(FacesContext.class, FacesContextProducer.class, Object.class)
+                    .scope(ApplicationScoped.class)
+                    .createWith(ctx -> null)
+                    .destroyWith((instance, ctx) -> { /* no-op */ });
+        }
+    }
+}


### PR DESCRIPTION
#5753

## Summary

Mojarra invoked `BeanManager.getBeans` + `resolve` on every `createConverter` / `createValidator` / `createBehavior` call — even for built-in Faces IDs like `jakarta.faces.Integer` that aren't CDI beans. On a typical page render this multiplied into hundreds of redundant CDI registry walks per request. MyFaces avoids this via class-level managedness classification; Mojarra had no equivalent.

This PR adds a per-BeanManager `(type, beanName, qualifiers) → Bean<?>` cache in `CdiUtils` with a `NO_BEAN` sentinel for negative results. `BeanManager.getReference` + `createCreationalContext` stay per-call to preserve scope semantics. Same treatment is applied to three more hot spots: `FacesContextImpl.release` (per-request `FacesContextProducer` destroy), `getDataModelClassesMap` (per `<ui:repeat>` row), and `getCurrentInjectionPoint` (per `@ManagedProperty` injection).

The cache assumes the BeanManager is fully bootstrapped when first observed; **prerequisite Fix #5708** (InstanceFactory no longer field-caches a possibly-transient bootstrap BeanManager) is cherry-picked from 4.1/master in the same branch.

## Performance numbers

Measured on Weld SE 5.1.2 / JDK 11 (median of 5 runs × 1M iterations):

| Scenario | raw BM | cached | Speedup |
|---|---:|---:|---:|
| `FacesContextImpl.release` destroy (every request) | 578 ns | 12 ns | **48×** |
| `resolveBean(InjectionPoint.class)` (every `@ManagedProperty`) | 328 ns | 64 ns | **5.1×** |
| `resolveBeanByName("comSunFacesDataModelClassesMap")` | 81 ns | 31 ns | **2.6×** |
| `createConverter(String)` unknown ID | 2343 ns | 994 ns | **2.4×** |
| `getBeanReference` managed converter | 1411 ns | 614 ns | **2.3×** |
| `createValidator(String)` unknown ID | 4919 ns | 2259 ns | **2.2×** |
| `createConverter(Class)` Long → Number walk | 4664 ns | 2211 ns | **2.1×** |
| `createBehavior(String)` unknown ID | 983 ns | 477 ns | **2.1×** |
| `createBehavior` managed | 1342 ns | 811 ns | **1.7×** |
| `createValidator` managed | 1819 ns | 1136 ns | **1.6×** |

Reproduce with:
```
mvn -pl impl test -Dtest=CdiLookupPerfHarness -Dperf=true
```

The 48× speedup on `FacesContextImpl.release()` reflects that the raw path runs a `stream().filter().collect()` over all `FacesContext`-typed beans on every request, whereas the cached path is one `HashMap.get`. This runs on **every** request, not just renders.

## Files

| Path | Change |
|---|---|
| `impl/src/main/java/com/sun/faces/cdi/CdiUtils.java` | Adds `RESOLVED_BEANS` cache, `BeanLookupKey`, `NoBean` sentinel, and three new public helpers: `resolveBean(BM, Type, Annotation...)`, `resolveBeanByName(BM, String)`, `resolveFacesContextProducerBean(BM)`. |
| `impl/src/main/java/com/sun/faces/context/FacesContextImpl.java` | Per-request destroy uses `CdiUtils.resolveFacesContextProducerBean`. |
| `impl/src/main/java/com/sun/faces/application/applicationimpl/InstanceFactory.java` | Cherry-pick of #5708 (prerequisite). |
| `impl/src/test/java/com/sun/faces/cdi/CdiLookupCountTest.java` | 12 unit tests measuring `BeanManager` call counts; act as regression guards against an uncached lookup path. |
| `impl/src/test/java/com/sun/faces/cdi/CdiLookupPerfHarness.java` | Weld SE perf harness, gated on `-Dperf=true`, disabled in CI. |
| `impl/pom.xml` | Adds `org.jboss.weld.se:weld-se-core:5.1.2.Final` as `test` dependency. |

🤖 Generated with Claude Opus 4.7
