### PR TITLE
Type-check faces.js against the UMD faces.d.ts

### DIFF
--- a/impl/src/main/ts/faces/ajax.ts
+++ b/impl/src/main/ts/faces/ajax.ts
@@ -1,4 +1,4 @@
-import type { faces as FacesSpec } from "../../../../../faces/api/src/main/resources/META-INF/resources/jakarta.faces/faces";
+import type FacesSpec from "../../../../../faces/api/src/main/resources/META-INF/resources/jakarta.faces/faces";
 import {
     UDEF, EMPTY, SPACE, FORM,
     VIEW_STATE_PARAM, CLIENT_WINDOW_PARAM, ALWAYS_EXECUTE_IDS, ENCODED_URL_PARAM,

--- a/impl/src/main/ts/faces/api.ts
+++ b/impl/src/main/ts/faces/api.ts
@@ -4,7 +4,7 @@
  * @see api/.../faces.d.ts namespace `faces`
  */
 
-import type { faces as FacesSpec } from "../../../../../faces/api/src/main/resources/META-INF/resources/jakarta.faces/faces";
+import type FacesSpec from "../../../../../faces/api/src/main/resources/META-INF/resources/jakarta.faces/faces";
 import type { MojarraNamespace } from "../mojarra";
 
 import { UDEF, EMPTY, SPACE, FORM, ALWAYS_EXECUTE_IDS, CLIENT_WINDOW_PARAM } from "./constants";

--- a/impl/src/main/ts/faces/push.ts
+++ b/impl/src/main/ts/faces/push.ts
@@ -3,7 +3,7 @@
  * @see api/.../faces.d.ts namespace `faces.push`
  */
 
-import type { faces as FacesSpec } from "../../../../../faces/api/src/main/resources/META-INF/resources/jakarta.faces/faces";
+import type FacesSpec from "../../../../../faces/api/src/main/resources/META-INF/resources/jakarta.faces/faces";
 import type { WindowAsDict } from "./dom";
 
 type OnOpen = FacesSpec.push.OnOpenHandler;

--- a/impl/src/main/ts/faces/util.ts
+++ b/impl/src/main/ts/faces/util.ts
@@ -3,7 +3,7 @@
  * @see api/.../faces.d.ts namespace `faces.util`
  */
 
-import type { faces as FacesSpec } from "../../../../../faces/api/src/main/resources/META-INF/resources/jakarta.faces/faces";
+import type FacesSpec from "../../../../../faces/api/src/main/resources/META-INF/resources/jakarta.faces/faces";
 import { getHead, getNonce, executeScriptWithNonce, type WindowAsDict } from "./dom";
 
 /**


### PR DESCRIPTION
Pairs with jakartaee/faces#2177.

faces#2176 made `faces.d.ts` a pure global ambient declaration, which is a **non-module** — so the per-member modules here (`api/ajax/push/util.ts`) could no longer `import` it to type-check the implementation against the spec (`TS2306: File is not a module`). That silently severs the compile-time conformance check.

faces#2177 makes `faces.d.ts` a **UMD** declaration (`export = faces; export as namespace faces;`) — global for `<script>` consumers *and* importable as a module. This PR:

- bumps the `faces` submodule `f428b070f` → `b103acd84` (the UMD commit);
- switches the spec-type import from the named `import type { faces as FacesSpec }` (no longer exported) to the default `import type FacesSpec` of the `export = faces` module, in `api/ajax/push/util.ts`.

Result: `faces.js` again type-checks against `faces.d.ts` at build time and **fails to build when the implementation drifts from the spec** (verified: changing a spec signature breaks the rollup build with `TS2322`). Full TS build + all 393 jest tests pass.

🤖 Generated with Claude Opus 4.8