### PR TITLE
Reduce request-pipeline overhead (state, traversal, render output, events) — 4.0 backport

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/applicationimpl/Events.java
+++ b/impl/src/main/java/com/sun/faces/application/applicationimpl/Events.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
 import com.sun.faces.application.applicationimpl.events.ComponentSystemEventHelper;
@@ -56,6 +57,12 @@ public class Events {
 
     private final SystemEventHelper systemEventHelper = new SystemEventHelper();
     private final ComponentSystemEventHelper compSysEventHelper = new ComponentSystemEventHelper();
+
+    // Application-level (global) listener subscriptions, by event class. Lets publishEvent skip the
+    // global listener lookup for events nobody subscribed to globally (the common case for the
+    // per-component Pre/PostValidateEvent, PreRenderComponentEvent, etc.). Over-approximating: classes
+    // are never removed on unsubscribe, so a stale entry only costs an empty lookup, never a missed event.
+    private final Set<Class<? extends SystemEvent>> globallySubscribedEventClasses = ConcurrentHashMap.newKeySet();
 
     /*
      * This class encapsulates the behavior to prevent infinite loops when the publishing of one event leads to the queueing
@@ -100,11 +107,15 @@ public class Events {
             // Look for and invoke any 'view' listeners
             event = invokeViewListenersFor(context, systemEventClass, event, source);
 
-            // Look for and invoke any listeners stored on the application using source type.
-            event = invokeListenersFor(systemEventClass, event, source, sourceBaseType, true);
+            // Look for and invoke any application-level listeners. Skip the lookup entirely when no
+            // global listener was ever registered for this event class (the common case).
+            if (globallySubscribedEventClasses.contains(systemEventClass)) {
+                // Look for and invoke any listeners stored on the application using source type.
+                event = invokeListenersFor(systemEventClass, event, source, sourceBaseType, true);
 
-            // Look for and invoke any listeners not specific to the source class
-            invokeListenersFor(systemEventClass, event, source, null, false);
+                // Look for and invoke any listeners not specific to the source class
+                invokeListenersFor(systemEventClass, event, source, null, false);
+            }
         } catch (AbortProcessingException ape) {
             context.getApplication().publishEvent(context, ExceptionQueuedEvent.class, new ExceptionQueuedEventContext(context, ape));
         }
@@ -126,6 +137,7 @@ public class Events {
         notNull(LISTENER, listener);
 
         getListeners(systemEventClass, sourceClass).add(listener);
+        globallySubscribedEventClasses.add(systemEventClass);
     }
 
     /*
@@ -181,30 +193,28 @@ public class Events {
     }
 
     private SystemEvent invokeViewListenersFor(FacesContext ctx, Class<? extends SystemEvent> systemEventClass, SystemEvent event, Object source) {
-        SystemEvent result = event;
+        UIViewRoot root = ctx.getViewRoot();
+        if (root == null) {
+            return event;
+        }
+
+        // Resolve the view listeners before touching the reentrancy guard: the common case has none,
+        // and the guard's bookkeeping (a per-request map) is only needed while actually invoking them.
+        List<SystemEventListener> listeners = root.getViewListenersForEventClass(systemEventClass);
+        if (null == listeners) {
+            return null;
+        }
 
         if (listenerInvocationGuard.isGuardSet(ctx, systemEventClass)) {
-            return result;
+            return event;
         }
         listenerInvocationGuard.setGuard(ctx, systemEventClass);
-
-        UIViewRoot root = ctx.getViewRoot();
         try {
-            if (root != null) {
-                List<SystemEventListener> listeners = root.getViewListenersForEventClass(systemEventClass);
-                if (null == listeners) {
-                    return null;
-                }
-
-                EventInfo rootEventInfo = systemEventHelper.getEventInfo(systemEventClass, UIViewRoot.class);
-                // process view listeners
-                result = processListenersAccountingForAdds(listeners, event, source, rootEventInfo);
-            }
+            EventInfo rootEventInfo = systemEventHelper.getEventInfo(systemEventClass, UIViewRoot.class);
+            return processListenersAccountingForAdds(listeners, event, source, rootEventInfo);
         } finally {
             listenerInvocationGuard.clearGuard(ctx, systemEventClass);
         }
-        return result;
-
     }
 
     /**

--- a/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
+++ b/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
@@ -770,6 +770,7 @@ public class WebConfiguration {
         ResourceUpdateCheckPeriod("com.sun.faces.resourceUpdateCheckPeriod", "5"), // in minutes
         CompressableMimeTypes("com.sun.faces.compressableMimeTypes", ""),
         DisableUnicodeEscaping("com.sun.faces.disableUnicodeEscaping", "auto"),
+        DisableIdUniquenessCheck("com.sun.faces.disableIdUniquenessCheck", "auto"), // true|false|auto; auto skips the check in Production
         FaceletsDefaultRefreshPeriod(ViewHandler.FACELETS_REFRESH_PERIOD_PARAM_NAME, "2"),
         FaceletsViewMappings(ViewHandler.FACELETS_VIEW_MAPPINGS_PARAM_NAME, ""),
         FaceletsLibraries(ViewHandler.FACELETS_LIBRARIES_PARAM_NAME, ""),
@@ -880,7 +881,6 @@ public class WebConfiguration {
         CacheResourceModificationTimestamp("com.sun.faces.cacheResourceModificationTimestamp", false),
         EnableDistributable("com.sun.faces.enableDistributable", false),
         EnableMissingResourceLibraryDetection("com.sun.faces.enableMissingResourceLibraryDetection", false),
-        DisableIdUniquenessCheck("com.sun.faces.disableIdUniquenessCheck", false),
         CspNonceEnabled(ResourceHandlerImpl.ENABLE_CSP_NONCE_PARAM_NAME, false),
         EnableTransitionTimeNoOpFlash("com.sun.faces.enableTransitionTimeNoOpFlash", false),
         ForceAlwaysWriteFlashCookie("com.sun.faces.forceAlwaysWriteFlashCookie", false),

--- a/impl/src/main/java/com/sun/faces/context/ExternalContextImpl.java
+++ b/impl/src/main/java/com/sun/faces/context/ExternalContextImpl.java
@@ -23,6 +23,7 @@ import static com.sun.faces.util.MessageUtils.NULL_PARAMETERS_ERROR_MESSAGE_ID;
 import static com.sun.faces.util.MessageUtils.getExceptionMessageString;
 import static com.sun.faces.util.Util.isEmpty;
 
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -85,6 +86,12 @@ public class ExternalContextImpl extends ExternalContext {
     private ServletContext servletContext = null;
     private ServletRequest request = null;
     private ServletResponse response = null;
+    // Cached response writer (lazily created). A BufferedWriter so the many small render-time writes --
+    // and any writes by render-view listeners that obtain this same writer -- coalesce into larger chunks
+    // before the container's writer (some servlet writers, e.g. undertow, pay a per-write encode cost).
+    // Caching means every caller shares one buffer, preserving write order; flushed in release() and
+    // responseFlushBuffer().
+    private Writer responseOutputWriter;
     private ClientWindow clientWindow = null;
 
     private Map<String, Object> applicationMap = null;
@@ -829,7 +836,10 @@ public class ExternalContextImpl extends ExternalContext {
      */
     @Override
     public Writer getResponseOutputWriter() throws IOException {
-        return response.getWriter();
+        if (responseOutputWriter == null) {
+            responseOutputWriter = new BufferedWriter(response.getWriter());
+        }
+        return responseOutputWriter;
     }
 
     /**
@@ -934,6 +944,10 @@ public class ExternalContextImpl extends ExternalContext {
             doLastPhaseActions(facesContext, false);
         }
 
+        if (responseOutputWriter != null) {
+            responseOutputWriter.flush();
+        }
+
         response.flushBuffer();
     }
 
@@ -1026,6 +1040,18 @@ public class ExternalContextImpl extends ExternalContext {
 
     @Override
     public void release() {
+        // Flush buffered render output to the container's writer before discarding the response. This is
+        // the guaranteed end-of-request hook (FacesContext.release runs in the FacesServlet finally), so it
+        // covers output written after renderView -- e.g. by PostRenderViewEvent listeners.
+        if (responseOutputWriter != null) {
+            try {
+                responseOutputWriter.flush();
+            } catch (IOException ignored) {
+                // Best-effort at teardown; a genuine write failure surfaces via the container.
+            }
+            responseOutputWriter = null;
+        }
+
         servletContext = null;
         request = null;
         response = null;

--- a/impl/src/main/java/com/sun/faces/facelets/component/UIRepeat.java
+++ b/impl/src/main/java/com/sun/faces/facelets/component/UIRepeat.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
 import java.sql.ResultSet;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -342,17 +343,16 @@ public class UIRepeat extends UINamingContainer {
     private Map<String, SavedState> childState;
 
     /**
-     * Per-iteration cache: {@code true} if any descendant is an {@link EditableValueHolder} whose
-     * state needs to be saved/restored across {@link #setIndex} changes; {@code false} if the
-     * entire subtree is read-only. {@code null} means not yet scanned. Computed lazily by
-     * {@link #hasStatefulDescendants()} on first need; cleared when iteration ends
+     * Per-iteration cache of the descendants the per-row save/restore walks act on, collected by
+     * {@link #ensureIterationLists()} on first need and cleared when iteration ends
      * ({@link #setIndex} to {@code -1}) so the next iteration re-evaluates the tree shape.
-     *
-     * <p>When this is {@code false}, {@link #saveChildState(FacesContext)} and
-     * {@link #restoreChildState(FacesContext)} become no-ops, eliminating the per-row tree walk
-     * for read-only repeats.
+     * {@code iterationResetList} is every descendant -- all need their cached clientId reset each
+     * row; {@code iterationStatefulList} is the {@link EditableValueHolder} subset carrying per-row
+     * state. {@code null} means not yet collected. Iterating these flat lists replaces the previous
+     * per-row recursive tree walk; a read-only repeat has an empty stateful list, so save is a no-op.
      */
-    private transient Boolean hasStatefulDescendants;
+    private transient List<UIComponent> iterationResetList;
+    private transient List<UIComponent> iterationStatefulList;
 
     private Map<String, SavedState> getChildState() {
         if (childState == null) {
@@ -365,59 +365,46 @@ public class UIRepeat extends UINamingContainer {
         childState = null;
     }
 
-    private boolean hasStatefulDescendants() {
-        Boolean cached = hasStatefulDescendants;
-        if (cached != null) {
-            return cached;
+    /**
+     * Collects, once per iteration, the descendants the per-row save/restore walks act on, so those
+     * walks become flat-list iterations instead of recursive tree traversals re-done every row.
+     * {@code iterationResetList} is every descendant (each needs its cached clientId reset per row);
+     * {@code iterationStatefulList} is the {@link EditableValueHolder} subset. Cleared on
+     * {@code setIndex(-1)} so the next iteration re-evaluates the tree shape.
+     */
+    private void ensureIterationLists() {
+        if (iterationResetList != null) {
+            return;
         }
-        boolean result = scanForStatefulDescendants();
-        hasStatefulDescendants = result;
-        return result;
-    }
-
-    private boolean scanForStatefulDescendants() {
-        if (getChildCount() == 0) {
-            return false;
-        }
-        for (UIComponent kid : getChildren()) {
-            if (subtreeHasStatefulDescendant(kid)) {
-                return true;
+        List<UIComponent> reset = new ArrayList<>();
+        List<UIComponent> stateful = new ArrayList<>();
+        if (getChildCount() > 0) {
+            for (UIComponent kid : getChildren()) {
+                collectIterationState(kid, reset, stateful);
             }
         }
-        return false;
+        iterationResetList = reset;
+        iterationStatefulList = stateful;
     }
 
-    private boolean subtreeHasStatefulDescendant(UIComponent component) {
+    private void collectIterationState(UIComponent component, List<UIComponent> reset, List<UIComponent> stateful) {
+        reset.add(component);
         if (component instanceof EditableValueHolder) {
-            return true;
+            stateful.add(component);
         }
-        if (component.getChildCount() > 0) {
-            for (UIComponent kid : component.getChildren()) {
-                if (subtreeHasStatefulDescendant(kid)) {
-                    return true;
-                }
-            }
+        Iterator<UIComponent> itr = component.getFacetsAndChildren();
+        while (itr.hasNext()) {
+            collectIterationState(itr.next(), reset, stateful);
         }
-        if (component.getFacetCount() > 0) {
-            for (UIComponent facet : component.getFacets().values()) {
-                if (subtreeHasStatefulDescendant(facet)) {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 
     private void saveChildState(FacesContext ctx) {
-        // Skip the per-row tree walk entirely if no descendants need per-row state.
-        if (!hasStatefulDescendants()) {
+        ensureIterationLists();
+        if (iterationStatefulList.isEmpty()) {
             return;
         }
-        if (getChildCount() > 0) {
-
-            for (UIComponent uiComponent : getChildren()) {
-                this.saveChildState(ctx, uiComponent);
-            }
+        for (UIComponent uiComponent : iterationStatefulList) {
+            this.saveChildState(ctx, uiComponent);
         }
     }
 
@@ -448,7 +435,7 @@ public class UIRepeat extends UINamingContainer {
     }
 
     private void saveChildState(FacesContext faces, UIComponent c) {
-
+        // Called per stateful descendant from the precollected list; no recursion here.
         if (c instanceof EditableValueHolder && !c.isTransient()) {
             String clientId = c.getClientId(faces);
             SavedState ss = getChildState().get(clientId);
@@ -458,37 +445,28 @@ public class UIRepeat extends UINamingContainer {
             }
             ss.populate((EditableValueHolder) c);
         }
-
-        // continue hack
-        Iterator itr = c.getFacetsAndChildren();
-        while (itr.hasNext()) {
-            saveChildState(faces, (UIComponent) itr.next());
-        }
     }
 
     private void restoreChildState(FacesContext ctx) {
-        // Unlike saveChildState, the restore-side walk must always run even when no
-        // descendants carry per-row state: restoreChildState(faces, c, childState) below
-        // calls setId(getId()) on every component to invalidate its cached clientId so each
-        // row gets a row-specific clientId (e.g. repeat:N:foo). Skipping the walk would leave
-        // stale clientIds and render duplicate id="..." attributes across rows.
-        if (getChildCount() > 0) {
-
-            // The child-state map is invariant across this walk; fetch it once and thread it
-            // through the recursion instead of re-querying getChildState() at every node.
+        // The clientId reset must run for every descendant (not just stateful ones): each row needs a
+        // row-specific clientId (e.g. repeat:N:foo), else rows render duplicate id="...". The descendant
+        // set is constant within an iteration, so it is collected once and walked here as a flat list.
+        ensureIterationLists();
+        for (UIComponent component : iterationResetList) {
+            component.setId(component.getId()); // forces the cached clientId to be recomputed
+        }
+        if (!iterationStatefulList.isEmpty()) {
+            // The child-state map is invariant across this walk; fetch it once.
             Map<String, SavedState> childStateMap = getChildState();
-            for (UIComponent uiComponent : getChildren()) {
-                this.restoreChildState(ctx, uiComponent, childStateMap);
+            for (UIComponent component : iterationStatefulList) {
+                this.restoreChildState(ctx, component, childStateMap);
             }
         }
     }
 
     private void restoreChildState(FacesContext faces, UIComponent c, Map<String, SavedState> childStateMap) {
-        // reset id
-        String id = c.getId();
-        c.setId(id);
-
-        // hack
+        // The clientId reset happens in the caller's iterationResetList walk; here we only restore the
+        // per-row transient state of a single stateful descendant.
         if (c instanceof EditableValueHolder) {
             EditableValueHolder evh = (EditableValueHolder) c;
             String clientId = c.getClientId(faces);
@@ -498,12 +476,6 @@ public class UIRepeat extends UINamingContainer {
             } else {
                 NULL_STATE.apply(evh);
             }
-        }
-
-        // continue hack
-        Iterator itr = c.getFacetsAndChildren();
-        while (itr.hasNext()) {
-            restoreChildState(faces, (UIComponent) itr.next(), childStateMap);
         }
     }
 
@@ -560,7 +532,8 @@ public class UIRepeat extends UINamingContainer {
         // iteration re-evaluates the tree shape (children can change between iterations).
         // Cleared after restoreChildState() so the in-iteration walks still hit the cache.
         if (this.index == -1) {
-            hasStatefulDescendants = null;
+            iterationResetList = null;
+            iterationStatefulList = null;
         }
     }
 

--- a/impl/src/main/java/com/sun/faces/util/Util.java
+++ b/impl/src/main/java/com/sun/faces/util/Util.java
@@ -1168,44 +1168,51 @@ public class Util {
      * Utility method to validate ID uniqueness for the tree represented by <code>component</code>.
      */
     public static void checkIdUniqueness(FacesContext context, UIComponent component, Set<String> componentIds) {
-
-        boolean uniquenessCheckDisabled = false;
-
-        if (context.isProjectStage(ProjectStage.Production)) {
-            WebConfiguration config = WebConfiguration.getInstance(context.getExternalContext());
-            uniquenessCheckDisabled = config.isOptionEnabled(WebConfiguration.BooleanWebContextInitParameter.DisableIdUniquenessCheck);
+        if (!isIdUniquenessCheckDisabled(context)) {
+            doCheckIdUniqueness(context, component, componentIds);
         }
+    }
 
-        if (!uniquenessCheckDisabled) {
+    // com.sun.faces.disableIdUniquenessCheck is true|false|auto (default auto). auto skips the check
+    // in Production only, mirroring MyFaces' CHECK_ID_PRODUCTION_MODE default; a duplicate-id bug would
+    // already have surfaced in Development, so the per-build tree walk buys nothing in Production.
+    private static boolean isIdUniquenessCheckDisabled(FacesContext context) {
+        String value = WebConfiguration.getInstance(context.getExternalContext())
+                .getOptionValue(WebConfiguration.WebContextInitParameter.DisableIdUniquenessCheck);
+        if (value == null || "auto".equals(value)) {
+            return context.isProjectStage(ProjectStage.Production);
+        }
+        return Boolean.parseBoolean(value);
+    }
 
-            // deal with children/facets that are marked transient.
-            for (Iterator<UIComponent> kids = component.getFacetsAndChildren(); kids.hasNext();) {
+    private static void doCheckIdUniqueness(FacesContext context, UIComponent component, Set<String> componentIds) {
+        // deal with children/facets that are marked transient.
+        for (Iterator<UIComponent> kids = component.getFacetsAndChildren(); kids.hasNext();) {
 
-                UIComponent kid = kids.next();
-                // Skip UntargetableComponent descendants (e.g. Facelets-compiler-generated
-                // UILeaf wrappers for static text/whitespace). They have auto-generated ids
-                // that cannot collide via user-authored templates, and they have no
-                // user-targetable descendants -- checking them is wasted work on every
-                // save-view.
-                if (kid instanceof UntargetableComponent) {
-                    continue;
+            UIComponent kid = kids.next();
+            // Skip UntargetableComponent descendants (e.g. Facelets-compiler-generated
+            // UILeaf wrappers for static text/whitespace). They have auto-generated ids
+            // that cannot collide via user-authored templates, and they have no
+            // user-targetable descendants -- checking them is wasted work on every
+            // save-view.
+            if (kid instanceof UntargetableComponent) {
+                continue;
+            }
+            // check for id uniqueness
+            String id = kid.getClientId(context);
+            if (componentIds.add(id)) {
+                doCheckIdUniqueness(context, kid, componentIds);
+            } else {
+                if (LOGGER.isLoggable(Level.SEVERE)) {
+                    LOGGER.log(Level.SEVERE, "faces.duplicate_component_id_error", id);
+
+                    FastStringWriter writer = new FastStringWriter(128);
+                    DebugUtil.simplePrintTree(context.getViewRoot(), id, writer);
+                    LOGGER.severe(writer.toString());
                 }
-                // check for id uniqueness
-                String id = kid.getClientId(context);
-                if (componentIds.add(id)) {
-                    checkIdUniqueness(context, kid, componentIds);
-                } else {
-                    if (LOGGER.isLoggable(Level.SEVERE)) {
-                        LOGGER.log(Level.SEVERE, "faces.duplicate_component_id_error", id);
 
-                        FastStringWriter writer = new FastStringWriter(128);
-                        DebugUtil.simplePrintTree(context.getViewRoot(), id, writer);
-                        LOGGER.severe(writer.toString());
-                    }
-
-                    String message = MessageUtils.getExceptionMessageString(MessageUtils.DUPLICATE_COMPONENT_ID_ERROR_ID, id);
-                    throw new IllegalStateException(message);
-                }
+                String message = MessageUtils.getExceptionMessageString(MessageUtils.DUPLICATE_COMPONENT_ID_ERROR_ID, id);
+                throw new IllegalStateException(message);
             }
         }
     }

--- a/impl/src/main/java/jakarta/faces/component/UIComponent.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponent.java
@@ -1433,9 +1433,13 @@ public abstract class UIComponent implements PartialStateHolder, TransientStateH
 
         if (getRendersChildren()) {
             encodeChildren(context);
-        } else if (getChildCount() > 0) {
-            for (UIComponent kid : getChildren()) {
-                kid.encodeAll(context);
+        } else {
+            int childCount = getChildCount();
+            if (childCount > 0) {
+                List<UIComponent> children = getChildren();
+                for (int i = 0; i < childCount; i++) {
+                    children.get(i).encodeAll(context);
+                }
             }
         }
 

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -154,6 +154,12 @@ public abstract class UIComponentBase extends UIComponent {
      */
     private String clientId;
 
+    // Cached first NamingContainer ancestor, resolved lazily by getNamingContainerAncestor(). Depends only
+    // on the parent chain, so it survives UIData/UIRepeat row iteration (which changes rowIndex and clientIds
+    // but not the tree) and lets the per-row clientId recompute skip the parent-chain walk. Invalidated only
+    // in setParent (the sole place this component's parent chain changes).
+    private UIComponent namingContainerAncestor;
+
     /**
      * <p>
      * The parent component for this component.
@@ -289,6 +295,9 @@ public abstract class UIComponentBase extends UIComponent {
         }
 
         clientId = null; // Erase any cached value
+        // Note: the cached NamingContainer ancestor is deliberately NOT cleared here. It depends only on
+        // the parent chain, which setId never changes; clearing it would defeat the cache during iteration,
+        // where UIRepeat/UIData call setId(getId()) per row on every descendant to refresh their clientIds.
     }
 
     @Override
@@ -302,6 +311,8 @@ public abstract class UIComponentBase extends UIComponent {
         // Parenting can move this component under a different UIViewRoot (and therefore a
         // different RenderKit), so invalidate the cached Renderer defensively.
         cachedRenderer = null;
+        // The parent chain changed, so the cached NamingContainer ancestor is no longer valid.
+        namingContainerAncestor = null;
 
         if (parent == null) {
             if (this.parent != null) {
@@ -3281,12 +3292,14 @@ public abstract class UIComponentBase extends UIComponent {
     }
 
     private UIComponent getNamingContainerAncestor() {
-        UIComponent namingContainer = getParent();
-        while (namingContainer != null) {
-            if (namingContainer instanceof NamingContainer) {
-                return namingContainer;
+        if (namingContainerAncestor != null) {
+            return namingContainerAncestor;
+        }
+
+        for (UIComponent ancestor = getParent(); ancestor != null; ancestor = ancestor.getParent()) {
+            if (ancestor instanceof NamingContainer) {
+                return namingContainerAncestor = ancestor;
             }
-            namingContainer = namingContainer.getParent();
         }
 
         return null;

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -1964,36 +1964,33 @@ public abstract class UIComponentBase extends UIComponent {
             if (ATTRIBUTES_THAT_ARE_SET_KEY.equals(key)) {
                 result = component.getStateHelper().get(UIComponent.PropertyKeysPrivate.attributesThatAreSet);
             }
-            Map<String, Object> attributes = (Map<String, Object>) component.getStateHelper().get(PropertyKeys.attributes);
+            // Resolved lazily: the property-backed fast path below never needs it.
+            Map<String, Object> attributes = null;
             if (null == result) {
-                PropertyDescriptor pd = getPropertyDescriptor(key);
-                if (pd != null) {
-                    try {
-                        if (null == readMap) {
-                            readMap = new ConcurrentHashMap<>();
-                        }
-                        Method readMethod = readMap.get(key);
-                        if (null == readMethod) {
-                            readMethod = pd.getReadMethod();
-                            Method putResult = readMap.putIfAbsent(key, readMethod);
-                            if (null != putResult) {
-                                readMethod = putResult;
-                            }
-                        }
-
+                // A previously-resolved property getter is cached by name. Invoke it directly and skip the
+                // per-read PropertyDescriptor lookup -- the descriptor is only needed to discover the getter
+                // once. This is the hot path when the same component is rendered repeatedly (UIData/UIRepeat rows).
+                Method readMethod = readMap == null ? null : readMap.get(key);
+                if (readMethod != null) {
+                    result = invokeReadMethod(readMethod);
+                } else {
+                    PropertyDescriptor pd = getPropertyDescriptor(key);
+                    if (pd != null) {
+                        readMethod = pd.getReadMethod();
                         if (readMethod != null) {
-                            result = readMethod.invoke(component, EMPTY_OBJECT_ARRAY);
+                            if (null == readMap) {
+                                readMap = new ConcurrentHashMap<>();
+                            }
+                            readMap.putIfAbsent(key, readMethod);
+                            result = invokeReadMethod(readMethod);
                         } else {
                             throw new IllegalArgumentException(key);
                         }
-                    } catch (IllegalAccessException e) {
-                        throw new FacesException(e);
-                    } catch (InvocationTargetException e) {
-                        throw new FacesException(e.getTargetException());
-                    }
-                } else if (attributes != null) {
-                    if (attributes.containsKey(key)) {
-                        result = attributes.get(key);
+                    } else {
+                        attributes = (Map<String, Object>) component.getStateHelper().get(PropertyKeys.attributes);
+                        if (attributes != null && attributes.containsKey(key)) {
+                            result = attributes.get(key);
+                        }
                     }
                 }
             }
@@ -2007,8 +2004,13 @@ public abstract class UIComponentBase extends UIComponent {
                     }
                 }
             }
-            if (result == null && attributes != null && isCompositeComponent(component)) {
-                result = getCompositeComponentAttributeDefaultValue(key, attributes);
+            if (result == null && isCompositeComponent(component)) {
+                if (attributes == null) {
+                    attributes = (Map<String, Object>) component.getStateHelper().get(PropertyKeys.attributes);
+                }
+                if (attributes != null) {
+                    result = getCompositeComponentAttributeDefaultValue(key, attributes);
+                }
             }
             return result;
         }
@@ -2223,6 +2225,16 @@ public abstract class UIComponentBase extends UIComponent {
 
         private Object putAttribute(String key, Object value) {
             return component.getStateHelper().put(PropertyKeys.attributes, key, value);
+        }
+
+        private Object invokeReadMethod(Method readMethod) {
+            try {
+                return readMethod.invoke(component, EMPTY_OBJECT_ARRAY);
+            } catch (IllegalAccessException e) {
+                throw new FacesException(e);
+            } catch (InvocationTargetException e) {
+                throw new FacesException(e.getTargetException());
+            }
         }
 
         /**
@@ -3175,6 +3187,18 @@ public abstract class UIComponentBase extends UIComponent {
             if (propertyDescriptors != null) {
                 propertyDescriptorMap = new HashMap<>(propertyDescriptors.length, 1.0f);
                 for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
+                    // Suppress the per-invoke reflective access check on the (public) property getter.
+                    // It is invoked on every property-backed attribute read, which is hot under render
+                    // and UIData/UIRepeat iteration. Done once per component class (this map is cached
+                    // application-wide below). Guarded: the module system may forbid it for a getter in a
+                    // non-exported user package, in which case the normal access check simply remains.
+                    Method readMethod = propertyDescriptor.getReadMethod();
+                    if (readMethod != null) {
+                        try {
+                            readMethod.setAccessible(true);
+                        } catch (RuntimeException accessNotSuppressed) {
+                        }
+                    }
                     propertyDescriptorMap.put(propertyDescriptor.getName(), propertyDescriptor);
                 }
 

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -882,11 +882,18 @@ public abstract class UIComponentBase extends UIComponent {
         pushComponentToEL(context, null);
 
         try {
-            // Process all facets and children of this component
-            Iterator<UIComponent> kids = getFacetsAndChildren();
-            while (kids.hasNext()) {
-                UIComponent kid = kids.next();
-                kid.processDecodes(context);
+            // Process all facets and children of this component, facets first (matching getFacetsAndChildren()).
+            if (getFacetCount() > 0) {
+                for (UIComponent facet : getFacets().values()) {
+                    facet.processDecodes(context);
+                }
+            }
+            int childCount = getChildCount();
+            if (childCount > 0) {
+                List<UIComponent> children = getChildren();
+                for (int i = 0; i < childCount; i++) {
+                    children.get(i).processDecodes(context);
+                }
             }
 
             // Process this component itself
@@ -922,11 +929,18 @@ public abstract class UIComponentBase extends UIComponent {
             Application application = context.getApplication();
             application.publishEvent(context, PreValidateEvent.class, this);
 
-            // Process all the facets and children of this component
-            Iterator<UIComponent> kids = getFacetsAndChildren();
-            while (kids.hasNext()) {
-                UIComponent kid = kids.next();
-                kid.processValidators(context);
+            // Process all facets and children of this component, facets first (matching getFacetsAndChildren()).
+            if (getFacetCount() > 0) {
+                for (UIComponent facet : getFacets().values()) {
+                    facet.processValidators(context);
+                }
+            }
+            int childCount = getChildCount();
+            if (childCount > 0) {
+                List<UIComponent> children = getChildren();
+                for (int i = 0; i < childCount; i++) {
+                    children.get(i).processValidators(context);
+                }
             }
 
             application.publishEvent(context, PostValidateEvent.class, this);
@@ -953,11 +967,18 @@ public abstract class UIComponentBase extends UIComponent {
         pushComponentToEL(context, null);
 
         try {
-            // Process all facets and children of this component
-            Iterator<UIComponent> kids = getFacetsAndChildren();
-            while (kids.hasNext()) {
-                UIComponent kid = kids.next();
-                kid.processUpdates(context);
+            // Process all facets and children of this component, facets first (matching getFacetsAndChildren()).
+            if (getFacetCount() > 0) {
+                for (UIComponent facet : getFacets().values()) {
+                    facet.processUpdates(context);
+                }
+            }
+            int childCount = getChildCount();
+            if (childCount > 0) {
+                List<UIComponent> children = getChildren();
+                for (int i = 0; i < childCount; i++) {
+                    children.get(i).processUpdates(context);
+                }
             }
         } finally {
             popComponentFromEL(context);
@@ -2699,6 +2720,15 @@ public abstract class UIComponentBase extends UIComponent {
             return new ArrayList<>(super.keySet()).iterator();
         }
 
+        // Snapshot of the live entries (super.* to bypass this map's wrapping views), so the values
+        // iterator can return each facet directly instead of re-looking it up by key per next().
+        Iterator<Map.Entry<String, UIComponent>> entrySetIterator() {
+            if (super.isEmpty()) {
+                return Collections.emptyIterator();
+            }
+            return new ArrayList<>(super.entrySet()).iterator();
+        }
+
     }
 
     // Private implementation of Set for FacetsMap.getEntrySet()
@@ -3076,12 +3106,12 @@ public abstract class UIComponentBase extends UIComponent {
 
         public FacetsMapValuesIterator(FacetsMap map) {
             this.map = map;
-            iterator = map.keySetIterator();
+            iterator = map.entrySetIterator();
         }
 
         private FacetsMap map = null;
-        private Iterator<String> iterator = null;
-        private Object last = null;
+        private Iterator<Map.Entry<String, UIComponent>> iterator = null;
+        private Map.Entry<String, UIComponent> last = null;
 
         @Override
         public boolean hasNext() {
@@ -3091,7 +3121,7 @@ public abstract class UIComponentBase extends UIComponent {
         @Override
         public UIComponent next() {
             last = iterator.next();
-            return map.get(last);
+            return last.getValue();
         }
 
         @Override
@@ -3099,7 +3129,7 @@ public abstract class UIComponentBase extends UIComponent {
             if (last == null) {
                 throw new IllegalStateException();
             }
-            map.remove(last);
+            map.remove(last.getKey());
             last = null;
         }
 

--- a/impl/src/main/java/jakarta/faces/component/UIData.java
+++ b/impl/src/main/java/jakarta/faces/component/UIData.java
@@ -244,17 +244,18 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
     private Object _initialDescendantFullComponentState = null;
 
     /**
-     * Per-iteration cache: {@code true} if any descendant is an {@link EditableValueHolder} or
-     * {@link UIForm} whose state needs to be saved/restored across {@link #setRowIndex} changes;
-     * {@code false} if the entire subtree is read-only. {@code null} means not yet scanned.
-     * Computed lazily by {@link #hasStatefulDescendants()} on first need; cleared when iteration
-     * ends ({@link #setRowIndex} to {@code -1}) so the next iteration re-evaluates the tree shape.
-     *
-     * <p>When this is {@code false}, {@link #saveDescendantState()} and {@link #restoreDescendantState()}
-     * become no-ops, eliminating the per-row tree walk for read-only tables (e.g. a table of
-     * {@code <h:outputText/>}).
+     * Per-iteration cache of the descendants the per-row save/restore walks act on, collected by
+     * {@link #ensureIterationLists()} on first need and cleared when iteration ends
+     * ({@link #setRowIndex} to {@code -1}) so the next iteration re-evaluates the tree shape.
+     * {@code iterationResetList} is every descendant under the table's {@link UIColumn} children --
+     * all need their cached clientId reset each row; {@code iterationStatefulList} is the
+     * {@link EditableValueHolder}/{@link UIForm} subset that actually carries per-row state.
+     * {@code null} means not yet collected for the current iteration. Iterating these flat lists
+     * replaces the previous per-row recursive tree walk; a read-only table has an empty stateful
+     * list, so save is a no-op.
      */
-    private transient Boolean hasStatefulDescendants;
+    private transient List<UIComponent> iterationResetList;
+    private transient List<UIComponent> iterationStatefulList;
 
     // -------------------------------------------------------------- Properties
 
@@ -537,7 +538,8 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
         // Cleared after restoreDescendantState() so the in-iteration walks still hit the
         // cache; this avoids a redundant re-scan on the iteration-end save+restore.
         if (rowIndex == -1) {
-            hasStatefulDescendants = null;
+            iterationResetList = null;
+            iterationStatefulList = null;
         }
 
     }
@@ -2167,22 +2169,21 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
      */
     private void restoreDescendantState() {
 
-        // Unlike saveDescendantState, the restore-side walk must always run even when no
-        // descendants carry per-row state: restoreDescendantState(component, context, saved)
-        // below calls setId(getId()) on every component to invalidate its cached clientId so
-        // each row gets a row-specific clientId (e.g. data:N:foo). Skipping the walk would
-        // leave stale clientIds and render duplicate id="..." attributes across rows.
-
+        // The clientId reset must run for every descendant (not just the stateful ones): each row
+        // needs a row-specific clientId (e.g. data:N:foo), else rows render duplicate id="...". The
+        // descendant set is constant within an iteration, so it is collected once and walked here as
+        // a flat list rather than re-traversing the tree every row.
         FacesContext context = getFacesContext();
-        // The saved-state map is invariant across this walk; fetch it once and thread it
-        // through the recursion instead of re-querying the state helper at every node.
-        @SuppressWarnings("unchecked")
-        Map<String, SavedState> saved = (Map<String, SavedState>) getStateHelper().get(PropertyKeys.saved);
-        if (getChildCount() > 0) {
-            for (UIComponent kid : getChildren()) {
-                if (kid instanceof UIColumn) {
-                    restoreDescendantState(kid, context, saved);
-                }
+        ensureIterationLists();
+        for (UIComponent component : iterationResetList) {
+            component.setId(component.getId()); // forces the cached clientId to be recomputed
+        }
+        if (!iterationStatefulList.isEmpty()) {
+            // The saved-state map is invariant across this walk; fetch it once.
+            @SuppressWarnings("unchecked")
+            Map<String, SavedState> saved = (Map<String, SavedState>) getStateHelper().get(PropertyKeys.saved);
+            for (UIComponent component : iterationStatefulList) {
+                restoreDescendantState(component, context, saved);
             }
         }
 
@@ -2198,10 +2199,8 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
      */
     private void restoreDescendantState(UIComponent component, FacesContext context, Map<String, SavedState> saved) {
 
-        // Reset the client identifier for this component
-        String id = component.getId();
-        component.setId(id); // Forces client id to be reset
-        // Restore state for this component (if it is a EditableValueHolder)
+        // The clientId reset happens in the caller's iterationResetList walk; here we only restore
+        // the per-row transient state of a single stateful descendant.
         if (component instanceof EditableValueHolder) {
             EditableValueHolder input = (EditableValueHolder) component;
             String clientId = component.getClientId(context);
@@ -2229,20 +2228,6 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
             }
         }
 
-        // Restore state for children of this component
-        if (component.getChildCount() > 0) {
-            for (UIComponent kid : component.getChildren()) {
-                restoreDescendantState(kid, context, saved);
-            }
-        }
-
-        // Restore state for facets of this component
-        if (component.getFacetCount() > 0) {
-            for (UIComponent facet : component.getFacets().values()) {
-                restoreDescendantState(facet, context, saved);
-            }
-        }
-
     }
 
     /**
@@ -2251,71 +2236,57 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
      * </p>
      */
     private void saveDescendantState() {
-
-        // Skip the per-row tree walk entirely if no descendants need per-row state. This is
-        // the common case for read-only tables (e.g. all-output-text columns).
-        if (!hasStatefulDescendants()) {
+        ensureIterationLists();
+        if (iterationStatefulList.isEmpty()) {
+            // Read-only table (e.g. all-output-text columns): nothing to save.
             return;
         }
-
         FacesContext context = getFacesContext();
-        if (getChildCount() > 0) {
-            for (UIComponent kid : getChildren()) {
-                if (kid instanceof UIColumn) {
-                    saveDescendantState(kid, context);
-                }
-            }
+        for (UIComponent component : iterationStatefulList) {
+            saveDescendantState(component, context);
         }
-
     }
 
     /**
-     * Returns whether any descendant under this table's UIColumn children is an
-     * {@link EditableValueHolder} or {@link UIForm} -- i.e. whether per-row state save/restore
-     * has anything to do at all. Computed lazily and cached for the duration of the current
-     * iteration (cleared on {@code setRowIndex(-1)}). Read-only tables short-circuit to {@code false}.
+     * Collects, once per iteration, the descendants the per-row save/restore walks act on, so those
+     * walks become flat-list iterations instead of recursive tree traversals re-done every row.
+     * {@code iterationResetList} is every descendant under the table's {@link UIColumn} children
+     * (each needs its cached clientId reset per row); {@code iterationStatefulList} is the
+     * {@link EditableValueHolder}/{@link UIForm} subset carrying per-row state. Cleared on
+     * {@code setRowIndex(-1)} so the next iteration re-evaluates the tree shape.
      */
-    private boolean hasStatefulDescendants() {
-        Boolean cached = hasStatefulDescendants;
-        if (cached != null) {
-            return cached;
+    private void ensureIterationLists() {
+        if (iterationResetList != null) {
+            return;
         }
-        boolean result = scanForStatefulDescendants();
-        hasStatefulDescendants = result;
-        return result;
-    }
-
-    private boolean scanForStatefulDescendants() {
-        if (getChildCount() == 0) {
-            return false;
-        }
-        for (UIComponent kid : getChildren()) {
-            if (kid instanceof UIColumn && subtreeHasStatefulDescendant(kid)) {
-                return true;
+        List<UIComponent> reset = new ArrayList<>();
+        List<UIComponent> stateful = new ArrayList<>();
+        if (getChildCount() > 0) {
+            for (UIComponent kid : getChildren()) {
+                if (kid instanceof UIColumn) {
+                    collectIterationState(kid, reset, stateful);
+                }
             }
         }
-        return false;
+        iterationResetList = reset;
+        iterationStatefulList = stateful;
     }
 
-    private boolean subtreeHasStatefulDescendant(UIComponent component) {
+    private void collectIterationState(UIComponent component, List<UIComponent> reset, List<UIComponent> stateful) {
+        reset.add(component);
         if (component instanceof EditableValueHolder || component instanceof UIForm) {
-            return true;
+            stateful.add(component);
         }
         if (component.getChildCount() > 0) {
             for (UIComponent kid : component.getChildren()) {
-                if (subtreeHasStatefulDescendant(kid)) {
-                    return true;
-                }
+                collectIterationState(kid, reset, stateful);
             }
         }
         if (component.getFacetCount() > 0) {
             for (UIComponent facet : component.getFacets().values()) {
-                if (subtreeHasStatefulDescendant(facet)) {
-                    return true;
-                }
+                collectIterationState(facet, reset, stateful);
             }
         }
-        return false;
     }
 
     /**
@@ -2370,20 +2341,6 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
                 getStateHelper().put(PropertyKeys.saved, clientId, state);
             } else if (saved != null) {
                 getStateHelper().remove(PropertyKeys.saved, clientId);
-            }
-        }
-
-        // Save state for children of this component
-        if (component.getChildCount() > 0) {
-            for (UIComponent uiComponent : component.getChildren()) {
-                saveDescendantState(uiComponent, context);
-            }
-        }
-
-        // Save state for facets of this component
-        if (component.getFacetCount() > 0) {
-            for (UIComponent facet : component.getFacets().values()) {
-                saveDescendantState(facet, context);
             }
         }
 

--- a/impl/src/test/java/com/sun/faces/perf/ComponentTreePerfHarness.java
+++ b/impl/src/test/java/com/sun/faces/perf/ComponentTreePerfHarness.java
@@ -106,6 +106,9 @@ public class ComponentTreePerfHarness extends JUnitFacesTestCaseBase {
         renderKit.addRenderer(UIData.COMPONENT_FAMILY, "jakarta.faces.Table", new NoOpRenderer());
         // UIColumn has no rendererType by default; nothing to register for it.
         facesContext.getApplication(); // ensure Application is initialized
+        // Force the id-uniqueness check to run so the walk benchmark below measures the walk,
+        // not the default "auto" Production skip.
+        servletContext.addInitParameter("com.sun.faces.disableIdUniquenessCheck", "false");
         com.sun.faces.mock.MockRenderKitFactory rkf = (com.sun.faces.mock.MockRenderKitFactory) jakarta.faces.FactoryFinder
                 .getFactory(jakarta.faces.FactoryFinder.RENDER_KIT_FACTORY);
         try {


### PR DESCRIPTION
Backport of #5759 to 4.0 — the request-pipeline performance optimizations, **impl only** (the `test/perf` multi-server infrastructure is intentionally not backported). Java 11-clean (4.0 targets 11).

Cherry-picked impl commits:
- Resolve attributes map lazily in `AttributesMap.get` + `setAccessible` on cached property getters
- Skip the id-uniqueness check in `Production` by default
- Use indexed child traversal in `process*`/`encodeAll`
- Reduce `publishEvent` overhead in the no-listener case
- Cache the NamingContainer-ancestor lookup
- Precollect UIData/UIRepeat descendants for per-row state save/restore
- Coalesce render output before the container writer (at `getResponseOutputWriter()`)

See #5759 for rationale, six-server benchmarks, and TCK validation.

### Behavior change to note
The duplicate-id check is skipped in `Production` stage by default (`com.sun.faces.disableIdUniquenessCheck` tri-state `true|false|auto`, default `auto`); set it to `false` to restore the always-on check.

### Validation
- Builds on JDK 11.
- impl unit tests pass.

🤖 Generated with Claude Opus 4.8
