### PR TITLE
Fix slow RESTORE_VIEW: replace the descendant-mark-id cache with a refresh-gated direct scan — 4.0 backport

### DIFF
--- a/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
+++ b/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
@@ -770,7 +770,7 @@ public class WebConfiguration {
         ResourceUpdateCheckPeriod("com.sun.faces.resourceUpdateCheckPeriod", "5"), // in minutes
         CompressableMimeTypes("com.sun.faces.compressableMimeTypes", ""),
         DisableUnicodeEscaping("com.sun.faces.disableUnicodeEscaping", "auto"),
-        DisableIdUniquenessCheck("com.sun.faces.disableIdUniquenessCheck", "auto"), // true|false|auto; auto skips the check in Production
+        DisableIdUniquenessCheck("com.sun.faces.disableIdUniquenessCheck", "false"), // true|false|auto; default false (always check), opt-in auto skips it in Production
         FaceletsDefaultRefreshPeriod(ViewHandler.FACELETS_REFRESH_PERIOD_PARAM_NAME, "2"),
         FaceletsViewMappings(ViewHandler.FACELETS_VIEW_MAPPINGS_PARAM_NAME, ""),
         FaceletsLibraries(ViewHandler.FACELETS_LIBRARIES_PARAM_NAME, ""),

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentSupport.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentSupport.java
@@ -55,7 +55,15 @@ public final class ComponentSupport {
 
     private final static String MARK_DELETED = "com.sun.faces.facelets.MARK_DELETED";
     public final static String MARK_CREATED = "com.sun.faces.facelets.MARK_ID";
-    private final static String MARK_ID_CACHE = "com.sun.faces.facelets.MARK_ID_CACHE";
+
+    /**
+     * FacesContext-scoped flag set by {@code ComponentTagHandlerDelegateImpl} while applying the children of a
+     * freshly created component. When set, {@link #findChildByTagId} skips its scan: a freshly built subtree has
+     * no pre-existing children to reuse, so searching it is pure waste (the source of the O(n^2) refresh on wide
+     * views). The scan stays active for existing/reused parents -- binding-supplied or refreshed subtrees -- which
+     * is what keeps component-binding reuse (#4128/#4146) correct.
+     */
+    public final static String BUILDING_FRESH_SUBTREE = "com.sun.faces.facelets.BUILDING_FRESH_SUBTREE";
 
     // Expando boolean attribute used to identify parent components that have had
     // a dynamic child addition or removal.
@@ -204,15 +212,12 @@ public final class ComponentSupport {
     // never be in the tree at this point, so we can return null and skip iterating.
 
     public static UIComponent findUIInstructionChildByTagId(FacesContext context, UIComponent parent, String id) {
-        UIComponent result = null;
-        if (isBuildingNewComponentTree(context)) {
+        if (isBuildingNewComponentTree(context) || !isPartialStateSaving(context)) {
             return null;
         }
-        if (isPartialStateSaving(context)) {
-            result = getDescendantMarkIdCache(parent).get(id);
-        }
-
-        return result;
+        // The existing UIInstructions is a direct child of the parent it was applied under, so the bounded
+        // direct scan locates it by its MARK_CREATED tag id without a descendant cache.
+        return findChildByTagIdFullStateSaving(context, parent, id);
     }
 
     private static boolean isPartialStateSaving(FacesContext context) {
@@ -227,20 +232,20 @@ public final class ComponentSupport {
      * @return the UI component
      */
     public static UIComponent findChildByTagId(FacesContext context, UIComponent parent, String id) {
-        if (isPartialStateSaving(context)) {
-            // fast path - get the child from the descendant mark id cache
-            return getDescendantMarkIdCache(parent).get(id);
+        // While building a freshly created subtree there is nothing existing to find, so skip the scan entirely
+        // (this is the refresh-gate that keeps wide fresh builds O(n) instead of O(n^2)). For existing/reused
+        // parents the flag is unset/false and the bounded direct scan runs: the component is a direct child of
+        // the parent it is applied under, so no descendant cache or whole-subtree recursion is needed. Composite
+        // children relocated by cc:insertChildren are resolved separately via findReparentedComponent ->
+        // findChildByTagIdDeep, which bypasses this gate.
+        if (context.getAttributes().get(BUILDING_FRESH_SUBTREE) == Boolean.TRUE) {
+            return null;
         }
-        else {
-            // original impl - traverse the tree
-            return findChildByTagIdFullStateSaving(context, parent, id);
-        }
+        return findChildByTagIdFullStateSaving(context, parent, id);
     }
 
     private static UIComponent findChildByTagIdFullStateSaving(FacesContext context, UIComponent parent, String id) {
         UIComponent c = null;
-        UIViewRoot root = context.getViewRoot();
-        boolean hasDynamicComponents = (null != root && root.getAttributes().containsKey(RIConstants.TREE_HAS_DYNAMIC_COMPONENTS));
         String cid = null;
         List<UIComponent> components;
         String facetName = getFacetName(parent);
@@ -279,115 +284,40 @@ public final class ComponentSupport {
                     }
                 }
             }
-            if (hasDynamicComponents) {
-                /*
-                 * Make sure we look for the child recursively it might have moved
-                 * into a different parent in the parent hierarchy. Note currently
-                 * we are only looking down the tree. Maybe it would be better
-                 * to use the VisitTree API instead.
-                 */
-                UIComponent foundChild = findChildByTagId(context, c, id);
-                if (foundChild != null) {
-                    return foundChild;
-                }
-            }
         }
 
         return null;
     }
 
-    @SuppressWarnings("unchecked")
-    private static Map<String, UIComponent> getDescendantMarkIdCache(UIComponent component) {
-        Map<String, UIComponent> descendantMarkIdCache = (Map<String, UIComponent>) component.getTransientStateHelper().getTransient(MARK_ID_CACHE);
-
-        if (descendantMarkIdCache == null) {
-            descendantMarkIdCache = new HashMap<String, UIComponent>();
-            component.getTransientStateHelper().putTransient(MARK_ID_CACHE, descendantMarkIdCache);
-        }
-
-        return descendantMarkIdCache;
-    }
-
     /**
-     * Adds the mark id of the specified {@link UIComponent} <code>otherComponent</code> to the mark id cache of this component,
-     * including all its descendant mark ids. Changes are propagated up the component tree.
+     * Deep variant of {@link #findChildByTagId} that descends through intermediate containers. Used only to
+     * locate composite-component children relocated by {@code cc:insertChildren}, which may sit several
+     * container levels below the composite implementation facet (e.g. wrapped in an {@code h:panelGroup}).
+     * The hot postback-refresh path uses the bounded {@link #findChildByTagId} direct scan; this deep search
+     * is confined to the (small) composite implementation subtree, off that path.
      */
-    public static void addToDescendantMarkIdCache(UIComponent component, UIComponent otherComponent) {
-        String markId = (String) otherComponent.getAttributes().get(MARK_CREATED);
-        if (markId != null) {
-            addSingleDescendantMarkId(component, markId, otherComponent);
+    public static UIComponent findChildByTagIdDeep(FacesContext context, UIComponent parent, String id) {
+        // Raw scan (not findChildByTagId): the reparent path must search even inside a freshly built composite,
+        // so it deliberately bypasses the BUILDING_FRESH_SUBTREE gate.
+        UIComponent c = findChildByTagIdFullStateSaving(context, parent, id);
+        if (c != null) {
+            return c;
         }
-        Map<String, UIComponent> otherMarkIds = getDescendantMarkIdCache(otherComponent);
-        if (!otherMarkIds.isEmpty()) {
-            addAllDescendantMarkIds(component, otherMarkIds);
+        if (parent.getFacetCount() > 0) {
+            for (UIComponent facet : parent.getFacets().values()) {
+                c = findChildByTagIdDeep(context, facet, id);
+                if (c != null) {
+                    return c;
+                }
+            }
         }
-    }
-
-    /**
-     * Adds the specified <code>markId</code> and its corresponding {@link UIComponent} <code>otherComponent</code>
-     * to the mark id cache of this component. Changes are propagated up the component tree.
-     */
-    private static void addSingleDescendantMarkId(UIComponent component, String markId, UIComponent otherComponent) {
-        getDescendantMarkIdCache(component).put(markId, otherComponent);
-        UIComponent parent = component.getParent();
-        if (parent != null) {
-            addSingleDescendantMarkId(parent, markId, otherComponent);
+        for (UIComponent child : parent.getChildren()) {
+            c = findChildByTagIdDeep(context, child, id);
+            if (c != null) {
+                return c;
+            }
         }
-    }
-
-    /**
-     * Adds all specified <code>otherMarkIds</code> to the mark id cache of this component.
-     * Changes are propagated up the component tree.
-     */
-    private static void addAllDescendantMarkIds(UIComponent component, Map<String, UIComponent> otherMarkIds) {
-        getDescendantMarkIdCache(component).putAll(otherMarkIds);
-        UIComponent parent = component.getParent();
-        if (parent != null) {
-            addAllDescendantMarkIds(parent, otherMarkIds);
-        }
-    }
-
-    /**
-     * Removes the mark id of the specified {@link UIComponent} <code>otherComponent</code> from the mark id cache of this component,
-     * including all its descendant mark ids. Changes are propagated up the component tree.
-     */
-    public static void removeFromDescendantMarkIdCache(UIComponent component, UIComponent otherComponent) {
-        String markId = (String) otherComponent.getAttributes().get(MARK_CREATED);
-        if (markId != null) {
-            removeSingleDescendantMarkId(component, markId);
-        }
-        Map<String, UIComponent> otherMarkIds = getDescendantMarkIdCache(otherComponent);
-        if (!otherMarkIds.isEmpty()) {
-            removeAllDescendantMarkIds(component, otherMarkIds);
-        }
-    }
-
-    /**
-     * Removes the specified <code>markId</code> from the mark id cache of this component.
-     * Changes are propagated up the component tree.
-     */
-    private static void removeSingleDescendantMarkId(UIComponent component, String markId) {
-        getDescendantMarkIdCache(component).remove(markId);
-        UIComponent parent = component.getParent();
-        if (parent != null) {
-            removeSingleDescendantMarkId(parent, markId);
-        }
-    }
-
-    /**
-     * Removes all specified <code>otherMarkIds</code> from the mark id cache of this component.
-     * Changes are propagated up the component tree.
-     */
-    private static void removeAllDescendantMarkIds(UIComponent component, Map<String, UIComponent> otherMarkIds) {
-        Map<String, UIComponent> descendantMarkIdCache = getDescendantMarkIdCache(component);
-        Iterator<String> iterator = otherMarkIds.keySet().iterator();
-        while (iterator.hasNext()) {
-            descendantMarkIdCache.remove(iterator.next());
-        }
-        UIComponent parent = component.getParent();
-        if (parent != null) {
-            removeAllDescendantMarkIds(parent, otherMarkIds);
-        }
+        return null;
     }
 
     /**

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -172,10 +173,23 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
             isNaming = true;
             IterationIdManager.startNamingContainer(ctx);
         }
+
+        // Refresh-gate (see ComponentSupport.BUILDING_FRESH_SUBTREE): a freshly created component with no
+        // children yet begins an all-new subtree, so its descendants have nothing existing to reuse and
+        // findChildByTagId can skip scanning. A found or binding-supplied component (which arrives with its
+        // children already attached) may contain components to reuse, so the scan stays active for its subtree.
+        boolean freshSubtree = !componentFound && c.getChildCount() == 0;
+        Map<Object, Object> contextAttributes = context.getAttributes();
+        Object previousFreshSubtree = contextAttributes.put(ComponentSupport.BUILDING_FRESH_SUBTREE, freshSubtree);
         try {
             // first allow c to get populated
             owner.applyNextHandler(ctx, c);
         } finally {
+            if (previousFreshSubtree != null) {
+                contextAttributes.put(ComponentSupport.BUILDING_FRESH_SUBTREE, previousFreshSubtree);
+            } else {
+                contextAttributes.remove(ComponentSupport.BUILDING_FRESH_SUBTREE);
+            }
             if (isNaming) {
                 IterationIdManager.stopNamingContainer(ctx);
             }
@@ -462,7 +476,8 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
     protected UIComponent findReparentedComponent(FaceletContext ctx, UIComponent parent, String tagId) {
         UIComponent facet = parent.getFacets().get(UIComponent.COMPOSITE_FACET_NAME);
         if (facet != null) {
-            return findChild(ctx, facet, tagId);
+            // Relocated children may sit below intermediate containers in the implementation, so search deep.
+            return ComponentSupport.findChildByTagIdDeep(ctx.getFacesContext(), facet, tagId);
         }
         return null;
     }

--- a/impl/src/main/java/com/sun/faces/util/Util.java
+++ b/impl/src/main/java/com/sun/faces/util/Util.java
@@ -1173,9 +1173,9 @@ public class Util {
         }
     }
 
-    // com.sun.faces.disableIdUniquenessCheck is true|false|auto (default auto). auto skips the check
-    // in Production only, mirroring MyFaces' CHECK_ID_PRODUCTION_MODE default; a duplicate-id bug would
-    // already have surfaced in Development, so the per-build tree walk buys nothing in Production.
+    // com.sun.faces.disableIdUniquenessCheck is true|false|auto (default false: always run the check).
+    // Opt-in auto skips the whole-tree duplicate-id walk in Production only (a duplicate id would already
+    // have surfaced in Development). The default keeps the check on; the skip stays opt-in.
     private static boolean isIdUniquenessCheckDisabled(FacesContext context) {
         String value = WebConfiguration.getInstance(context.getExternalContext())
                 .getOptionValue(WebConfiguration.WebContextInitParameter.DisableIdUniquenessCheck);

--- a/impl/src/main/java/jakarta/faces/component/ComponentStateHelper.java
+++ b/impl/src/main/java/jakarta/faces/component/ComponentStateHelper.java
@@ -16,8 +16,6 @@
 
 package jakarta.faces.component;
 
-import static com.sun.faces.facelets.tag.faces.ComponentSupport.MARK_CREATED;
-import static com.sun.faces.facelets.tag.faces.ComponentSupport.addToDescendantMarkIdCache;
 import static jakarta.faces.component.UIComponentBase.restoreAttachedState;
 import static jakarta.faces.component.UIComponentBase.saveAttachedState;
 
@@ -30,7 +28,6 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import jakarta.el.ValueExpression;
-import jakarta.faces.component.UIComponent.PropertyKeys;
 import jakarta.faces.context.FacesContext;
 
 /**
@@ -128,16 +125,6 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
     @Override
     public Object put(Serializable key, String mapKey, Object value) {
         initMap(key);
-
-        if (MARK_CREATED.equals(mapKey)) {
-            if (PropertyKeys.attributes.equals(key)) {
-                UIComponent parent = component.getParent();
-                if (parent != null) {
-                    // remember this component by its mark id
-                    addToDescendantMarkIdCache(parent, component);
-                }
-            }
-        }
 
         Object ret = null;
         if (component.initialStateMarked()) {

--- a/impl/src/main/java/jakarta/faces/component/UIComponent.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponent.java
@@ -1448,7 +1448,17 @@ public abstract class UIComponent implements PartialStateHolder, TransientStateH
 
     @SuppressWarnings("unchecked")
     private static ArrayDeque<UIComponent> _getComponentELStack(String keyName, Map<Object, Object> contextAttributes) {
-        return (ArrayDeque<UIComponent>) contextAttributes.computeIfAbsent(keyName, e -> new ArrayDeque<>());
+        // Plain get + lazy put rather than computeIfAbsent: the stack is created once per request and present on
+        // every subsequent push/pop/getCurrentComponent, and this method is one of the hottest paths in the
+        // lifecycle (pushed/popped per component per phase). Avoiding the computeIfAbsent lambda keeps the hot
+        // path a single HashMap.get.
+        @SuppressWarnings("unchecked")
+        ArrayDeque<UIComponent> componentELStack = (ArrayDeque<UIComponent>) contextAttributes.get(keyName);
+        if (componentELStack == null) {
+            componentELStack = new ArrayDeque<>();
+            contextAttributes.put(keyName, componentELStack);
+        }
+        return componentELStack;
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -16,9 +16,6 @@
 
 package jakarta.faces.component;
 
-import static com.sun.faces.facelets.tag.faces.ComponentSupport.addToDescendantMarkIdCache;
-import static com.sun.faces.facelets.tag.faces.ComponentSupport.isNotRenderingResponse;
-import static com.sun.faces.facelets.tag.faces.ComponentSupport.removeFromDescendantMarkIdCache;
 import static com.sun.faces.util.Util.isAllNull;
 import static com.sun.faces.util.Util.isAnyNull;
 import static com.sun.faces.util.Util.isEmpty;
@@ -2319,12 +2316,10 @@ public abstract class UIComponentBase extends UIComponent {
          */
         private static final long serialVersionUID = 8926987612679576963L;
         private UIComponent component;
-        private FacesContext context;
 
         public ChildrenList(UIComponent component) {
             super(6);
             this.component = component;
-            this.context = component.getFacesContext();
         }
 
         @Override
@@ -2334,7 +2329,6 @@ public abstract class UIComponentBase extends UIComponent {
             } else if (index < 0 || index > size()) {
                 throw new IndexOutOfBoundsException();
             } else {
-                addToDescendantMarkIdCache(component, element);
                 eraseParent(element);
                 super.add(index, element);
                 element.setParent(component);
@@ -2347,7 +2341,6 @@ public abstract class UIComponentBase extends UIComponent {
             if (element == null) {
                 throw new NullPointerException();
             } else {
-                addToDescendantMarkIdCache(component, element);
                 eraseParent(element);
                 boolean result = super.add(element);
                 element.setParent(component);
@@ -2395,9 +2388,6 @@ public abstract class UIComponentBase extends UIComponent {
             }
             for (int i = 0; i < n; i++) {
                 UIComponent child = get(i);
-                if (isNotRenderingResponse(context)) {
-                    removeFromDescendantMarkIdCache(component, child);
-                }
                 child.setParent(null);
             }
             super.clear();
@@ -2421,9 +2411,6 @@ public abstract class UIComponentBase extends UIComponent {
         @Override
         public UIComponent remove(int index) {
             UIComponent child = get(index);
-            if (isNotRenderingResponse(context)) {
-                removeFromDescendantMarkIdCache(component, child);
-            }
             child.setParent(null);
             super.remove(index);
             return child;
@@ -2434,9 +2421,6 @@ public abstract class UIComponentBase extends UIComponent {
             UIComponent element = (UIComponent) elementObj;
             if (element == null) {
                 throw new NullPointerException();
-            }
-            if (isNotRenderingResponse(context)) {
-                removeFromDescendantMarkIdCache(component, element);
             }
             if (super.indexOf(element) != -1) {
                 element.setParent(null);
@@ -2479,10 +2463,8 @@ public abstract class UIComponentBase extends UIComponent {
             } else if (index < 0 || index >= size()) {
                 throw new IndexOutOfBoundsException();
             } else {
-                addToDescendantMarkIdCache(component, element);
                 eraseParent(element);
                 UIComponent previous = get(index);
-                removeFromDescendantMarkIdCache(component, previous);
                 super.set(index, element);
                 previous.setParent(null);
                 element.setParent(component);
@@ -2647,12 +2629,10 @@ public abstract class UIComponentBase extends UIComponent {
          */
         private static final long serialVersionUID = -1444791615672259097L;
         private UIComponent component;
-        private FacesContext context;
 
         public FacetsMap(UIComponent component) {
             super(3, 1.0f);
             this.component = component;
-            context = component.getFacesContext();
         }
 
         @Override
@@ -2685,10 +2665,8 @@ public abstract class UIComponentBase extends UIComponent {
             }
             UIComponent previous = super.get(key);
             if (previous != null) {
-                removeFromDescendantMarkIdCache(component, previous);
                 previous.setParent(null);
             }
-            addToDescendantMarkIdCache(component, value);
             eraseParent(value);
             UIComponent result = super.put(key, value);
             value.setParent(component);
@@ -2710,9 +2688,6 @@ public abstract class UIComponentBase extends UIComponent {
         public UIComponent remove(Object key) {
             UIComponent previous = get(key);
             if (previous != null) {
-                if (isNotRenderingResponse(context)) {
-                    removeFromDescendantMarkIdCache(component, previous);
-                }
                 previous.setParent(null);
             }
             super.remove(key);

--- a/test/perf/README.md
+++ b/test/perf/README.md
@@ -110,6 +110,7 @@ Run both sides on the same server profile so the comparison is fair.
 - `composite-readonly` — readonly composite component, 200 instances
 - `composite-inputs` — input composite component, 40 instances
 - `composite-nested` — composite component nested inside ui:repeat (5×10)
+- `composite-heavy` — large *static* tree (`c:forEach` of ~500 small composite components ≈ 3000 components, all NamingContainers) at issue #4811 scale; stresses the Facelets refresh / per-component state+attribute cost on postback
 - `form-inputs-ajax`, `table-inputs-ajax`, `repeat-inputs-ajax` — same as their non-ajax twins but submit via `<f:ajax execute="@form" render="@form messages">`; driver sends a partial-ajax POST and refreshes `ViewState` from the XML response.
 - `viewparam-get` — GET with `<f:metadata><f:viewParam><f:viewAction></f:metadata>` so the GET runs the **entire** lifecycle (Apply Request Values → Render Response), not just Restore View + Render Response.
 

--- a/test/perf/src/main/webapp/composite-heavy.xhtml
+++ b/test/perf/src/main/webapp/composite-heavy.xhtml
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="#{facesContext.viewRoot.locale.language}"
+    xmlns:h="jakarta.faces.html"
+    xmlns:c="jakarta.tags.core"
+    xmlns:cc="jakarta.faces.composite/cc"
+>
+    <h:head>
+        <title>composite-heavy</title>
+    </h:head>
+    <h:body>
+        Large static tree of composite components (issue #4811 scale).
+
+        <h:form id="form">
+            <!-- c:forEach unrolls at build time, so each iteration is a DISTINCT composite subtree;
+                 ~1000 cells x ~6 components = ~6000 static components, all NamingContainers. -->
+            <c:forEach var="i" begin="1" end="500">
+                <cc:cell value="#{i}"/>
+            </c:forEach>
+            <h:commandButton id="submit" value="Submit" />
+        </h:form>
+    </h:body>
+</html>

--- a/test/perf/src/main/webapp/resources/cc/cell.xhtml
+++ b/test/perf/src/main/webapp/resources/cc/cell.xhtml
@@ -1,0 +1,34 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<ui:component
+    xmlns:h="jakarta.faces.html"
+    xmlns:ui="jakarta.faces.facelets"
+    xmlns:cc="jakarta.faces.composite"
+>
+    <cc:interface>
+        <cc:attribute name="value"/>
+    </cc:interface>
+
+    <cc:implementation>
+        <h:panelGroup layout="block">
+            <h:outputText value="#{cc.attrs.value}-a"/>
+            <h:outputText value="#{cc.attrs.value}-b"/>
+            <h:outputText value="#{cc.attrs.value}-c"/>
+        </h:panelGroup>
+    </cc:implementation>
+</ui:component>

--- a/test/perf/src/test/java/org/eclipse/mojarra/test/perf/PerfBenchIT.java
+++ b/test/perf/src/test/java/org/eclipse/mojarra/test/perf/PerfBenchIT.java
@@ -138,6 +138,7 @@ class PerfBenchIT extends BaseIT {
             "repeat-nested",
             "composite-inputs",
             "composite-nested",
+            "composite-heavy",
             "table-inputs-heavy",
             "repeat-inputs-heavy"));
 


### PR DESCRIPTION
Backport of #5761 to 4.0 — the slow-`RESTORE_VIEW` fix. Java 11-clean (4.0 targets 11).

Cherry-picked commits:
- Replace the descendant-mark-id cache with a refresh-gated direct scan in Facelets refresh
- Resolve the component EL stack with `get` + lazy `put` instead of `computeIfAbsent`
- Default `com.sun.faces.disableIdUniquenessCheck` to `false` instead of `auto`
- Add the `composite-heavy` perf scenario (issue #4811 scale) — the one `test/perf` addition, a self-contained scenario (`test/perf` already exists on 4.0)

### Conflict resolution
One adjacent-line conflict in `WebConfiguration`: took the intended `disableIdUniquenessCheck` `auto`→`false` change and kept 4.0's `FaceletsDefaultRefreshPeriod` default of `2`. The `2`→`0` on 4.1 is a pre-existing 4.1-only divergence unrelated to #5761 (none of the four commits touch it). The other three commits are byte-identical to their 4.1 sources (verified by patch-id).

### Behavior change to note
Following #5761, `com.sun.faces.disableIdUniquenessCheck` now defaults to `false` (always run the duplicate-id check). This reverses the `auto` default that #5759 / #5760 introduced on 4.0. Opt into the Production skip with `auto` or `true`.

### Validation
- Builds on JDK 11.
- impl unit tests: 1078 run, 0 failures, 0 errors, 4 skipped.

See #5761 for rationale and the six-server benchmarks.

🤖 Generated with Claude Opus 4.8
