### PR TITLE
Reduce RESTORE_VIEW overhead: dynamic-add gate, field-backed Facelets markers, ancestor memoization

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategy.java
@@ -341,6 +341,11 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
         if (state != null) {
             try {
                 stateContext.setTrackViewModifications(false);
+                // No saved dynamic actions => no component carries DYNAMIC_COMPONENT, so the per-component
+                // marker lookup in componentAddedDynamically can be skipped across the whole restore traversal.
+                @SuppressWarnings("unchecked")
+                List<Object> savedActions = (List<Object>) state.get(DYNAMIC_ACTIONS);
+                stateContext.setHasDynamicComponents(!isEmpty(savedActions));
 
                 VisitContext visitContext = VisitContext.createVisitContext(context, null, SKIP_ITERATION_AND_EXECUTE_LIFECYCLE_HINTS);
                 viewRoot.visitTree(visitContext, (context1, target) -> {
@@ -366,6 +371,7 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
                 });
                 restoreDynamicActions(context, stateContext, state);
             } finally {
+                stateContext.setHasDynamicComponents(true);
                 stateContext.setTrackViewModifications(true);
             }
         } else {

--- a/impl/src/main/java/com/sun/faces/context/StateContext.java
+++ b/impl/src/main/java/com/sun/faces/context/StateContext.java
@@ -62,6 +62,10 @@ public class StateContext {
     private boolean partial;
     private boolean partialLocked;
     private boolean trackMods = true;
+    // A view whose saved state carries no dynamic add/remove actions has no component bearing the
+    // DYNAMIC_COMPONENT marker, so componentAddedDynamically can skip the per-component attribute
+    // lookup. The partial-state restore sets this false for such views; true (always check) otherwise.
+    private boolean hasDynamicComponents = true;
     private AddRemoveListener modListener;
     private ApplicationStateInfo stateInfo;
     private WeakReference<UIViewRoot> viewRootRef = new WeakReference<>(null);
@@ -192,7 +196,19 @@ public class StateContext {
      * @return <code>true</code> if the component was added after the initial view construction
      */
     public boolean componentAddedDynamically(UIComponent c) {
-        return c.getAttributes().containsKey(DYNAMIC_COMPONENT);
+        return hasDynamicComponents && c.getAttributes().containsKey(DYNAMIC_COMPONENT);
+    }
+
+    /**
+     * Hint from the state-management strategy: when a restored view's saved state carries no dynamic
+     * add/remove actions, no component can bear the {@code DYNAMIC_COMPONENT} marker, so
+     * {@link #componentAddedDynamically} skips the per-component attribute lookup. Defaults to
+     * {@code true} (always check) for every other call path.
+     *
+     * @param hasDynamicComponents whether the current view may contain dynamically added/removed components
+     */
+    public void setHasDynamicComponents(boolean hasDynamicComponents) {
+        this.hasDynamicComponents = hasDynamicComponents;
     }
 
     public int getIndexOfDynamicallyAddedChildInParent(UIComponent c) {

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentSupport.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentSupport.java
@@ -55,7 +55,7 @@ import jakarta.faces.view.facelets.TagAttributeException;
  */
 public final class ComponentSupport {
 
-    private final static String MARK_DELETED = "com.sun.faces.facelets.MARK_DELETED";
+    public final static String MARK_DELETED = "com.sun.faces.facelets.MARK_DELETED";
     public final static String MARK_CREATED = "com.sun.faces.facelets.MARK_ID";
 
     /**

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
@@ -396,20 +396,19 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
         if (this.id != null && !(this.id.isLiteral() && IterationIdManager.registerLiteralId(ctx, this.id.getValue()))) {
             c.setId(this.id.getValue(ctx));
         } else {
-            UIViewRoot root = ComponentSupport.getViewRoot(ctx, parent);
-            if (root != null) {
-                String uid;
-                IdMapper mapper = IdMapper.getMapper(ctx.getFacesContext());
-                String mid = mapper != null ? mapper.getAliasedId(id) : id;
-                UIComponent ancestorNamingContainer = parent.getNamingContainer();
-                if (null != ancestorNamingContainer && ancestorNamingContainer instanceof UniqueIdVendor) {
-                    uid = ((UniqueIdVendor) ancestorNamingContainer).createUniqueId(ctx.getFacesContext(), mid);
-                } else {
-                    uid = root.createUniqueId(ctx.getFacesContext(), mid);
+            IdMapper mapper = IdMapper.getMapper(ctx.getFacesContext());
+            String mid = mapper != null ? mapper.getAliasedId(id) : id;
+            UIComponent ancestorNamingContainer = parent.getNamingContainer();
+            if (ancestorNamingContainer instanceof UniqueIdVendor) {
+                c.setId(((UniqueIdVendor) ancestorNamingContainer).createUniqueId(ctx.getFacesContext(), mid));
+            } else {
+                // No UniqueIdVendor ancestor: fall back to the view root. getViewRoot walks the parent chain,
+                // so resolve it only on this branch instead of unconditionally for every component.
+                UIViewRoot root = ComponentSupport.getViewRoot(ctx, parent);
+                if (root != null) {
+                    c.setId(root.createUniqueId(ctx.getFacesContext(), mid));
                 }
-                c.setId(uid);
             }
-
         }
 
         if (rendererType != null) {

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -3386,7 +3386,19 @@ public abstract class UIComponentBase extends UIComponent {
             return namingContainerAncestor;
         }
 
-        for (UIComponent ancestor = getParent(); ancestor != null; ancestor = ancestor.getParent()) {
+        // Resolve via the parent's (memoized) ancestor rather than walking the whole chain: each level is
+        // cached, so building/visiting the tree is O(n) instead of an O(depth) walk per component. The value
+        // is identical to the walk, with the same invalidation point (setParent clears the field).
+        UIComponent parent = getParent();
+        if (parent instanceof NamingContainer) {
+            return namingContainerAncestor = parent;
+        }
+        if (parent instanceof UIComponentBase) {
+            return namingContainerAncestor = ((UIComponentBase) parent).getNamingContainerAncestor();
+        }
+
+        // Rare: a non-UIComponentBase parent has no memoized ancestor, so fall back to the chain walk.
+        for (UIComponent ancestor = parent; ancestor != null; ancestor = ancestor.getParent()) {
             if (ancestor instanceof NamingContainer) {
                 return namingContainerAncestor = ancestor;
             }

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -17,6 +17,12 @@
 
 package jakarta.faces.component;
 
+import static com.sun.faces.facelets.tag.faces.ComponentSupport.MARK_CHILDREN_MODIFIED;
+import static com.sun.faces.facelets.tag.faces.ComponentSupport.MARK_CREATED;
+import static com.sun.faces.facelets.tag.faces.ComponentSupport.MARK_DELETED;
+import static com.sun.faces.facelets.tag.faces.ComponentSupport.REMOVED_CHILDREN;
+import static com.sun.faces.RIConstants.DYNAMIC_COMPONENT;
+import static com.sun.faces.facelets.tag.faces.core.FacetHandler.KEY;
 import static com.sun.faces.util.Util.isAllNull;
 import static com.sun.faces.util.Util.isAnyNull;
 import static com.sun.faces.util.Util.isEmpty;
@@ -137,6 +143,17 @@ public abstract class UIComponentBase extends UIComponent {
      * </p>
      */
     private AttributesMap attributes;
+
+    // Facelets framework markers, read per component on every Facelets refresh (findChildByTagId, deletion
+    // marking, facet-name and child-modified checks). Cached on fields so AttributesMap.get/containsKey skip
+    // the per-read state-map lookup; writes still flow through the attributes map (AttributesMap.put/remove),
+    // so saved/restored state is unchanged. See markerGet/markerContains/markerPut/markerRemove.
+    private String markCreated;            // ComponentSupport.MARK_CREATED (tag id)
+    private String facetName;              // FacetHandler.KEY
+    private Object removedChildren;        // ComponentSupport.REMOVED_CHILDREN (Collection)
+    private Object dynamicComponent;       // RIConstants.DYNAMIC_COMPONENT (Integer index)
+    private boolean markDeleted;           // ComponentSupport.MARK_DELETED
+    private boolean markChildrenModified;  // ComponentSupport.MARK_CHILDREN_MODIFIED
 
     /**
      * <p>
@@ -1295,6 +1312,9 @@ public abstract class UIComponentBase extends UIComponent {
             if (values[5] != null) {
                 id = (String) values[5];
             }
+            // Full-state restore does not re-run buildView, so sync the field-backed markers from the
+            // restored attributes map (partial-state restore re-establishes them via buildView).
+            restoreMarkersFromState();
         }
 
         // StateHelper.restoreState may rewrite rendererType without going through
@@ -1569,6 +1589,88 @@ public abstract class UIComponentBase extends UIComponent {
 
     Map<String, PropertyDescriptor> getDescriptorMap() {
         return propertyDescriptorMap;
+    }
+
+    // ---- Field-backed Facelets markers (authoritative cache for AttributesMap) ----
+    // The marker fields are the single source of truth: AttributesMap.put/remove keep them in sync, and
+    // AttributesMap.get/containsKey read them WITHOUT touching the state map -- so the per-component
+    // "is this deleted / a facet / dynamically added?" checks during Facelets refresh (which are almost
+    // always negative on a stable tree) are field reads, not HashMap lookups. Partial-state restore (the
+    // default) is self-correcting: fresh component instances start absent and buildView re-puts the present
+    // markers. Full-state restore deserializes without buildView, so it repopulates the fields from the
+    // restored attributes map (see restoreMarkersFromState). markerGet returns NOT_MARKER for non-marker
+    // keys, telling AttributesMap to fall through to its normal property/attribute resolution.
+
+    private static final Object NOT_MARKER = new Object();
+
+    private Object markerGet(Object key) {
+        if (MARK_CREATED.equals(key)) {
+            return markCreated;
+        }
+        if (KEY.equals(key)) {
+            return facetName;
+        }
+        if (REMOVED_CHILDREN.equals(key)) {
+            return removedChildren;
+        }
+        if (DYNAMIC_COMPONENT.equals(key)) {
+            return dynamicComponent;
+        }
+        if (MARK_DELETED.equals(key)) {
+            return markDeleted ? Boolean.TRUE : null;
+        }
+        if (MARK_CHILDREN_MODIFIED.equals(key)) {
+            return markChildrenModified ? Boolean.TRUE : null;
+        }
+        return NOT_MARKER;
+    }
+
+    private void markerPut(Object key, Object value) {
+        if (MARK_CREATED.equals(key)) {
+            markCreated = (String) value;
+        } else if (KEY.equals(key)) {
+            facetName = (String) value;
+        } else if (REMOVED_CHILDREN.equals(key)) {
+            removedChildren = value;
+        } else if (DYNAMIC_COMPONENT.equals(key)) {
+            dynamicComponent = value;
+        } else if (MARK_DELETED.equals(key)) {
+            markDeleted = Boolean.TRUE.equals(value);
+        } else if (MARK_CHILDREN_MODIFIED.equals(key)) {
+            markChildrenModified = Boolean.TRUE.equals(value);
+        }
+    }
+
+    private void markerRemove(Object key) {
+        if (MARK_CREATED.equals(key)) {
+            markCreated = null;
+        } else if (KEY.equals(key)) {
+            facetName = null;
+        } else if (REMOVED_CHILDREN.equals(key)) {
+            removedChildren = null;
+        } else if (DYNAMIC_COMPONENT.equals(key)) {
+            dynamicComponent = null;
+        } else if (MARK_DELETED.equals(key)) {
+            markDeleted = false;
+        } else if (MARK_CHILDREN_MODIFIED.equals(key)) {
+            markChildrenModified = false;
+        }
+    }
+
+    // Full-state restore deserializes the tree without re-running buildView, so the marker fields are synced
+    // from the restored attributes map here. Partial-state restore re-puts them via buildView instead.
+    @SuppressWarnings("unchecked")
+    private void restoreMarkersFromState() {
+        Map<String, Object> attrs = (Map<String, Object>) getStateHelper().get(PropertyKeys.attributes);
+        if (attrs == null || attrs.isEmpty()) {
+            return;
+        }
+        markCreated = (String) attrs.get(MARK_CREATED);
+        facetName = (String) attrs.get(KEY);
+        removedChildren = attrs.get(REMOVED_CHILDREN);
+        dynamicComponent = attrs.get(DYNAMIC_COMPONENT);
+        markDeleted = Boolean.TRUE.equals(attrs.get(MARK_DELETED));
+        markChildrenModified = Boolean.TRUE.equals(attrs.get(MARK_CHILDREN_MODIFIED));
     }
 
     private void doPostAddProcessing(FacesContext context, UIComponent added) {
@@ -1954,19 +2056,23 @@ public abstract class UIComponentBase extends UIComponent {
         // private Map<String, Object> attributes;
         private transient Map<String, PropertyDescriptor> pdMap;
         private transient ConcurrentMap<String, Method> readMap;
-        private transient UIComponent component;
+        private transient UIComponentBase component;
         private static final long serialVersionUID = -6773035086539772945L;
 
         // -------------------------------------------------------- Constructors
 
         private AttributesMap(UIComponent component) {
 
-            this.component = component;
-            pdMap = ((UIComponentBase) component).getDescriptorMap();
+            this.component = (UIComponentBase) component;
+            pdMap = this.component.getDescriptorMap();
         }
 
         @Override
         public boolean containsKey(Object keyObj) {
+            Object marker = component.markerGet(keyObj);
+            if (marker != NOT_MARKER) {
+                return marker != null;
+            }
             if (ATTRIBUTES_THAT_ARE_SET_KEY.equals(keyObj)) {
                 return true;
             }
@@ -1990,6 +2096,10 @@ public abstract class UIComponentBase extends UIComponent {
             Object result = null;
             if (key == null) {
                 throw new NullPointerException();
+            }
+            Object marker = component.markerGet(key);
+            if (marker != NOT_MARKER) {
+                return marker;
             }
             if (ATTRIBUTES_THAT_ARE_SET_KEY.equals(key)) {
                 result = component.getStateHelper().get(UIComponent.PropertyKeysPrivate.attributesThatAreSet);
@@ -2074,6 +2184,9 @@ public abstract class UIComponentBase extends UIComponent {
                 throw new NullPointerException();
             }
 
+            // Keep the field cache in sync; the value is still stored in the attributes map below.
+            component.markerPut(keyValue, value);
+
             if (ATTRIBUTES_THAT_ARE_SET_KEY.equals(keyValue)) {
                 if (component.attributesThatAreSet == null) {
                     if (value instanceof List) {
@@ -2136,6 +2249,7 @@ public abstract class UIComponentBase extends UIComponent {
             if (key == null) {
                 throw new NullPointerException();
             }
+            component.markerRemove(key);
             if (ATTRIBUTES_THAT_ARE_SET_KEY.equals(key)) {
                 return null;
             }
@@ -2300,7 +2414,7 @@ public abstract class UIComponentBase extends UIComponent {
             // noinspection unchecked
             Class<?> clazz = (Class<?>) in.readObject();
             try {
-                component = (UIComponent) clazz.getDeclaredConstructor().newInstance();
+                component = (UIComponentBase) clazz.getDeclaredConstructor().newInstance();
             } catch (IllegalArgumentException | ReflectiveOperationException | SecurityException e) {
                 throw new RuntimeException(e);
             }

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -3381,6 +3381,19 @@ public abstract class UIComponentBase extends UIComponent {
         return context.getViewRoot().createUniqueId();
     }
 
+    /**
+     * Overridden to reuse the memoized {@link #getNamingContainerAncestor()} cache instead of the default
+     * uncached parent-chain walk, which is hot during view build (assignUniqueId / clientId resolution).
+     * Same result: this component if it is a {@link NamingContainer}, else its first NamingContainer ancestor.
+     */
+    @Override
+    public UIComponent getNamingContainer() {
+        if (this instanceof NamingContainer) {
+            return this;
+        }
+        return getNamingContainerAncestor();
+    }
+
     private UIComponent getNamingContainerAncestor() {
         if (namingContainerAncestor != null) {
             return namingContainerAncestor;


### PR DESCRIPTION
Follow-up to #5759 / #5761 on the `RESTORE_VIEW` performance work tracked in #5753. Five targeted, broadly-applicable reductions in per-component restore overhead (restore covers the postback `buildView` + partial-state restore), validated by JFR (composite-heavy, the #4811-scale scenario) and the [perf bench](https://github.com/eclipse-ee4j/mojarra/blob/4.1/test/perf/README.md).

### Commits

1. **Skip the per-component dynamic-add lookup during partial-state restore.** `StateContext.componentAddedDynamically` did `getAttributes().containsKey(DYNAMIC_COMPONENT)` for every component in the restore `visitTree`. Seeded from the saved dynamic-action list, a view with no dynamic actions skips it entirely. Default stays "always check" on every other path.

2. **Field-back the hot Facelets markers for authoritative attribute reads.** `MARK_CREATED`, `MARK_DELETED`, facet name, `MARK_CHILDREN_MODIFIED`, `REMOVED_CHILDREN`, `DYNAMIC_COMPONENT` were read via `getAttributes().get/containsKey` on every refresh — a state-map `HashMap` lookup hashing a long key string, and the common *absent* case ("is this deleted / a facet / dynamically added?") still paid for it. They're now cached on private `UIComponentBase` fields that `AttributesMap.get/containsKey` read **authoritatively** (no map fallthrough), so absent-marker checks become field reads. Writes still flow through the attributes map, so **saved state is unchanged**: partial-state restore is self-correcting (`buildView` re-puts), full-state restore repopulates the fields from the restored map. This is the same shape MyFaces uses (`_ComponentAttributesMap` → component fields).

3. **Memoize `getNamingContainerAncestor` through the parent's cached ancestor.** The cache (added in #5759) was recomputed with a full O(depth) parent-chain walk whenever cold — and `buildView` clears it per component via `setParent` — so it was O(n·depth) across the tree. Resolving via the parent's already-memoized ancestor makes it O(n), same value, same invalidation point.

4. **Override `getNamingContainer` to reuse that same memoized cache** (companion to 3). `UIComponent.getNamingContainer()` did its own uncached parent-chain walk, called per component during build (`assignUniqueId`, the text handlers). Override in `UIComponentBase` to reuse the cached ancestor: `this` if it is a `NamingContainer`, else the memoized ancestor.

5. **Defer `getViewRoot` in `assignUniqueId` to the non-`UniqueIdVendor` branch.** The view root was resolved unconditionally per component (a parent-chain walk), but is only used when the component's `NamingContainer` is *not* a `UniqueIdVendor` (rare — composites/forms/the view root all are). Resolve it lazily only on that branch.

### Measurements (JFR, composite-heavy restore phase)

| metric | before | after | note |
|---|--:|--:|---|
| `AttributesMap.get/containsKey` | 25.2% | **6.1%** | now below MyFaces' ~8% |
| `HashMap.getNode` (restore leaf) | 35.8% | **10.6%** | |
| `getNamingContainerAncestor` | 8.0% | **1.5%** | |
| RESTORE_VIEW wall (GlassFish) | ~16.7 ms | **~15.1 ms** | ~10%, same-session, non-overlapping ranges |

Cross-impl, Tomcat, full bench (Mojarra 4.1.10-SNAPSHOT *with this branch* vs MyFaces 4.1.4-SNAPSHOT): overall wall within ~5%; `APPLY_REQUEST_VALUES` −17%; `RENDER_RESPONSE` +4%; `RESTORE_VIEW` still +55%, concentrated in `composite-heavy` (+96%).

### Validation

- 1078 impl unit tests pass — including `SearchExpressionHandlerTest`'s exact multi-level nested clientId assertions (`form:outerContainer:innerContainer:source`), which directly exercise the `getNamingContainerAncestor` change.
- All 19 bench scenarios pass (real GET→postback cycles; a wrong marker/clientId would break field matching on postback).

### Where this leaves it

These (plus #5759 / #5761) take the concentrated per-component overhead off `RESTORE_VIEW` and flatten the profile: `AttributesMap` is no longer a factor, the ancestor walk is gone. After them, composite-heavy restore is **~62% `buildView`** — re-executing the Facelets template to rebuild ~3000 components on every postback (tag-handler application, unique-id/clientId construction, composite-stack management). The remaining per-component hotspots (clientId `StringBuilder` allocation, `privateOnComponentPopulated`, tag-attribute application) are each only a few percent.

The cross-impl gap on composite-heavy (~2×) is **`buildView` efficiency**, not view pooling: MyFaces view pooling is **off by default** (its `ViewPoolProcessor` is only created in Production with `org.apache.myfaces.CACHE_EL_EXPRESSIONS=alwaysRecompile` and `FACELETS_REFRESH_PERIOD=-1`; the default is `noCache`, so it is never instantiated), and the bench runs MyFaces on defaults. So MyFaces rebuilds the same tree ~2× faster than Mojarra with pooling off on both sides.

A direct Mojarra-vs-MyFaces `buildView` comparison (composite-heavy) places the residual in **per-component `HashMap` operations**: Mojarra's unique-id generation (`DefaultFaceletContext.generateUniqueId` `ids.get`/`put` + per-component `IdMapper.getMapper`/`createUniqueId`) and the per-component tag application, where MyFaces uses **section counters and instance fields** (`startComponentUniqueIdSection`). Commits 4–5 take the clean parts (the redundant ancestor / view-root walks); the rest is structural — closing it to par would mean a section/counter-based unique-id generation, which carries a sharp correctness constraint (generated ids must stay deterministic and identical between save and restore) and so is a separate, TCK-gated change, not incremental hotspot-picking.

This PR banks the broadly-applicable per-component restore wins. The remaining composite-heavy gap is structural in the Facelets build layer (section-based id generation, or — orthogonally — view pooling to skip the rebuild entirely), and is tracked as follow-up to #5753.

🤖 Generated with Claude Opus 4.8
