### PR TITLE
Fix <ui:debug> under CSP: drop gratuitous eval in generated script

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/tag/ui/UIDebug.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/ui/UIDebug.java
@@ -82,10 +82,9 @@ public final class UIDebug extends UIComponentBase {
             StringBuffer sb = new StringBuffer(512);
             sb.append("//<![CDATA[\n");
             sb.append("function faceletsDebugWindow(URL) {");
-            sb.append("day = new Date();");
-            sb.append("id = day.getTime();");
+            sb.append("var id = '' + new Date().getTime();");
             sb.append(
-                    "eval(\"page\" + id + \" = window.open(URL, '\" + id + \"', 'toolbar=0,scrollbars=1,location=0,statusbar=0,menubar=0,resizable=1,width=800,height=600,left = 240,top = 212');\"); };");
+                    "window.open(URL, id, 'toolbar=0,scrollbars=1,location=0,statusbar=0,menubar=0,resizable=1,width=800,height=600,left=240,top=212'); };");
             sb.append("(function() { if (typeof faceletsDebug === 'undefined') { var faceletsDebug = false; } if (!faceletsDebug) {");
             sb.append("var faceletsOrigKeyup = document.onkeyup;");
             sb.append("document.onkeyup = function(e) { if (window.event) e = window.event; if (String.fromCharCode(e.keyCode) == '" + getHotkey()


### PR DESCRIPTION
The debug hotkey handler ran window.open via eval() to assign the result to a dynamically-named global (page<timestamp>) that nothing ever reads. With com.sun.faces.enableCspNonce the default policy is "script-src 'self' 'nonce-#{nonce}' 'strict-dynamic'" (no unsafe-eval), so the eval is blocked and the debug window never opens.

Call window.open directly; the dynamic global was the only reason for eval and its value was discarded anyway. Also declare the id local with var instead of leaking it (and the former day var) as an implicit global.

Closes #5763