### PR TITLE
Backport #5764 to 4.0: reduce RESTORE_VIEW overhead (dynamic-add gate, field-backed Facelets markers, ancestor memoization)

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategy.java
@@ -341,6 +341,11 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
         if (state != null) {
             try {
                 stateContext.setTrackViewModifications(false);
+                // No saved dynamic actions => no component carries DYNAMIC_COMPONENT, so the per-component
+                // marker lookup in componentAddedDynamically can be skipped across the whole restore traversal.
+                @SuppressWarnings("unchecked")
+                List<Object> savedActions = (List<Object>) state.get(DYNAMIC_ACTIONS);
+                stateContext.setHasDynamicComponents(!isEmpty(savedActions));
 
                 VisitContext visitContext = VisitContext.createVisitContext(context, null, SKIP_ITERATION_AND_EXECUTE_LIFECYCLE_HINTS);
                 viewRoot.visitTree(visitContext, (context1, target) -> {
@@ -366,6 +371,7 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
                 });
                 restoreDynamicActions(context, stateContext, state);
             } finally {
+                stateContext.setHasDynamicComponents(true);
                 stateContext.setTrackViewModifications(true);
             }
         } else {

--- a/impl/src/main/java/com/sun/faces/context/StateContext.java
+++ b/impl/src/main/java/com/sun/faces/context/StateContext.java
@@ -62,6 +62,10 @@ public class StateContext {
     private boolean partial;
     private boolean partialLocked;
     private boolean trackMods = true;
+    // A view whose saved state carries no dynamic add/remove actions has no component bearing the
+    // DYNAMIC_COMPONENT marker, so componentAddedDynamically can skip the per-component attribute
+    // lookup. The partial-state restore sets this false for such views; true (always check) otherwise.
+    private boolean hasDynamicComponents = true;
     private AddRemoveListener modListener;
     private ApplicationStateInfo stateInfo;
     private WeakReference<UIViewRoot> viewRootRef = new WeakReference<>(null);
@@ -192,7 +196,19 @@ public class StateContext {
      * @return <code>true</code> if the component was added after the initial view construction
      */
     public boolean componentAddedDynamically(UIComponent c) {
-        return c.getAttributes().containsKey(DYNAMIC_COMPONENT);
+        return hasDynamicComponents && c.getAttributes().containsKey(DYNAMIC_COMPONENT);
+    }
+
+    /**
+     * Hint from the state-management strategy: when a restored view's saved state carries no dynamic
+     * add/remove actions, no component can bear the {@code DYNAMIC_COMPONENT} marker, so
+     * {@link #componentAddedDynamically} skips the per-component attribute lookup. Defaults to
+     * {@code true} (always check) for every other call path.
+     *
+     * @param hasDynamicComponents whether the current view may contain dynamically added/removed components
+     */
+    public void setHasDynamicComponents(boolean hasDynamicComponents) {
+        this.hasDynamicComponents = hasDynamicComponents;
     }
 
     public int getIndexOfDynamicallyAddedChildInParent(UIComponent c) {

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentSupport.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentSupport.java
@@ -53,7 +53,7 @@ import jakarta.faces.view.facelets.TagAttributeException;
  */
 public final class ComponentSupport {
 
-    private final static String MARK_DELETED = "com.sun.faces.facelets.MARK_DELETED";
+    public final static String MARK_DELETED = "com.sun.faces.facelets.MARK_DELETED";
     public final static String MARK_CREATED = "com.sun.faces.facelets.MARK_ID";
 
     /**

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
@@ -396,20 +396,19 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
         if (this.id != null && !(this.id.isLiteral() && IterationIdManager.registerLiteralId(ctx, this.id.getValue()))) {
             c.setId(this.id.getValue(ctx));
         } else {
-            UIViewRoot root = ComponentSupport.getViewRoot(ctx, parent);
-            if (root != null) {
-                String uid;
-                IdMapper mapper = IdMapper.getMapper(ctx.getFacesContext());
-                String mid = mapper != null ? mapper.getAliasedId(id) : id;
-                UIComponent ancestorNamingContainer = parent.getNamingContainer();
-                if (null != ancestorNamingContainer && ancestorNamingContainer instanceof UniqueIdVendor) {
-                    uid = ((UniqueIdVendor) ancestorNamingContainer).createUniqueId(ctx.getFacesContext(), mid);
-                } else {
-                    uid = root.createUniqueId(ctx.getFacesContext(), mid);
+            IdMapper mapper = IdMapper.getMapper(ctx.getFacesContext());
+            String mid = mapper != null ? mapper.getAliasedId(id) : id;
+            UIComponent ancestorNamingContainer = parent.getNamingContainer();
+            if (ancestorNamingContainer instanceof UniqueIdVendor) {
+                c.setId(((UniqueIdVendor) ancestorNamingContainer).createUniqueId(ctx.getFacesContext(), mid));
+            } else {
+                // No UniqueIdVendor ancestor: fall back to the view root. getViewRoot walks the parent chain,
+                // so resolve it only on this branch instead of unconditionally for every component.
+                UIViewRoot root = ComponentSupport.getViewRoot(ctx, parent);
+                if (root != null) {
+                    c.setId(root.createUniqueId(ctx.getFacesContext(), mid));
                 }
-                c.setId(uid);
             }
-
         }
 
         if (rendererType != null) {

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -3380,6 +3380,19 @@ public abstract class UIComponentBase extends UIComponent {
         return context.getViewRoot().createUniqueId();
     }
 
+    /**
+     * Overridden to reuse the memoized {@link #getNamingContainerAncestor()} cache instead of the default
+     * uncached parent-chain walk, which is hot during view build (assignUniqueId / clientId resolution).
+     * Same result: this component if it is a {@link NamingContainer}, else its first NamingContainer ancestor.
+     */
+    @Override
+    public UIComponent getNamingContainer() {
+        if (this instanceof NamingContainer) {
+            return this;
+        }
+        return getNamingContainerAncestor();
+    }
+
     private UIComponent getNamingContainerAncestor() {
         if (namingContainerAncestor != null) {
             return namingContainerAncestor;

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -3385,7 +3385,19 @@ public abstract class UIComponentBase extends UIComponent {
             return namingContainerAncestor;
         }
 
-        for (UIComponent ancestor = getParent(); ancestor != null; ancestor = ancestor.getParent()) {
+        // Resolve via the parent's (memoized) ancestor rather than walking the whole chain: each level is
+        // cached, so building/visiting the tree is O(n) instead of an O(depth) walk per component. The value
+        // is identical to the walk, with the same invalidation point (setParent clears the field).
+        UIComponent parent = getParent();
+        if (parent instanceof NamingContainer) {
+            return namingContainerAncestor = parent;
+        }
+        if (parent instanceof UIComponentBase) {
+            return namingContainerAncestor = ((UIComponentBase) parent).getNamingContainerAncestor();
+        }
+
+        // Rare: a non-UIComponentBase parent has no memoized ancestor, so fall back to the chain walk.
+        for (UIComponent ancestor = parent; ancestor != null; ancestor = ancestor.getParent()) {
             if (ancestor instanceof NamingContainer) {
                 return namingContainerAncestor = ancestor;
             }

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -16,6 +16,12 @@
 
 package jakarta.faces.component;
 
+import static com.sun.faces.facelets.tag.faces.ComponentSupport.MARK_CHILDREN_MODIFIED;
+import static com.sun.faces.facelets.tag.faces.ComponentSupport.MARK_CREATED;
+import static com.sun.faces.facelets.tag.faces.ComponentSupport.MARK_DELETED;
+import static com.sun.faces.facelets.tag.faces.ComponentSupport.REMOVED_CHILDREN;
+import static com.sun.faces.RIConstants.DYNAMIC_COMPONENT;
+import static com.sun.faces.facelets.tag.faces.core.FacetHandler.KEY;
 import static com.sun.faces.util.Util.isAllNull;
 import static com.sun.faces.util.Util.isAnyNull;
 import static com.sun.faces.util.Util.isEmpty;
@@ -136,6 +142,17 @@ public abstract class UIComponentBase extends UIComponent {
      * </p>
      */
     private AttributesMap attributes;
+
+    // Facelets framework markers, read per component on every Facelets refresh (findChildByTagId, deletion
+    // marking, facet-name and child-modified checks). Cached on fields so AttributesMap.get/containsKey skip
+    // the per-read state-map lookup; writes still flow through the attributes map (AttributesMap.put/remove),
+    // so saved/restored state is unchanged. See markerGet/markerContains/markerPut/markerRemove.
+    private String markCreated;            // ComponentSupport.MARK_CREATED (tag id)
+    private String facetName;              // FacetHandler.KEY
+    private Object removedChildren;        // ComponentSupport.REMOVED_CHILDREN (Collection)
+    private Object dynamicComponent;       // RIConstants.DYNAMIC_COMPONENT (Integer index)
+    private boolean markDeleted;           // ComponentSupport.MARK_DELETED
+    private boolean markChildrenModified;  // ComponentSupport.MARK_CHILDREN_MODIFIED
 
     /**
      * <p>
@@ -1294,6 +1311,9 @@ public abstract class UIComponentBase extends UIComponent {
             if (values[5] != null) {
                 id = (String) values[5];
             }
+            // Full-state restore does not re-run buildView, so sync the field-backed markers from the
+            // restored attributes map (partial-state restore re-establishes them via buildView).
+            restoreMarkersFromState();
         }
 
         // StateHelper.restoreState may rewrite rendererType without going through
@@ -1568,6 +1588,88 @@ public abstract class UIComponentBase extends UIComponent {
 
     Map<String, PropertyDescriptor> getDescriptorMap() {
         return propertyDescriptorMap;
+    }
+
+    // ---- Field-backed Facelets markers (authoritative cache for AttributesMap) ----
+    // The marker fields are the single source of truth: AttributesMap.put/remove keep them in sync, and
+    // AttributesMap.get/containsKey read them WITHOUT touching the state map -- so the per-component
+    // "is this deleted / a facet / dynamically added?" checks during Facelets refresh (which are almost
+    // always negative on a stable tree) are field reads, not HashMap lookups. Partial-state restore (the
+    // default) is self-correcting: fresh component instances start absent and buildView re-puts the present
+    // markers. Full-state restore deserializes without buildView, so it repopulates the fields from the
+    // restored attributes map (see restoreMarkersFromState). markerGet returns NOT_MARKER for non-marker
+    // keys, telling AttributesMap to fall through to its normal property/attribute resolution.
+
+    private static final Object NOT_MARKER = new Object();
+
+    private Object markerGet(Object key) {
+        if (MARK_CREATED.equals(key)) {
+            return markCreated;
+        }
+        if (KEY.equals(key)) {
+            return facetName;
+        }
+        if (REMOVED_CHILDREN.equals(key)) {
+            return removedChildren;
+        }
+        if (DYNAMIC_COMPONENT.equals(key)) {
+            return dynamicComponent;
+        }
+        if (MARK_DELETED.equals(key)) {
+            return markDeleted ? Boolean.TRUE : null;
+        }
+        if (MARK_CHILDREN_MODIFIED.equals(key)) {
+            return markChildrenModified ? Boolean.TRUE : null;
+        }
+        return NOT_MARKER;
+    }
+
+    private void markerPut(Object key, Object value) {
+        if (MARK_CREATED.equals(key)) {
+            markCreated = (String) value;
+        } else if (KEY.equals(key)) {
+            facetName = (String) value;
+        } else if (REMOVED_CHILDREN.equals(key)) {
+            removedChildren = value;
+        } else if (DYNAMIC_COMPONENT.equals(key)) {
+            dynamicComponent = value;
+        } else if (MARK_DELETED.equals(key)) {
+            markDeleted = Boolean.TRUE.equals(value);
+        } else if (MARK_CHILDREN_MODIFIED.equals(key)) {
+            markChildrenModified = Boolean.TRUE.equals(value);
+        }
+    }
+
+    private void markerRemove(Object key) {
+        if (MARK_CREATED.equals(key)) {
+            markCreated = null;
+        } else if (KEY.equals(key)) {
+            facetName = null;
+        } else if (REMOVED_CHILDREN.equals(key)) {
+            removedChildren = null;
+        } else if (DYNAMIC_COMPONENT.equals(key)) {
+            dynamicComponent = null;
+        } else if (MARK_DELETED.equals(key)) {
+            markDeleted = false;
+        } else if (MARK_CHILDREN_MODIFIED.equals(key)) {
+            markChildrenModified = false;
+        }
+    }
+
+    // Full-state restore deserializes the tree without re-running buildView, so the marker fields are synced
+    // from the restored attributes map here. Partial-state restore re-puts them via buildView instead.
+    @SuppressWarnings("unchecked")
+    private void restoreMarkersFromState() {
+        Map<String, Object> attrs = (Map<String, Object>) getStateHelper().get(PropertyKeys.attributes);
+        if (attrs == null || attrs.isEmpty()) {
+            return;
+        }
+        markCreated = (String) attrs.get(MARK_CREATED);
+        facetName = (String) attrs.get(KEY);
+        removedChildren = attrs.get(REMOVED_CHILDREN);
+        dynamicComponent = attrs.get(DYNAMIC_COMPONENT);
+        markDeleted = Boolean.TRUE.equals(attrs.get(MARK_DELETED));
+        markChildrenModified = Boolean.TRUE.equals(attrs.get(MARK_CHILDREN_MODIFIED));
     }
 
     private void doPostAddProcessing(FacesContext context, UIComponent added) {
@@ -1953,19 +2055,23 @@ public abstract class UIComponentBase extends UIComponent {
         // private Map<String, Object> attributes;
         private transient Map<String, PropertyDescriptor> pdMap;
         private transient ConcurrentMap<String, Method> readMap;
-        private transient UIComponent component;
+        private transient UIComponentBase component;
         private static final long serialVersionUID = -6773035086539772945L;
 
         // -------------------------------------------------------- Constructors
 
         private AttributesMap(UIComponent component) {
 
-            this.component = component;
-            pdMap = ((UIComponentBase) component).getDescriptorMap();
+            this.component = (UIComponentBase) component;
+            pdMap = this.component.getDescriptorMap();
         }
 
         @Override
         public boolean containsKey(Object keyObj) {
+            Object marker = component.markerGet(keyObj);
+            if (marker != NOT_MARKER) {
+                return marker != null;
+            }
             if (ATTRIBUTES_THAT_ARE_SET_KEY.equals(keyObj)) {
                 return true;
             }
@@ -1989,6 +2095,10 @@ public abstract class UIComponentBase extends UIComponent {
             Object result = null;
             if (key == null) {
                 throw new NullPointerException();
+            }
+            Object marker = component.markerGet(key);
+            if (marker != NOT_MARKER) {
+                return marker;
             }
             if (ATTRIBUTES_THAT_ARE_SET_KEY.equals(key)) {
                 result = component.getStateHelper().get(UIComponent.PropertyKeysPrivate.attributesThatAreSet);
@@ -2073,6 +2183,9 @@ public abstract class UIComponentBase extends UIComponent {
                 throw new NullPointerException();
             }
 
+            // Keep the field cache in sync; the value is still stored in the attributes map below.
+            component.markerPut(keyValue, value);
+
             if (ATTRIBUTES_THAT_ARE_SET_KEY.equals(keyValue)) {
                 if (component.attributesThatAreSet == null) {
                     if (value instanceof List) {
@@ -2135,6 +2248,7 @@ public abstract class UIComponentBase extends UIComponent {
             if (key == null) {
                 throw new NullPointerException();
             }
+            component.markerRemove(key);
             if (ATTRIBUTES_THAT_ARE_SET_KEY.equals(key)) {
                 return null;
             }
@@ -2299,7 +2413,7 @@ public abstract class UIComponentBase extends UIComponent {
             // noinspection unchecked
             Class<?> clazz = (Class<?>) in.readObject();
             try {
-                component = (UIComponent) clazz.getDeclaredConstructor().newInstance();
+                component = (UIComponentBase) clazz.getDeclaredConstructor().newInstance();
             } catch (IllegalArgumentException | ReflectiveOperationException | SecurityException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
Backport of #5764 to 4.0.

Clean cherry-pick of all 5 commits — zero conflicts; the per-hunk content is identical to the 4.1 PR (only line offsets shift, from minor file-length differences). Prerequisite `getNamingContainerAncestor` (#5759) is already present on 4.0.

Five targeted reductions in per-component `RESTORE_VIEW` overhead (restore = postback `buildView` + partial-state restore):

1. **Skip the per-component dynamic-add lookup during partial-state restore.** `StateContext.componentAddedDynamically` did `getAttributes().containsKey(DYNAMIC_COMPONENT)` for every component in the restore `visitTree`. Seeded from the saved dynamic-action list, a view with no dynamic actions skips it entirely. Default stays "always check" on every other path.
2. **Field-back the hot Facelets markers for authoritative attribute reads.** `MARK_CREATED`, `MARK_DELETED`, facet name, `MARK_CHILDREN_MODIFIED`, `REMOVED_CHILDREN`, `DYNAMIC_COMPONENT` are now cached on private `UIComponentBase` fields that `AttributesMap.get/containsKey` read authoritatively, so absent-marker checks become field reads. Writes still flow through the attributes map, so **saved state is unchanged**.
3. **Memoize `getNamingContainerAncestor` through the parent's cached ancestor** — O(n·depth) → O(n), same value, same invalidation point (`setParent`).
4. **Override `getNamingContainer` to reuse that memoized cache** (companion to 3): `this` if it is a `NamingContainer`, else the memoized ancestor.
5. **Defer `getViewRoot` in `assignUniqueId` to the non-`UniqueIdVendor` branch** — only used on that rare branch.

### Validation (on this 4.0 branch)

- `mvn -pl impl clean test` (Java 11): 1078 impl unit tests pass (4 skipped), 344 TS tests pass.

See #5764 for full JFR measurements and the structural-gap analysis.

🤖 Generated with Claude Opus 4.8
