### PR TITLE
Eliminate nested UIData/UIRepeat per-row state cost; field-back UIInput hot properties

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/component/UIRepeat.java
+++ b/impl/src/main/java/com/sun/faces/facelets/component/UIRepeat.java
@@ -391,7 +391,11 @@ public class UIRepeat extends UINamingContainer {
         }
     }
 
-    private Map<String, SavedState> childState;
+    // Per-row transient state of the stateful descendants, keyed by row index. The value array is positionally
+    // aligned to iterationStatefulList (the EditableValueHolder descendants in deterministic tree order), so save and
+    // restore index by position instead of recomputing a clientId and hashing it per child per row. The array length
+    // is guarded on restore so a tree-shape change between requests degrades to NULL_STATE rather than misaligning.
+    private Map<Integer, SavedState[]> childState;
 
     /**
      * Per-iteration cache of the descendants the per-row save/restore walks act on, collected by
@@ -405,7 +409,7 @@ public class UIRepeat extends UINamingContainer {
     private transient List<UIComponent> iterationResetList;
     private transient List<UIComponent> iterationStatefulList;
 
-    private Map<String, SavedState> getChildState() {
+    private Map<Integer, SavedState[]> getChildState() {
         if (childState == null) {
             childState = new HashMap<>();
         }
@@ -451,50 +455,31 @@ public class UIRepeat extends UINamingContainer {
 
     private void saveChildState(FacesContext ctx) {
         ensureIterationLists();
-        if (iterationStatefulList.isEmpty()) {
+        int count = iterationStatefulList.size();
+        if (count == 0) {
             return;
         }
-        for (UIComponent uiComponent : iterationStatefulList) {
-            this.saveChildState(ctx, uiComponent);
+        SavedState[] rowState = getChildState().get(index);
+        if (rowState == null || rowState.length != count) {
+            rowState = new SavedState[count];
+            getChildState().put(index, rowState);
+        }
+        for (int i = 0; i < count; i++) {
+            UIComponent c = iterationStatefulList.get(i);
+            if (!c.isTransient()) {
+                SavedState ss = rowState[i];
+                if (ss == null) {
+                    ss = new SavedState();
+                    rowState[i] = ss;
+                }
+                ss.populate((EditableValueHolder) c);
+            }
         }
     }
 
     private void removeChildState(FacesContext ctx) {
-        if (getChildCount() > 0) {
-
-            for (UIComponent uiComponent : getChildren()) {
-                this.removeChildState(ctx, uiComponent);
-            }
-
-            if (childState != null) {
-                childState.remove(this.getClientId(ctx));
-            }
-        }
-    }
-
-    private void removeChildState(FacesContext faces, UIComponent c) {
-        String id = c.getId();
-        c.setId(id);
-
-        Iterator itr = c.getFacetsAndChildren();
-        while (itr.hasNext()) {
-            removeChildState(faces, (UIComponent) itr.next());
-        }
         if (childState != null) {
-            childState.remove(c.getClientId(faces));
-        }
-    }
-
-    private void saveChildState(FacesContext faces, UIComponent c) {
-        // Called per stateful descendant from the precollected list; no recursion here.
-        if (c instanceof EditableValueHolder && !c.isTransient()) {
-            String clientId = c.getClientId(faces);
-            SavedState ss = getChildState().get(clientId);
-            if (ss == null) {
-                ss = new SavedState();
-                getChildState().put(clientId, ss);
-            }
-            ss.populate((EditableValueHolder) c);
+            childState.remove(index);
         }
     }
 
@@ -506,27 +491,17 @@ public class UIRepeat extends UINamingContainer {
         for (UIComponent component : iterationResetList) {
             component.setId(component.getId()); // forces the cached clientId to be recomputed
         }
-        if (!iterationStatefulList.isEmpty()) {
-            // The child-state map is invariant across this walk; fetch it once.
-            Map<String, SavedState> childStateMap = getChildState();
-            for (UIComponent component : iterationStatefulList) {
-                this.restoreChildState(ctx, component, childStateMap);
-            }
+        int count = iterationStatefulList.size();
+        if (count == 0) {
+            return;
         }
-    }
-
-    private void restoreChildState(FacesContext faces, UIComponent c, Map<String, SavedState> childStateMap) {
-        // The clientId reset happens in the caller's iterationResetList walk; here we only restore the
-        // per-row transient state of a single stateful descendant.
-        if (c instanceof EditableValueHolder) {
-            EditableValueHolder evh = (EditableValueHolder) c;
-            String clientId = c.getClientId(faces);
-            SavedState ss = childStateMap.get(clientId);
-            if (ss != null) {
-                ss.apply(evh);
-            } else {
-                NULL_STATE.apply(evh);
-            }
+        // Positional restore: index into this row's saved-state array rather than rebuilding/hashing a clientId per
+        // child. A null array (row never saved) or short array (tree shape changed) falls back to NULL_STATE per slot.
+        SavedState[] rowState = childState == null ? null : childState.get(index);
+        for (int i = 0; i < count; i++) {
+            EditableValueHolder evh = (EditableValueHolder) iterationStatefulList.get(i);
+            SavedState ss = rowState != null && i < rowState.length ? rowState[i] : null;
+            (ss != null ? ss : NULL_STATE).apply(evh);
         }
     }
 
@@ -1199,7 +1174,7 @@ public class UIRepeat extends UINamingContainer {
         Object[] state = (Object[]) object;
         super.restoreState(faces, state[0]);
         // noinspection unchecked
-        childState = (Map<String, SavedState>) state[1];
+        childState = (Map<Integer, SavedState[]>) state[1];
         begin = (Integer) state[2];
         end = (Integer) state[3];
         step = (Integer) state[4];

--- a/impl/src/main/java/jakarta/faces/component/UIData.java
+++ b/impl/src/main/java/jakarta/faces/component/UIData.java
@@ -148,15 +148,6 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
 
         /**
          * <p>
-         * This map contains <code>SavedState</code> instances for each descendant component, keyed by the client identifier of
-         * the descendant. Because descendant client identifiers will contain the <code>rowIndex</code> value of the parent,
-         * per-row state information is actually preserved.
-         * </p>
-         */
-        saved,
-
-        /**
-         * <p>
          * The local value of this {@link UIComponent}.
          * </p>
          */
@@ -241,6 +232,11 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
      * </p>
      */
     private Boolean isNested = null;
+
+    // Per-row transient state of the stateful descendants, keyed by row index. The value array is positionally
+    // aligned to iterationStatefulList, so save/restore index by position instead of recomputing a clientId and
+    // hashing it per descendant per row. Mirrors UIRepeat#childState; saved/restored explicitly in saveState below.
+    private Map<Integer, SavedState[]> childState;
 
     private Map<String, Object> _rowDeltaStates = new HashMap<>();
     private Map<String, Object> _rowTransientStates = new HashMap<>();
@@ -1485,6 +1481,7 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
         } else {
             _rowDeltaStates = (Map<String, Object>) restoredRowStates;
         }
+        childState = (Map<Integer, SavedState[]>) values[2];
     }
 
     private void resetClientIds(UIComponent component) {
@@ -1500,25 +1497,12 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
     public Object saveState(FacesContext context) {
         resetClientIds(this);
 
-        if (initialStateMarked()) {
-            Object superState = super.saveState(context);
-
-            if (superState == null && _rowDeltaStates.isEmpty()) {
-                return null;
-            } else {
-                Object values[] = null;
-                Object attachedState = UIComponentBase.saveAttachedState(context, _rowDeltaStates);
-                if (superState != null || attachedState != null) {
-                    values = new Object[] { superState, attachedState };
-                }
-                return values;
-            }
-        } else {
-            Object values[] = new Object[2];
-            values[0] = super.saveState(context);
-            values[1] = UIComponentBase.saveAttachedState(context, _rowDeltaStates);
-            return values;
+        Object superState = super.saveState(context);
+        Object rowDeltaState = UIComponentBase.saveAttachedState(context, _rowDeltaStates);
+        if (initialStateMarked() && superState == null && _rowDeltaStates.isEmpty() && childState == null) {
+            return null;
         }
+        return new Object[] { superState, rowDeltaState, childState };
     }
 
     // --------------------------------------------------------- Protected Methods
@@ -1668,10 +1652,8 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
     // (ie. processDecodes()) or during a tree visit (ie. visitTree()).
     private void preDecode(FacesContext context) {
         setDataModel(null); // Re-evaluate even with server-side state saving
-        Map<String, SavedState> saved = (Map<String, SavedState>) getStateHelper().get(PropertyKeys.saved);
-        if (null == saved || !keepSaved(context)) {
-            // noinspection CollectionWithoutInitialCapacity
-            getStateHelper().remove(PropertyKeys.saved);
+        if (!keepSaved(context)) {
+            childState = null;
         }
     }
 
@@ -1699,9 +1681,7 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
     private void preEncode(FacesContext context) {
         setDataModel(null); // re-evaluate even with server-side state saving
         if (!keepSaved(context)) {
-            //// noinspection CollectionWithoutInitialCapacity
-            // saved = new HashMap<String, SavedState>();
-            getStateHelper().remove(PropertyKeys.saved);
+            childState = null;
         }
     }
 
@@ -1993,39 +1973,33 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
         // needs a row-specific clientId (e.g. data:N:foo), else rows render duplicate id="...". The
         // descendant set is constant within an iteration, so it is collected once and walked here as
         // a flat list rather than re-traversing the tree every row.
-        FacesContext context = getFacesContext();
         ensureIterationLists();
         for (UIComponent component : iterationResetList) {
             component.setId(component.getId()); // forces the cached clientId to be recomputed
         }
-        if (!iterationStatefulList.isEmpty()) {
-            // The saved-state map is invariant across this walk; fetch it once.
-            @SuppressWarnings("unchecked")
-            Map<String, SavedState> saved = (Map<String, SavedState>) getStateHelper().get(PropertyKeys.saved);
-            for (UIComponent component : iterationStatefulList) {
-                restoreDescendantState(component, context, saved);
-            }
+        int count = iterationStatefulList.size();
+        if (count == 0) {
+            return;
+        }
+        // Positional restore: index this row's saved-state array rather than rebuilding/hashing a clientId per
+        // child. A null array (row never saved) or short array (tree shape changed) falls back to a reset per slot.
+        SavedState[] rowState = childState == null ? null : childState.get(getRowIndex());
+        for (int i = 0; i < count; i++) {
+            SavedState state = rowState != null && i < rowState.length ? rowState[i] : null;
+            restoreComponentState(iterationStatefulList.get(i), state);
         }
 
     }
 
     /**
      * <p>
-     * Restore state information for the specified component and its descendants.
+     * Restore the per-row transient state of a single stateful descendant. The clientId reset happens in the
+     * caller's iterationResetList walk; a {@code null} state resets the component to its un-submitted defaults.
      * </p>
-     *
-     * @param component Component for which to restore state information
-     * @param context {@link FacesContext} for the current request
      */
-    private void restoreDescendantState(UIComponent component, FacesContext context, Map<String, SavedState> saved) {
-
-        // The clientId reset happens in the caller's iterationResetList walk; here we only restore
-        // the per-row transient state of a single stateful descendant.
+    private void restoreComponentState(UIComponent component, SavedState state) {
         if (component instanceof EditableValueHolder) {
             EditableValueHolder input = (EditableValueHolder) component;
-            String clientId = component.getClientId(context);
-
-            SavedState state = saved == null ? null : saved.get(clientId);
             if (state == null) {
                 input.resetValue();
             } else {
@@ -2037,17 +2011,9 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
                 input.setLocalValueSet(state.isLocalValueSet());
             }
         } else if (component instanceof UIForm) {
-            UIForm form = (UIForm) component;
-            String clientId = component.getClientId(context);
-            SavedState state = saved == null ? null : saved.get(clientId);
-            if (state == null) {
-                // submitted is transient state
-                form.setSubmitted(false);
-            } else {
-                form.setSubmitted(state.getSubmitted());
-            }
+            // submitted is transient state
+            ((UIForm) component).setSubmitted(state != null && state.getSubmitted());
         }
-
     }
 
     /**
@@ -2057,14 +2023,49 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
      */
     private void saveDescendantState() {
         ensureIterationLists();
-        if (iterationStatefulList.isEmpty()) {
+        int count = iterationStatefulList.size();
+        if (count == 0) {
             // Read-only table (e.g. all-output-text columns): nothing to save.
             return;
         }
-        FacesContext context = getFacesContext();
-        for (UIComponent component : iterationStatefulList) {
-            saveDescendantState(component, context);
+        // Capture per position; only slots with delta state hold a SavedState. Persist the row array only when some
+        // slot carries delta, else drop the row entry — keeping the saved state minimal.
+        int row = getRowIndex();
+        SavedState[] rowState = new SavedState[count];
+        boolean anyDelta = false;
+        for (int i = 0; i < count; i++) {
+            SavedState state = captureComponentState(iterationStatefulList.get(i));
+            if (state.hasDeltaState()) {
+                rowState[i] = state;
+                anyDelta = true;
+            }
         }
+        if (anyDelta) {
+            getChildState().put(row, rowState);
+        } else if (childState != null) {
+            childState.remove(row);
+        }
+    }
+
+    private Map<Integer, SavedState[]> getChildState() {
+        if (childState == null) {
+            childState = new HashMap<>();
+        }
+        return childState;
+    }
+
+    private SavedState captureComponentState(UIComponent component) {
+        SavedState state = new SavedState();
+        if (component instanceof EditableValueHolder) {
+            EditableValueHolder input = (EditableValueHolder) component;
+            state.setValue(input.getLocalValue());
+            state.setValid(input.isValid());
+            state.setSubmittedValue(input.getSubmittedValue());
+            state.setLocalValueSet(input.isLocalValueSet());
+        } else if (component instanceof UIForm) {
+            state.setSubmitted(((UIForm) component).isSubmitted());
+        }
+        return state;
     }
 
     /**
@@ -2107,63 +2108,6 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
                 collectIterationState(facet, reset, stateful);
             }
         }
-    }
-
-    /**
-     * <p>
-     * Save state information for the specified component and its descendants.
-     * </p>
-     *
-     * @param component Component for which to save state information
-     * @param context {@link FacesContext} for the current request
-     */
-    private void saveDescendantState(UIComponent component, FacesContext context) {
-
-        // Save state for this component (if it is a EditableValueHolder)
-        Map<String, SavedState> saved = (Map<String, SavedState>) getStateHelper().get(PropertyKeys.saved);
-        if (component instanceof EditableValueHolder) {
-            EditableValueHolder input = (EditableValueHolder) component;
-            SavedState state = null;
-            String clientId = component.getClientId(context);
-            if (saved == null) {
-                state = new SavedState();
-            }
-            if (state == null) {
-                state = saved.get(clientId);
-                if (state == null) {
-                    state = new SavedState();
-                }
-            }
-            state.setValue(input.getLocalValue());
-            state.setValid(input.isValid());
-            state.setSubmittedValue(input.getSubmittedValue());
-            state.setLocalValueSet(input.isLocalValueSet());
-            if (state.hasDeltaState()) {
-                getStateHelper().put(PropertyKeys.saved, clientId, state);
-            } else if (saved != null) {
-                getStateHelper().remove(PropertyKeys.saved, clientId);
-            }
-        } else if (component instanceof UIForm) {
-            UIForm form = (UIForm) component;
-            String clientId = component.getClientId(context);
-            SavedState state = null;
-            if (saved == null) {
-                state = new SavedState();
-            }
-            if (state == null) {
-                state = saved.get(clientId);
-                if (state == null) {
-                    state = new SavedState();
-                }
-            }
-            state.setSubmitted(form.isSubmitted());
-            if (state.hasDeltaState()) {
-                getStateHelper().put(PropertyKeys.saved, clientId, state);
-            } else if (saved != null) {
-                getStateHelper().remove(PropertyKeys.saved, clientId);
-            }
-        }
-
     }
 
 }

--- a/impl/src/main/java/jakarta/faces/component/UIInput.java
+++ b/impl/src/main/java/jakarta/faces/component/UIInput.java
@@ -244,6 +244,19 @@ public class UIInput extends UIOutput implements EditableValueHolder {
      */
     private transient Object submittedValue = null;
 
+    // The "valid" and "localValueSet" flags are pure per-request lifecycle state: never bound to a ValueExpression and
+    // only mutated during the process phases (always a delta), so they live in plain fields rather than the StateHelper
+    // map. isValid()/isLocalValueSet() are read several times per component per lifecycle; a field read avoids a HashMap
+    // lookup on that hot path. They are saved/restored explicitly in saveState()/restoreState().
+    private boolean valid = true;
+    private boolean localValueSet = false;
+
+    // "required" and "immediate" can be a literal or a ValueExpression. A non-null field holds the literal; when null we
+    // fall back to the bound ValueExpression (mirroring the old StateHelper.eval(key, default) contract). Field-backing
+    // keeps isRequired()/isImmediate() off the HashMap on the validate path. Saved/restored explicitly below.
+    private Boolean required;
+    private Boolean immediate;
+
     /**
      * <p>
      * Return the submittedValue value of this {@link UIInput} component. This method should only be used by the
@@ -327,8 +340,8 @@ public class UIInput extends UIOutput implements EditableValueHolder {
     public void resetValue() {
         super.resetValue();
         setSubmittedValue(null);
-        getStateHelper().remove(PropertyKeys.localValueSet);
-        getStateHelper().remove(PropertyKeys.valid);
+        localValueSet = false;
+        valid = true;
     }
 
     /**
@@ -337,7 +350,7 @@ public class UIInput extends UIOutput implements EditableValueHolder {
      */
     @Override
     public boolean isLocalValueSet() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.localValueSet, false);
+        return localValueSet;
     }
 
     /**
@@ -345,7 +358,7 @@ public class UIInput extends UIOutput implements EditableValueHolder {
      */
     @Override
     public void setLocalValueSet(boolean localValueSet) {
-        getStateHelper().put(PropertyKeys.localValueSet, localValueSet);
+        this.localValueSet = localValueSet;
     }
 
     /**
@@ -356,8 +369,17 @@ public class UIInput extends UIOutput implements EditableValueHolder {
     @Override
     public boolean isRequired() {
 
-        return (Boolean) getStateHelper().eval(PropertyKeys.required, false);
-
+        if (required != null) {
+            return required;
+        }
+        ValueExpression ve = getValueExpression(PropertyKeys.required.toString());
+        if (ve != null) {
+            Boolean value = (Boolean) ve.getValue(getFacesContext().getELContext());
+            if (value != null) {
+                return value;
+            }
+        }
+        return false;
     }
 
     /**
@@ -456,16 +478,12 @@ public class UIInput extends UIOutput implements EditableValueHolder {
 
     @Override
     public boolean isValid() {
-
-        return (Boolean) getStateHelper().eval(PropertyKeys.valid, true);
-
+        return valid;
     }
 
     @Override
     public void setValid(boolean valid) {
-
-        getStateHelper().put(PropertyKeys.valid, valid);
-
+        this.valid = valid;
     }
 
     /**
@@ -478,21 +496,30 @@ public class UIInput extends UIOutput implements EditableValueHolder {
     @Override
     public void setRequired(boolean required) {
 
-        getStateHelper().put(PropertyKeys.required, required);
+        this.required = required;
 
     }
 
     @Override
     public boolean isImmediate() {
 
-        return (Boolean) getStateHelper().eval(PropertyKeys.immediate, false);
-
+        if (immediate != null) {
+            return immediate;
+        }
+        ValueExpression ve = getValueExpression(PropertyKeys.immediate.toString());
+        if (ve != null) {
+            Boolean value = (Boolean) ve.getValue(getFacesContext().getELContext());
+            if (value != null) {
+                return value;
+            }
+        }
+        return false;
     }
 
     @Override
     public void setImmediate(boolean immediate) {
 
-        getStateHelper().put(PropertyKeys.immediate, immediate);
+        this.immediate = immediate;
 
     }
 
@@ -1258,16 +1285,16 @@ public class UIInput extends UIOutput implements EditableValueHolder {
             throw new NullPointerException();
         }
 
-        Object[] result = null;
-
         Object superState = super.saveState(context);
         Object validatorsState = validators != null ? validators.saveState(context) : null;
 
-        if (superState != null || validatorsState != null) {
-            result = new Object[] { superState, validatorsState };
+        // valid/localValueSet/required/immediate are not in the StateHelper anymore, so they must be saved explicitly;
+        // skip the array entirely only when everything (including these flags) is at its default.
+        if (superState == null && validatorsState == null && valid && !localValueSet && required == null && immediate == null) {
+            return null;
         }
 
-        return result;
+        return new Object[] { superState, validatorsState, valid, localValueSet, required, immediate };
     }
 
     @Override
@@ -1288,7 +1315,10 @@ public class UIInput extends UIOutput implements EditableValueHolder {
             }
             validators.restoreState(context, values[1]);
         }
-
+        valid = (boolean) values[2];
+        localValueSet = (boolean) values[3];
+        required = (Boolean) values[4];
+        immediate = (Boolean) values[5];
     }
 
     private Converter getConverterWithType(FacesContext context) {

--- a/impl/src/main/java/jakarta/faces/component/UIOutput.java
+++ b/impl/src/main/java/jakarta/faces/component/UIOutput.java
@@ -16,6 +16,7 @@
 
 package jakarta.faces.component;
 
+import jakarta.el.ValueExpression;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.convert.Converter;
 
@@ -104,7 +105,10 @@ public class UIOutput extends UIComponentBase implements ValueHolder {
             return converter;
         }
 
-        return (Converter) getStateHelper().eval(PropertyKeys.converter);
+        // The converter is only ever stored in the field (setConverter) or as a ValueExpression; PropertyKeys.converter
+        // is never written to the StateHelper, so go straight to the expression and skip the always-miss HashMap lookup.
+        ValueExpression ve = getValueExpression(PropertyKeys.converter.toString());
+        return ve != null ? (Converter) ve.getValue(getFacesContext().getELContext()) : null;
     }
 
     @Override

--- a/test/perf/README.md
+++ b/test/perf/README.md
@@ -189,6 +189,7 @@ mvn clean verify -Dperf=true \
 - `table-readonly-heavy` — h:dataTable, 2000 rows, outputs only
 - `table-inputs` — h:dataTable, 50 rows, per-row inputs + converters/validators
 - `table-inputs-heavy` — h:dataTable, 200 rows, per-row inputs + converters/validators
+- `table-nested` — h:dataTable ∋ h:dataTable with a per-row input composite (5×10); UIData twin of `composite-nested`, isolating UIData's per-row child-state save/restore against ui:repeat's
 - `repeat-readonly` — ui:repeat, 200 rows, outputs only
 - `repeat-readonly-heavy` — ui:repeat, 2000 rows, outputs only
 - `repeat-inputs` — ui:repeat, 40 rows, per-row inputs

--- a/test/perf/src/main/webapp/table-nested.xhtml
+++ b/test/perf/src/main/webapp/table-nested.xhtml
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!-- UIData twin of composite-nested: same data and composite, h:dataTable instead of ui:repeat, to isolate UIData's per-row child-state cost. -->
+<html lang="#{facesContext.viewRoot.locale.language}"
+    xmlns:h="jakarta.faces.html"
+    xmlns:cc="jakarta.faces.composite/cc"
+>
+    <h:head>
+        <title>table-nested</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <h:dataTable value="#{repeatBean.groups}" var="group">
+                <h:column>
+                    <h2>#{group.name}</h2>
+                    <h:dataTable value="#{group.rows}" var="row">
+                        <h:column>
+                            <cc:inputs row="#{row}"/>
+                        </h:column>
+                    </h:dataTable>
+                </h:column>
+            </h:dataTable>
+            <h:commandButton id="submit" value="Save" action="#{repeatBean.save}"/>
+            <h:messages globalOnly="false"/>
+        </h:form>
+    </h:body>
+</html>

--- a/test/perf/src/test/java/org/eclipse/mojarra/test/perf/PerfBenchIT.java
+++ b/test/perf/src/test/java/org/eclipse/mojarra/test/perf/PerfBenchIT.java
@@ -134,12 +134,13 @@ class PerfBenchIT extends BaseIT {
             "form-inputs",
             "table-inputs",
             "repeat-inputs",
-            "repeat-nested",
             "composite-inputs",
+            "table-nested",
+            "repeat-nested",
             "composite-nested",
-            "composite-heavy",
             "table-inputs-heavy",
-            "repeat-inputs-heavy"));
+            "repeat-inputs-heavy",
+            "composite-heavy"));
 
     /** Ajax-partial postbacks. Same body fields as their non-ajax twin plus the
      *  {@code jakarta.faces.partial.*} markers and the {@code Faces-Request} header. */


### PR DESCRIPTION
## What

Removes the dominant per-request cost of nested `UIData`/`UIRepeat` iteration and trims the input read-path, bringing Mojarra from well behind MyFaces on these phases to ahead of it.

Three changes:

1. **`UIData` + `UIRepeat`: key per-row child state by row index, not by clientId.** Both saved/restored each stateful descendant's per-row state in a map keyed by `clientId`, which recomputed a clientId (NamingContainer walk + `StringBuilder`) and hashed it **per child per row** on every row-index change during APPLY/VALIDATE/UPDATE. This was the dominant cost of nested iteration. Now a `Map<Integer, SavedState[]>` field keyed by row index, the array positionally aligned to the cached `iterationStatefulList`; save/restore index by position — no per-child clientId construction or hashing. Length-guarded on restore (a tree-shape change degrades to the reset/`NULL_STATE` per slot), and the clientId reset loop is retained for render/decode correctness.

   `UIData` previously stored this map in the `StateHelper` (`PropertyKeys.saved`, a String-keyed sub-map), which is the only reason it diverged from `UIRepeat` here. It already hand-writes `saveState`/`restoreState`, so the map moves to a plain field matching `UIRepeat`; `PropertyKeys.saved` is dropped. The per-row save/restore is now identical in both components (the seam for a future shared `UIIterable`).

2. **`UIInput`: field-back `valid`/`localValueSet`/`required`/`immediate`.** These were routed through the `StateHelper` HashMap on the hot read path; `isValid()`/`isLocalValueSet()` are read several times per component per request. `valid`/`localValueSet` are pure per-request state (never EL-bound) → plain fields. `required`/`immediate` use nullable `Boolean` fields: a literal lives in the field, an EL-bound value keeps the field null and is re-evaluated from the `ValueExpression` on every call, preserving per-phase semantics (e.g. `required="#{not empty other.value}"`).

3. **`UIOutput.getConverter()`: drop the dead `StateHelper` lookup.** `PropertyKeys.converter` is never written to the `StateHelper` (`setConverter` sets the field), so the fallback `getStateHelper().eval(converter)` always missed; go straight to the `ValueExpression`.

State format is not spec-defined and save/restore move together, so this is safe within a release.

## Results

Full perf-bench suite (`test/perf`), Mojarra vs Apache MyFaces 4.1.4, `warmup=50 runs=1000`. The nested-iteration deficit is eliminated and Mojarra now leads decode/validate/update; reproduced on WildFly and Tomcat.

Nested `PROCESS_VALIDATIONS` (avg µs/req), before this change vs after, vs MyFaces (WildFly):

| scenario | before | after | MyFaces |
|---|--:|--:|--:|
| composite-nested (`ui:repeat`) | 2789 | 768 (−72%) | 904 |
| repeat-nested (`ui:repeat`) | 1055 | 316 (−70%) | 404 |
| table-nested (`UIData`, new bench scenario) | 3080 | 738 (−76%) | 824 |

Across the full Tomcat suite the wall-clock gap to MyFaces narrows from +18% (pre-change) to +4%; APPLY −18…−70% and UPDATE −11…−40% vs MyFaces across input scenarios. The remaining Mojarra-side deficits are RESTORE/RENDER only (the `AttributesMap`/render cost — out of scope here).

A new `table-nested` bench scenario (UIData twin of `composite-nested`) is added to exercise the `UIData` path.

## Testing

Full Jakarta Faces TCK passes (on the corresponding 5.0 downmerge). Existing impl unit tests pass.

Follow-up to the benchmarking in #5753.
