### PR TITLE
Reduce per-component buildView/render overhead (lazy state map, UIOutput converter, rendererType, AttributesMap getter)

### DIFF
--- a/impl/src/main/java/jakarta/faces/component/ComponentStateHelper.java
+++ b/impl/src/main/java/jakarta/faces/component/ComponentStateHelper.java
@@ -47,14 +47,18 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
      * {@code null} as an empty map.
      */
     private Map<Serializable, Object> deltaMap;
-    private final Map<Serializable, Object> defaultMap;
+    /**
+     * Component state written before {@code initialStateMarked()} (the bulk of buildView state).
+     * Lazily allocated on the first write through {@link #defaultMap()}; reads treat {@code null}
+     * as an empty map, so a component that never stores state pays no HashMap allocation.
+     */
+    private Map<Serializable, Object> defaultMap;
     private Map<Object, Object> transientState;
 
     // ------------------------------------------------------------ Constructors
 
     public ComponentStateHelper(UIComponent component) {
         this.component = component;
-        defaultMap = new HashMap<>();
         transientState = null;
     }
 
@@ -68,6 +72,17 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
             deltaMap = new HashMap<>(2);
         }
         return deltaMap;
+    }
+
+    /**
+     * Returns the default map, allocating it on first access. All write sites must route through
+     * this accessor; read-only sites treat {@code defaultMap == null} as an empty map.
+     */
+    private Map<Serializable, Object> defaultMap() {
+        if (defaultMap == null) {
+            defaultMap = new HashMap<>();
+        }
+        return defaultMap;
     }
 
     // ------------------------------------------------ Methods from StateHelper
@@ -86,15 +101,15 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
             Object retVal = deltaMap().put(key, value);
 
             if (retVal == null) {
-                return defaultMap.put(key, value);
+                return defaultMap().put(key, value);
             }
 
-            defaultMap.put(key, value);
+            defaultMap().put(key, value);
             return retVal;
 
         }
 
-        return defaultMap.put(key, value);
+        return defaultMap().put(key, value);
     }
 
     /**
@@ -109,14 +124,16 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
             Object retVal = deltaMap == null ? null : deltaMap.remove(key);
 
             if (retVal == null) {
-                return defaultMap.remove(key);
+                return defaultMap == null ? null : defaultMap.remove(key);
             }
 
-            defaultMap.remove(key);
+            if (defaultMap != null) {
+                defaultMap.remove(key);
+            }
             return retVal;
         }
 
-        return defaultMap.remove(key);
+        return defaultMap == null ? null : defaultMap.remove(key);
     }
 
     /**
@@ -155,7 +172,7 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
         Map<String, Object> map = (Map<String, Object>) get(key);
         if (map == null) {
             map = new HashMap<>(8);
-            defaultMap.put(key, map);
+            defaultMap().put(key, map);
         }
     }
 
@@ -167,7 +184,7 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
      */
     @Override
     public Object get(Serializable key) {
-        return defaultMap.get(key);
+        return defaultMap == null ? null : defaultMap.get(key);
     }
 
     /**
@@ -242,7 +259,7 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
 
         if (get(key) == null) {
             List<Object> items = new ArrayList<>(4);
-            defaultMap.put(key, items);
+            defaultMap().put(key, items);
         }
     }
 
@@ -306,7 +323,7 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
             return;
         }
 
-        if (!component.initialStateMarked() && !defaultMap.isEmpty()) {
+        if (!component.initialStateMarked() && defaultMap != null && !defaultMap.isEmpty()) {
             defaultMap.clear();
             if (deltaMap != null && !deltaMap.isEmpty()) {
                 deltaMap.clear();
@@ -337,7 +354,9 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
                     put(serializable, entry.getKey(), entry.getValue());
                 }
             } else if (value instanceof List) {
-                defaultMap.remove(serializable);
+                if (defaultMap != null) {
+                    defaultMap.remove(serializable);
+                }
                 if (deltaMap != null) {
                     deltaMap.remove(serializable);
                 }
@@ -397,7 +416,7 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
 
     private Object saveMap(FacesContext context, Map<Serializable, Object> map) {
 
-        if (map.isEmpty()) {
+        if (map == null || map.isEmpty()) {
             if (!component.initialStateMarked()) {
                 // only need to propagate the component's delta status when
                 // delta tracking has been disabled. We're assuming that

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -203,6 +203,27 @@ public abstract class UIComponentBase extends UIComponent {
     private transient Renderer cachedRenderer;
 
     /**
+     * Field-backed {@code rendererType}, replacing the {@link StateHelper} entry that every component
+     * writes from its constructor. Backing it with a field keeps {@code defaultMap} unallocated for the
+     * common value-expression-bound leaf component (whose only would-be StateHelper entry is the
+     * renderer type) and turns every {@link #getRenderer}/{@link #getRendererType} read into a field read
+     * rather than a HashMap lookup.
+     *
+     * <p>State handling honours the partial-state contract: under partial state saving the constructor
+     * sets this <em>before</em> {@code markInitialState}, so {@code buildView} reconstructs it on restore
+     * and it is carried in the delta only when changed afterwards (see {@link #rendererTypeSet}); under
+     * full state saving it is persisted unconditionally, like {@link #id}.
+     */
+    private String rendererType;
+
+    /**
+     * {@code true} once {@code rendererType} is changed after {@code markInitialState}, so the change is
+     * carried in the partial-state delta. Transient: a freshly reconstructed component starts clean and
+     * relies on {@code buildView} (partial state) or the saved full state to re-establish the value.
+     */
+    private transient boolean rendererTypeSet;
+
+    /**
      * The <code>List</code> containing our child components.
      */
     private List<UIComponent> children;
@@ -366,12 +387,19 @@ public abstract class UIComponentBase extends UIComponent {
 
     @Override
     public String getRendererType() {
-        return (String) getStateHelper().eval(PropertyKeys.rendererType);
+        if (rendererType != null) {
+            return rendererType;
+        }
+        ValueExpression ve = getValueExpression(PropertyKeys.rendererType.toString());
+        return ve != null ? (String) ve.getValue(getFacesContext().getELContext()) : null;
     }
 
     @Override
     public void setRendererType(String rendererType) {
-        getStateHelper().put(PropertyKeys.rendererType, rendererType);
+        this.rendererType = rendererType;
+        if (initialStateMarked()) {
+            rendererTypeSet = true;
+        }
         cachedRenderer = null;
     }
 
@@ -1223,12 +1251,16 @@ public abstract class UIComponentBase extends UIComponent {
                 savedHelper = stateHelper.saveState(context);
             }
 
-            if (isAllNull(savedFacesListeners, savedSysEventListeners, savedBehaviors, savedBindings, savedHelper)) {
+            // rendererType is set from the constructor (before markInitialState) and rebuilt by buildView,
+            // so it only needs to ride along in the delta when it was changed after the initial state mark.
+            String savedRendererType = rendererTypeSet ? rendererType : null;
+
+            if (isAllNull(savedFacesListeners, savedSysEventListeners, savedBehaviors, savedBindings, savedHelper, savedRendererType)) {
                 return null;
             }
 
-            if (values == null || values.length != 5) {
-                values = new Object[5];
+            if (values == null || values.length != 6) {
+                values = new Object[6];
             }
 
             // Since we're saving partial state, skip id and clientId
@@ -1239,12 +1271,13 @@ public abstract class UIComponentBase extends UIComponent {
             values[2] = savedBehaviors;
             values[3] = savedBindings;
             values[4] = savedHelper;
+            values[5] = savedRendererType;
 
             return values;
 
         } else {
-            if (values == null || values.length != 6) {
-                values = new Object[6];
+            if (values == null || values.length != 7) {
+                values = new Object[7];
             }
 
             values[0] = listeners != null ? listeners.saveState(context) : null;
@@ -1259,7 +1292,9 @@ public abstract class UIComponentBase extends UIComponent {
                 values[4] = stateHelper.saveState(context);
             }
 
-            values[5] = id;
+            // Full state carries no buildView reconstruction, so persist rendererType unconditionally (like id).
+            values[5] = rendererType;
+            values[6] = id;
 
             return values;
         }
@@ -1306,15 +1341,21 @@ public abstract class UIComponentBase extends UIComponent {
             getStateHelper().restoreState(context, values[4]);
         }
 
-        if (values.length == 6) {
-            // This means we've saved full state and need to do a little more
-            // work to finish the job
-            if (values[5] != null) {
-                id = (String) values[5];
+        if (values.length == 7) {
+            // Full state is authoritative and runs no buildView reconstruction: restore rendererType
+            // exactly (including an explicit null, which must overwrite a constructor-set default) and
+            // the id, then sync the field-backed markers from the restored attributes map.
+            rendererType = (String) values[5];
+            if (values[6] != null) {
+                id = (String) values[6];
             }
-            // Full-state restore does not re-run buildView, so sync the field-backed markers from the
-            // restored attributes map (partial-state restore re-establishes them via buildView).
             restoreMarkersFromState();
+        } else if (values[5] != null) {
+            // Partial-state delta: rendererType changed after markInitialState; apply it and keep it
+            // marked dirty so it stays in the delta across subsequent postbacks. buildView re-established
+            // the pre-mark value, so a null here just means "no rendererType delta".
+            rendererType = (String) values[5];
+            rendererTypeSet = true;
         }
 
         // StateHelper.restoreState may rewrite rendererType without going through

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -2162,6 +2162,7 @@ public abstract class UIComponentBase extends UIComponent {
                             if (null == readMap) {
                                 readMap = new ConcurrentHashMap<>();
                             }
+                            suppressAccessCheck(readMethod);
                             readMap.putIfAbsent(key, readMethod);
                             result = invokeReadMethod(readMethod);
                         } else {
@@ -2419,6 +2420,24 @@ public abstract class UIComponentBase extends UIComponent {
                 throw new FacesException(e);
             } catch (InvocationTargetException e) {
                 throw new FacesException(e.getTargetException());
+            }
+        }
+
+        /**
+         * Suppresses the per-invoke reflective access check on the (public) property getter that gets
+         * cached in {@link #readMap} and then invoked on every property-backed attribute read — hot under
+         * render and {@code UIData}/{@code UIRepeat} iteration (a renderer reads each pass-through attribute
+         * through {@code getAttributes().get}). The check is otherwise re-run per invoke because
+         * {@link PropertyDescriptor#getReadMethod()} hands back the method via a soft {@link
+         * java.lang.ref.Reference} that may be regenerated, yielding a fresh {@link Method} whose access
+         * was never suppressed. Suppressing it on the strongly-held cached instance makes the win durable.
+         */
+        private static void suppressAccessCheck(Method readMethod) {
+            try {
+                // The module system may forbid this for a getter in a non-exported user package;
+                // when it does, the normal per-invoke access check simply remains.
+                readMethod.setAccessible(true);
+            } catch (RuntimeException accessNotSuppressed) {
             }
         }
 
@@ -3359,17 +3378,12 @@ public abstract class UIComponentBase extends UIComponent {
             if (propertyDescriptors != null) {
                 propertyDescriptorMap = new HashMap<>(propertyDescriptors.length, 1.0f);
                 for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
-                    // Suppress the per-invoke reflective access check on the (public) property getter.
-                    // It is invoked on every property-backed attribute read, which is hot under render
-                    // and UIData/UIRepeat iteration. Done once per component class (this map is cached
-                    // application-wide below). Guarded: the module system may forbid it for a getter in a
-                    // non-exported user package, in which case the normal access check simply remains.
+                    // Suppress the access check up front (see AttributesMap.suppressAccessCheck); note the
+                    // hot path additionally suppresses it on the readMap-cached instance, since the method
+                    // handed back here may be regenerated before that cache is populated.
                     Method readMethod = propertyDescriptor.getReadMethod();
                     if (readMethod != null) {
-                        try {
-                            readMethod.setAccessible(true);
-                        } catch (RuntimeException accessNotSuppressed) {
-                        }
+                        AttributesMap.suppressAccessCheck(readMethod);
                     }
                     propertyDescriptorMap.put(propertyDescriptor.getName(), propertyDescriptor);
                 }

--- a/impl/src/main/java/jakarta/faces/component/UIOutput.java
+++ b/impl/src/main/java/jakarta/faces/component/UIOutput.java
@@ -165,9 +165,12 @@ public class UIOutput extends UIComponentBase implements ValueHolder {
     public void markInitialState() {
         super.markInitialState();
 
-        Converter<?> c = getConverter();
-        if (c instanceof PartialStateHolder) {
-            ((PartialStateHolder) c).markInitialState();
+        // Use the field, not getConverter(): only an explicitly-installed converter can be a
+        // PartialStateHolder worth marking. A ValueExpression-bound converter is resolved lazily
+        // (a fresh instance per call), so resolving it here is meaningless — and getConverter() does
+        // a per-component ValueExpression lookup that dominates buildView on large views.
+        if (converter instanceof PartialStateHolder) {
+            ((PartialStateHolder) converter).markInitialState();
         }
     }
 
@@ -176,9 +179,8 @@ public class UIOutput extends UIComponentBase implements ValueHolder {
         if (initialStateMarked()) {
             super.clearInitialState();
 
-            Converter<?> c = getConverter();
-            if (c instanceof PartialStateHolder) {
-                ((PartialStateHolder) c).clearInitialState();
+            if (converter instanceof PartialStateHolder) {
+                ((PartialStateHolder) converter).clearInitialState();
             }
         }
     }

--- a/impl/src/test/java/jakarta/faces/component/UIComponentBaseTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIComponentBaseTestCase.java
@@ -1487,8 +1487,67 @@ public class UIComponentBaseTestCase extends UIComponentTestCase {
         invokeGetRenderer(test); // populate cache with rA
         test.setRendererType("TR_B"); // direct setter, also invalidates and re-caches on next lookup
         invokeGetRenderer(test); // re-cache as rB
-        test.restoreState(facesContext, savedWithA); // bring rendererType back to "TR_A" via StateHelper
+        test.restoreState(facesContext, savedWithA); // bring rendererType back to "TR_A" via the saved full state
         assertTrue(invokeGetRenderer(test) == rA, "after restoreState, lookup must reflect restored rendererType");
+    }
+
+    /**
+     * Verifies the partial-state contract for the field-backed {@code rendererType}: a value set before
+     * {@code markInitialState} (as every component's constructor does) is reconstructed by buildView and
+     * therefore carries no partial state, a value changed afterwards rides along in the delta and stays
+     * there across repeated postbacks, and full state persists the value unconditionally.
+     */
+    @Test
+    public void testRendererTypeStateHolder() throws Exception {
+        // Pre-mark rendererType is "initial" (buildView re-establishes it): no partial state to save.
+        ComponentTestImpl pristine = new ComponentTestImpl();
+        pristine.setRendererType("Foo");
+        pristine.markInitialState();
+        assertNull(pristine.saveState(facesContext), "constructor-set rendererType must not produce partial state");
+
+        // A post-mark change must ride along in the delta and restore on top of the reconstructed initial value.
+        ComponentTestImpl changed = new ComponentTestImpl();
+        changed.setRendererType("Foo");
+        changed.markInitialState();
+        changed.setRendererType("Bar");
+        Object delta = changed.saveState(facesContext);
+        assertNotNull(delta, "post-mark rendererType change must produce partial state");
+
+        ComponentTestImpl restored = newReconstructed("Foo");
+        restored.restoreState(facesContext, delta);
+        assertEquals("Bar", restored.getRendererType(), "post-mark rendererType change must restore");
+
+        // Stability across a second postback: re-saving the restored component must keep the delta.
+        Object delta2 = restored.saveState(facesContext);
+        assertNotNull(delta2, "restored post-mark rendererType must persist across re-save");
+        ComponentTestImpl restored2 = newReconstructed("Foo");
+        restored2.restoreState(facesContext, delta2);
+        assertEquals("Bar", restored2.getRendererType(), "rendererType delta must survive repeated postbacks");
+
+        // Full state (component never marked) persists rendererType unconditionally, with no reconstruction.
+        ComponentTestImpl full = new ComponentTestImpl();
+        full.setRendererType("Baz");
+        Object fullState = full.saveState(facesContext);
+        ComponentTestImpl fullRestored = new ComponentTestImpl();
+        fullRestored.restoreState(facesContext, fullState);
+        assertEquals("Baz", fullRestored.getRendererType(), "full state must persist rendererType");
+
+        // Full state must restore an explicit null rendererType, overwriting a constructor-set default.
+        ComponentTestImpl nulled = new ComponentTestImpl();
+        nulled.setRendererType(null);
+        Object nulledState = nulled.saveState(facesContext);
+        ComponentTestImpl nulledRestored = new ComponentTestImpl();
+        nulledRestored.setRendererType("jakarta.faces.Text"); // a constructor-set default
+        nulledRestored.restoreState(facesContext, nulledState);
+        assertNull(nulledRestored.getRendererType(), "full state must restore an explicit null rendererType over a default");
+    }
+
+    /** A component as buildView hands it back on a postback: constructor-equivalent rendererType, then marked. */
+    private ComponentTestImpl newReconstructed(String rendererType) {
+        ComponentTestImpl component = new ComponentTestImpl();
+        component.setRendererType(rendererType);
+        component.markInitialState();
+        return component;
     }
 
     /** Calls the protected {@code getRenderer(FacesContext)} via reflection. */

--- a/impl/src/test/java/jakarta/faces/component/UIComponentBaseTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIComponentBaseTestCase.java
@@ -1550,6 +1550,21 @@ public class UIComponentBaseTestCase extends UIComponentTestCase {
         return component;
     }
 
+    /**
+     * Reading a bean-property attribute through {@code getAttributes()} invokes the cached,
+     * access-suppressed property getter (the readMap fast path). It must return the live typed value on
+     * every call — the cache holds the {@code Method}, not the value, so it must reflect later mutations.
+     */
+    @Test
+    public void testPropertyBackedAttributeReadIsRepeatableAndLive() {
+        ComponentTestImpl c = new ComponentTestImpl();
+        c.setRendererType("Foo");
+        assertEquals("Foo", c.getAttributes().get("rendererType"));
+        assertEquals("Foo", c.getAttributes().get("rendererType")); // second read hits the cached getter
+        c.setRendererType("Bar");
+        assertEquals("Bar", c.getAttributes().get("rendererType")); // cached Method, so it sees the new value
+    }
+
     /** Calls the protected {@code getRenderer(FacesContext)} via reflection. */
     private jakarta.faces.render.Renderer invokeGetRenderer(UIComponent component) throws Exception {
         java.lang.reflect.Method m = UIComponentBase.class.getDeclaredMethod("getRenderer", FacesContext.class);
@@ -1558,6 +1573,7 @@ public class UIComponentBaseTestCase extends UIComponentTestCase {
     }
 
     // --------------------------------------------------------- Private Classes
+
     public static final class Listener implements SystemEventListener {
 
         private SystemEvent event;

--- a/test/perf/src/main/java/org/eclipse/mojarra/test/perf/BuildViewBenchServlet.java
+++ b/test/perf/src/main/java/org/eclipse/mojarra/test/perf/BuildViewBenchServlet.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.eclipse.mojarra.test.perf;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import jakarta.faces.FactoryFinder;
+import jakarta.faces.application.ViewHandler;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.context.FacesContextFactory;
+import jakarta.faces.lifecycle.Lifecycle;
+import jakarta.faces.lifecycle.LifecycleFactory;
+import jakarta.faces.view.ViewDeclarationLanguage;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Isolates the Facelets {@code buildView} cost — the component-tree construction the Restore View
+ * phase pays on every postback under partial state saving — apart from state restore, render and
+ * state save. Uses only standard {@code jakarta.faces} API, so the same endpoint runs on Eclipse
+ * Mojarra and Apache MyFaces, giving an apples-to-apples buildView comparison.
+ *
+ * <p>{@code GET /buildview-bench?scenario=composite-heavy&warmup=50&runs=2000} creates a fresh
+ * {@link UIViewRoot} and calls {@link ViewDeclarationLanguage#buildView} that many times (the
+ * compiled Facelet is cached after warmup, so each measured run rebuilds the component tree without
+ * recompiling), then reports ns per build and the component count of the last tree.
+ */
+@WebServlet("/buildview-bench")
+public class BuildViewBenchServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String scenario = request.getParameter("scenario");
+        if (scenario == null || scenario.isBlank()) {
+            scenario = "composite-heavy";
+        }
+        int warmup = intParam(request, "warmup", 50);
+        int runs = intParam(request, "runs", 2000);
+        String viewId = "/" + scenario + ".xhtml";
+
+        LifecycleFactory lifecycleFactory = (LifecycleFactory) FactoryFinder.getFactory(FactoryFinder.LIFECYCLE_FACTORY);
+        Lifecycle lifecycle = lifecycleFactory.getLifecycle(LifecycleFactory.DEFAULT_LIFECYCLE);
+        FacesContextFactory facesContextFactory = (FacesContextFactory) FactoryFinder.getFactory(FactoryFinder.FACES_CONTEXT_FACTORY);
+
+        for (int i = 0; i < warmup; i++) {
+            buildOnce(facesContextFactory, lifecycle, request, response, viewId);
+        }
+
+        int count = 0;
+        long start = System.nanoTime();
+        for (int i = 0; i < runs; i++) {
+            count = buildOnce(facesContextFactory, lifecycle, request, response, viewId);
+        }
+        long elapsedNanos = System.nanoTime() - start;
+
+        response.setContentType("text/plain");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().printf(
+                "# buildview-bench scenario=%s warmup=%d runs=%d components=%d ns_per_build=%d total_ms=%d%n",
+                scenario, warmup, runs, count, elapsedNanos / runs, elapsedNanos / 1_000_000L);
+    }
+
+    /**
+     * One build under its own FacesContext — mirrors a real request, so each build's per-view state and
+     * events are released and collectible rather than accumulating across the loop.
+     */
+    private int buildOnce(FacesContextFactory facesContextFactory, Lifecycle lifecycle,
+            HttpServletRequest request, HttpServletResponse response, String viewId) throws IOException {
+        FacesContext context = facesContextFactory.getFacesContext(getServletContext(), request, response, lifecycle);
+        try {
+            ViewDeclarationLanguage vdl = context.getApplication().getViewHandler().getViewDeclarationLanguage(context, viewId);
+            UIViewRoot root = vdl.createView(context, viewId);
+            context.setViewRoot(root);
+            vdl.buildView(context, root);
+            return countComponents(root);
+        } finally {
+            context.release();
+        }
+    }
+
+    private static int countComponents(UIComponent component) {
+        int count = 1;
+        for (Iterator<UIComponent> it = component.getFacetsAndChildren(); it.hasNext();) {
+            count += countComponents(it.next());
+        }
+        return count;
+    }
+
+    private static int intParam(HttpServletRequest request, String name, int defaultValue) {
+        String value = request.getParameter(name);
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+}

--- a/test/perf/src/main/java/org/eclipse/mojarra/test/perf/RenderResponseBenchServlet.java
+++ b/test/perf/src/main/java/org/eclipse/mojarra/test/perf/RenderResponseBenchServlet.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.eclipse.mojarra.test.perf;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import jakarta.faces.FactoryFinder;
+import jakarta.faces.application.ViewHandler;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.context.FacesContextFactory;
+import jakarta.faces.context.ResponseWriter;
+import jakarta.faces.lifecycle.Lifecycle;
+import jakarta.faces.lifecycle.LifecycleFactory;
+import jakarta.faces.view.ViewDeclarationLanguage;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Isolates the Render Response encode cost — the {@code encodeAll} tree walk — apart from buildView,
+ * state restore and state save. The scenario view is built once, then re-rendered to a discarding
+ * counting writer; uses only standard {@code jakarta.faces} API, so the same endpoint runs on Mojarra
+ * and MyFaces for an apples-to-apples render comparison.
+ *
+ * <p>{@code GET /renderresponse-bench?scenario=composite-heavy&warmup=50&runs=2000} reports ns per
+ * render and the output character count.
+ */
+@WebServlet("/renderresponse-bench")
+public class RenderResponseBenchServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String scenario = request.getParameter("scenario");
+        if (scenario == null || scenario.isBlank()) {
+            scenario = "composite-heavy";
+        }
+        int warmup = intParam(request, "warmup", 50);
+        int runs = intParam(request, "runs", 2000);
+        String viewId = "/" + scenario + ".xhtml";
+
+        LifecycleFactory lifecycleFactory = (LifecycleFactory) FactoryFinder.getFactory(FactoryFinder.LIFECYCLE_FACTORY);
+        Lifecycle lifecycle = lifecycleFactory.getLifecycle(LifecycleFactory.DEFAULT_LIFECYCLE);
+        FacesContextFactory facesContextFactory = (FacesContextFactory) FactoryFinder.getFactory(FactoryFinder.FACES_CONTEXT_FACTORY);
+        FacesContext context = facesContextFactory.getFacesContext(getServletContext(), request, response, lifecycle);
+
+        long elapsedNanos;
+        long chars;
+        try {
+            ViewHandler viewHandler = context.getApplication().getViewHandler();
+            ViewDeclarationLanguage vdl = viewHandler.getViewDeclarationLanguage(context, viewId);
+
+            UIViewRoot root = vdl.createView(context, viewId);
+            context.setViewRoot(root);
+            vdl.buildView(context, root); // build once; the loop measures only the encode walk
+
+            CountingWriter sink = new CountingWriter();
+            ResponseWriter writer = context.getRenderKit().createResponseWriter(sink, "text/html", "UTF-8");
+            context.setResponseWriter(writer);
+
+            for (int i = 0; i < warmup; i++) {
+                sink.count = 0;
+                root.encodeAll(context);
+            }
+
+            long start = System.nanoTime();
+            for (int i = 0; i < runs; i++) {
+                sink.count = 0;
+                root.encodeAll(context);
+            }
+            elapsedNanos = System.nanoTime() - start;
+            chars = sink.count;
+        } finally {
+            context.release();
+        }
+
+        response.setContentType("text/plain");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().printf(
+                "# renderresponse-bench scenario=%s warmup=%d runs=%d chars=%d ns_per_render=%d total_ms=%d%n",
+                scenario, warmup, runs, chars, elapsedNanos / runs, elapsedNanos / 1_000_000L);
+    }
+
+    private static int intParam(HttpServletRequest request, String name, int defaultValue) {
+        String value = request.getParameter(name);
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    /** Discards rendered output, counting characters so the work isn't dead-code-eliminated. */
+    private static final class CountingWriter extends Writer {
+        private long count;
+
+        @Override
+        public void write(char[] cbuf, int off, int len) {
+            count += len;
+        }
+
+        @Override
+        public void write(int c) {
+            count++;
+        }
+
+        @Override
+        public void write(String str, int off, int len) {
+            count += len;
+        }
+
+        @Override
+        public void flush() {
+            // no-op
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+    }
+}

--- a/test/perf/src/test/java/org/eclipse/mojarra/test/perf/BuildViewBenchIT.java
+++ b/test/perf/src/test/java/org/eclipse/mojarra/test/perf/BuildViewBenchIT.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.eclipse.mojarra.test.perf;
+
+import static java.lang.Integer.getInteger;
+import static java.net.http.HttpResponse.BodyHandlers.ofString;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.Duration.ofSeconds;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.eclipse.mojarra.test.base.BaseIT;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.openqa.selenium.WebDriver;
+
+/**
+ * Drives {@link BuildViewBenchServlet} so a JFR recording captures only the Facelets buildView loop
+ * (no render, no state save/restore). Run on Mojarra and on MyFaces (via the {@code -*-myfaces}
+ * profiles) and diff the recordings to see where Mojarra's buildView does more work.
+ *
+ * <p>Gated behind {@code -Dbuildview=true}. Iteration counts reuse {@code -Dperf.warmup}/{@code
+ * -Dperf.runs} (defaults 50/2000); {@code -Dperf.scenarios=<one>} selects the view (default
+ * composite-heavy).
+ */
+@EnabledIfSystemProperty(named = "buildview", matches = "true")
+class BuildViewBenchIT extends BaseIT {
+
+    private static final int WARMUP = getInteger("perf.warmup", 50);
+    private static final int RUNS = getInteger("perf.runs", 2000);
+
+    @Override
+    public void setup() {
+        // intentionally empty: browser is unused, the servlet drives buildView server-side
+    }
+
+    @Override
+    public void teardown() {
+        WebDriver driver = this.browser;
+        if (driver != null) {
+            driver.quit();
+        }
+    }
+
+    @Test
+    void buildView() throws Exception {
+        String scenario = System.getProperty("perf.scenarios", "composite-heavy").trim();
+        if (scenario.isEmpty() || scenario.contains(",")) {
+            scenario = "composite-heavy";
+        }
+
+        HttpClient client = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .connectTimeout(ofSeconds(10))
+                .build();
+
+        String url = baseURL + "buildview-bench?scenario=" + scenario + "&warmup=" + WARMUP + "&runs=" + RUNS;
+        HttpRequest request = HttpRequest.newBuilder(URI.create(url)).timeout(ofSeconds(600)).GET().build();
+        HttpResponse<String> response = client.send(request, ofString(UTF_8));
+
+        assertEquals(200, response.statusCode(), "buildview-bench");
+        System.out.println();
+        System.out.println(response.body());
+    }
+}

--- a/test/perf/src/test/java/org/eclipse/mojarra/test/perf/RenderResponseBenchIT.java
+++ b/test/perf/src/test/java/org/eclipse/mojarra/test/perf/RenderResponseBenchIT.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.eclipse.mojarra.test.perf;
+
+import static java.lang.Integer.getInteger;
+import static java.net.http.HttpResponse.BodyHandlers.ofString;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.Duration.ofSeconds;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.eclipse.mojarra.test.base.BaseIT;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.openqa.selenium.WebDriver;
+
+/**
+ * Drives {@link RenderResponseBenchServlet} so a JFR recording captures only the encode walk (no
+ * buildView, no state save/restore). Run on Mojarra and on MyFaces (via the {@code -*-myfaces}
+ * profiles) and diff the recordings to see where Mojarra's render does more work.
+ *
+ * <p>Gated behind {@code -Drender=true}. Iteration counts reuse {@code -Dperf.warmup}/{@code
+ * -Dperf.runs} (defaults 50/2000); {@code -Dperf.scenarios=<one>} selects the view (default
+ * composite-heavy).
+ */
+@EnabledIfSystemProperty(named = "render", matches = "true")
+class RenderResponseBenchIT extends BaseIT {
+
+    private static final int WARMUP = getInteger("perf.warmup", 50);
+    private static final int RUNS = getInteger("perf.runs", 2000);
+
+    @Override
+    public void setup() {
+        // intentionally empty: browser is unused, the servlet drives encode server-side
+    }
+
+    @Override
+    public void teardown() {
+        WebDriver driver = this.browser;
+        if (driver != null) {
+            driver.quit();
+        }
+    }
+
+    @Test
+    void renderResponse() throws Exception {
+        String scenario = System.getProperty("perf.scenarios", "composite-heavy").trim();
+        if (scenario.isEmpty() || scenario.contains(",")) {
+            scenario = "composite-heavy";
+        }
+
+        HttpClient client = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .connectTimeout(ofSeconds(10))
+                .build();
+
+        String url = baseURL + "renderresponse-bench?scenario=" + scenario + "&warmup=" + WARMUP + "&runs=" + RUNS;
+        HttpRequest request = HttpRequest.newBuilder(URI.create(url)).timeout(ofSeconds(600)).GET().build();
+        HttpResponse<String> response = client.send(request, ofString(UTF_8));
+
+        assertEquals(200, response.statusCode(), "renderresponse-bench");
+        System.out.println();
+        System.out.println(response.body());
+    }
+}


### PR DESCRIPTION
A bundle of small, independent, JFR-guided reductions in per-component **buildView** (`RESTORE_VIEW`) and **render** (`RENDER_RESPONSE`) overhead — the two phases the prior cross-server round flagged as Mojarra's remaining deficits. Each was measured with interleaved before/after A/Bs on Tomcat (composite-heavy: ~3000 components, #4811-scale). Part of the perf work tracked in #5753.

## Production changes

**1. Lazily allocate `ComponentStateHelper.defaultMap`.** `defaultMap` was eagerly `new HashMap<>()` in the constructor, so every component got a 16-slot map whether or not it ever stored state (~3000 allocations per postback on composite-heavy). `deltaMap` was already lazy; `defaultMap` now allocates on first write (reads/remove/save treat null as empty). Semantics unchanged, save/restore null-safe. Modest alone (~6% fewer HashMap allocations; CPU/wall flat), but it's what lets the leaf components below allocate *zero* state maps.

**2. Mark/clear UIOutput converter via the field, not `getConverter()`.** `markInitialState`/`clearInitialState` called `getConverter()` only to test for a `PartialStateHolder`; for a converterless component that's a per-component `getValueExpression("converter")` lookup, and buildView marks every component — JFR put it at **11.7% of composite-heavy buildView, 0% after**. Only an explicitly-installed converter (the field) can be a PartialStateHolder worth marking; matches MyFaces.

**3. Field-back `rendererType` (UIComponentBase).** Every component sets `rendererType` from its constructor → a `HashMap` put into `defaultMap`. For the common value-expression-bound leaf (e.g. `<h:outputText value="#{..}"/>`) the renderer type is the *only* would-be StateHelper entry, so backing it with a field (plus change 1) keeps `defaultMap` unallocated entirely and turns every `getRenderer`/`getRendererType` read into a field read. Partial-state contract preserved: constructor sets it before `markInitialState`, so `buildView` reconstructs it and it rides in the delta only when changed afterwards; full state persists it unconditionally (including an explicit null), like `id`. → **buildView −10%, render −10%.**

**4. Suppress the reflective access check on cached `AttributesMap` getters.** `AttributesMap.get` caches a property getter (`readMap`) and invokes it on every property-backed attribute read — hot when a renderer reads pass-through attributes and on `UIData`/`UIRepeat` row re-render. `getDescriptorMap` already called `setAccessible(true)`, but `PropertyDescriptor.getReadMethod()` returns the method via a soft `Reference` that can be regenerated, so the instance actually cached and invoked was a different, non-suppressed one. Suppress it on the `readMap`-cached instance via a shared helper. → **render −2.6%** (JFR: access-check samples under `invokeReadMethod` 9 → 0).

## Benchmark harnesses (test/perf)

Two isolated, build-once-then-loop harnesses added so each phase can be profiled apart from state save/restore, using only standard `jakarta.faces` API so the **same endpoint runs on Mojarra and MyFaces**:
- `BuildViewBenchServlet`/`BuildViewBenchIT` (`-Dbuildview=true`) — the Facelets `buildView` tree construction.
- `RenderResponseBenchServlet`/`RenderResponseBenchIT` (`-Drender=true`) — the `encodeAll` walk to a counting/discarding writer.

These drove the measurements above and the cross-server numbers posted to #5753.

## Scope / what was deliberately left out
The remaining gap to MyFaces is structural HashMap-lookup volume (`ComponentStateHelper.get`) plus composite/Facelet machinery — closing it needs the generated-component common-attribute field-backing campaign, out of scope here. Two approaches were prototyped and rejected by measurement: an array-backed small-map for `ComponentStateHelper` (swapping the container is a floor, not a win) and a MyFaces-style encode-scoped `isRendered` cache (no wall-clock gain — `eval(rendered)` is already cheap after change 3, and an `encodeAll` override on every component cancels it).

## State format
`rendererType` moves out of the StateHelper, changing the saved-state array layout (not spec-defined — only the round-tripped values are). Validated against the full Faces TCK on the 5.0 backport (faces20 api component suite green), including `stateHolderSaveRestoreStateTest`'s explicit-null `rendererType` round-trip.

## Testing
New unit tests in `UIComponentBaseTestCase` (rendererType partial/full-state round-trip incl. multi-postback stability and the explicit-null full-state case; property-backed attribute read stays live). Full `jakarta.faces.component` suite green.

🤖 Generated with Claude Opus 4.8
