### PR TITLE
Fix NPE rendering h:inputText with pt: attribute and f:ajax #5772

### DIFF
--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/TextRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/TextRenderer.java
@@ -133,7 +133,7 @@ public class TextRenderer extends HtmlBasicInputRenderer {
 
             // style is rendered as a passthru attribute
             Attribute[] attributes = component instanceof HtmlInputFile ? INPUTFILE_ATTRIBUTES : INPUTTEXT_ATTRIBUTES;
-            RenderKitUtils.renderPassThruAttributes(context, writer, component, null, hasPassthroughAttributes, attributes, "change", "valueChange");
+            RenderKitUtils.renderPassThruAttributes(context, writer, component, null, false, attributes, "change", "valueChange");
             RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, component);
 
             writer.endElement("input");

--- a/test/issue5772/pom.xml
+++ b/test/issue5772/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.mojarra.test</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.0.19-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>issue5772</artifactId>
+    <packaging>war</packaging>
+
+    <name>Mojarra ${project.version} - INTEGRATION TESTS - ${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.mojarra.test</groupId>
+            <artifactId>base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/test/issue5772/src/main/java/org/eclipse/mojarra/test/issue5772/Issue5772.java
+++ b/test/issue5772/src/main/java/org/eclipse/mojarra/test/issue5772/Issue5772.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.eclipse.mojarra.test.issue5772;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class Issue5772 {
+
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/test/issue5772/src/main/webapp/WEB-INF/beans.xml
+++ b/test/issue5772/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0" bean-discovery-mode="all">
+</beans>

--- a/test/issue5772/src/main/webapp/WEB-INF/web.xml
+++ b/test/issue5772/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+    version="6.0"
+>
+    <servlet>
+        <servlet-name>facesServlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>facesServlet</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/test/issue5772/src/main/webapp/issue5772.xhtml
+++ b/test/issue5772/src/main/webapp/issue5772.xhtml
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html
+    xmlns:f="jakarta.faces.core"
+    xmlns:h="jakarta.faces.html"
+    xmlns:pt="jakarta.faces.passthrough"
+>
+    <h:head>
+        <title>issue 5772</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <h:inputText id="name" value="#{issue5772.name}" pt:placeholder="Name">
+                <f:ajax event="change" execute="@form" render="@form" />
+            </h:inputText>
+            <h:outputText id="echo" value="#{issue5772.name}" />
+        </h:form>
+    </h:body>
+</html>

--- a/test/issue5772/src/test/java/org/eclipse/mojarra/test/issue5772/Issue5772IT.java
+++ b/test/issue5772/src/test/java/org/eclipse/mojarra/test/issue5772/Issue5772IT.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package org.eclipse.mojarra.test.issue5772;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.mojarra.test.base.BaseIT;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+class Issue5772IT extends BaseIT {
+
+    @FindBy(id = "form:name")
+    private WebElement name;
+
+    @FindBy(id = "form:echo")
+    private WebElement echo;
+
+    /**
+     * An h:inputText that combines a pass through attribute with an f:ajax behavior must render correctly and its
+     * ajax behavior must keep working: the pass through attribute is rendered verbatim and the change event triggers
+     * an ajax request that executes and re-renders the form, so the submitted value round-trips back to the view.
+     *
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/5772
+     */
+    @Test
+    void test() {
+        open("issue5772.xhtml");
+
+        // Pass through attribute is rendered verbatim onto the input element.
+        assertEquals("Name", name.getAttribute("placeholder"));
+
+        // The f:ajax change behavior executes and re-renders the form, so the value round-trips.
+        guardAjax(() -> {
+            name.sendKeys("John");
+            name.sendKeys(Keys.TAB);
+        });
+        assertEquals("John", echo.getText());
+    }
+}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -55,6 +55,7 @@
         <module>issue5663</module>
         <module>issue5676</module>
         <module>issue5750</module>
+        <module>issue5772</module>
         <module>perf</module>
     </modules>
 


### PR DESCRIPTION
## Problem

An `h:inputText` that combines a pass through attribute with a nested `f:ajax` throws a `NullPointerException` during rendering (reported on 4.1.10-SNAPSHOT in #5772):

```xml
<h:inputText id="name" value="#{bean.name}" pt:placeholder="Name">
    <f:ajax event="change" execute="@form" render="@form" />
</h:inputText>
```

```
java.lang.NullPointerException
	at java.base/java.util.ImmutableCollections$List12.indexOf(...)
	at com.sun.faces.renderkit.html_basic.AjaxBehaviorRenderer.buildAjaxCommand(AjaxBehaviorRenderer.java:169)
	...
	at com.sun.faces.renderkit.html_basic.TextRenderer.getEndTextToRender(TextRenderer.java:129)
```

## Root cause

A regression from the [CSP work](https://github.com/eclipse-ee4j/mojarra/commit/082789beb22b1f45d54372709fd1c788b29e77dd#diff-9121e1f526f626a317e2f428443323b0685353c7736608712fd0a3a46d8ebd52). `RenderKitUtils.renderPassThruAttributes` gained a `boolean incExec` parameter, but `TextRenderer` passed the local `hasPassthroughAttributes` into that slot instead of `false`.

When an `h:inputText` carries both a `pt:` attribute and an `f:ajax` behavior, the `true` value wrongly triggers the `h:selectManyCheckbox`-only `incExec` workaround in `AjaxBehaviorRenderer.buildAjaxCommand`, which calls `execute.contains(sourceId)` with a `null` `sourceId`. On 4.1+ the `@form`/`@this`/… keyword lists are immutable `List.of(...)`, whose `contains(null)` throws; on 4.0 it does not NPE but still emits a spurious `incExec` param and pollutes the `execute` list with the source client id.

## Fix

Pass `false`, matching every sibling input renderer (`TextareaRenderer`, `SecretRenderer`, `MenuRenderer`, `CheckboxRenderer`, `RadioRenderer`, `SelectManyCheckboxListRenderer`).

## Test

New integration test `test/issue5772/` reproducing the exact trigger. It asserts only spec-observable behavior — the pass through attribute renders verbatim and the `f:ajax` change behavior round-trips the submitted value through the re-rendered form — no Mojarra internals. Verified green with the fix; on 4.1+/5.0 it guards the NPE (the page would otherwise fail to render).

Closes #5772

🤖 Generated with Claude Opus 4.8
