### PR TITLE
Regression fixes after resurrecting lost tck

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/config/processor/AbstractConfigProcessor.java
+++ b/impl/src/main/java/org/glassfish/mojarra/config/processor/AbstractConfigProcessor.java
@@ -36,6 +36,11 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.AnnotatedType;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.enterprise.inject.spi.InjectionTarget;
 import jakarta.faces.FacesException;
 import jakarta.faces.FactoryFinder;
 import jakarta.faces.application.Application;
@@ -216,19 +221,10 @@ public abstract class AbstractConfigProcessor implements ConfigProcessor {
                     ApplicationInstanceFactoryMetadataMap<String, Object> classMetadataMap = getClassMetadataMap(sc);
 
                     if (classMetadataMap.hasAnnotations(className) && performInjection) {
-                        InjectionProvider injectionProvider = (InjectionProvider) facesContext.getAttributes().get(INJECTION_PROVIDER_KEY);
-
                         try {
-                            injectionProvider.inject(returnObject);
-                        } catch (InjectionProviderException ex) {
-                            LOGGER.log(SEVERE, "Unable to inject instance" + className, ex);
-                            throw new FacesException(ex);
-                        }
-
-                        try {
-                            injectionProvider.invokePostConstruct(returnObject);
-                        } catch (InjectionProviderException ex) {
-                            LOGGER.log(SEVERE, "Unable to invoke @PostConstruct annotated method on instance " + className, ex);
+                            injectAndPostConstruct(clazz, returnObject);
+                        } catch (Exception ex) {
+                            LOGGER.log(SEVERE, "Unable to inject instance " + className, ex);
                             throw new FacesException(ex);
                         }
 
@@ -303,6 +299,22 @@ public abstract class AbstractConfigProcessor implements ConfigProcessor {
     }
 
     // --------------------------------------------------------- Private Methods
+
+    /**
+     * Perform Jakarta EE resource injection ({@code @Resource}, {@code @Inject}, ...) and invoke {@code @PostConstruct} on
+     * a faces-config-declared artifact via CDI's non-contextual {@link InjectionTarget}. This delegates resource resolution
+     * to the container the same way {@code FactoryFinderInstance} already injects factories; the legacy container-provided
+     * {@code InjectionProvider} is no longer available in all environments.
+     */
+    private static <T> void injectAndPostConstruct(Class<T> clazz, Object instance) {
+        BeanManager beanManager = CDI.current().getBeanManager();
+        AnnotatedType<T> annotatedType = beanManager.createAnnotatedType(clazz);
+        InjectionTarget<T> injectionTarget = beanManager.getInjectionTargetFactory(annotatedType).createInjectionTarget(null);
+        T typedInstance = clazz.cast(instance);
+        CreationalContext<T> creationalContext = beanManager.createCreationalContext(null);
+        injectionTarget.inject(typedInstance, creationalContext);
+        injectionTarget.postConstruct(typedInstance);
+    }
 
     private String buildMessage(String cause, Node source) {
         return MessageFormat.format("\n  Source Document: {0}\n  Cause: {1}", source.getOwnerDocument().getDocumentURI(), cause);

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/HtmlResponseWriter.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/HtmlResponseWriter.java
@@ -1159,7 +1159,12 @@ public class HtmlResponseWriter extends ResponseWriter {
     }
 
     private String getElementName(String name) {
-        if (containsPassThroughAttribute(Renderer.PASSTHROUGH_RENDERER_LOCALNAME_KEY)) {
+        // The passthrough localName applies only to the element itself, never to framework-generated
+        // <script>/<style> elements (e.g. the CSP behavior-listener script written by renderScript()
+        // for a passthrough element that holds a client behavior such as f:ajax).
+        ElementKind kind = ElementKind.of(name);
+        if (kind != ElementKind.SCRIPT && kind != ElementKind.STYLE
+                && containsPassThroughAttribute(Renderer.PASSTHROUGH_RENDERER_LOCALNAME_KEY)) {
             FacesContext context = FacesContext.getCurrentInstance();
 
             String elementName = getAttributeValue(context, passthroughAttributes.get(Renderer.PASSTHROUGH_RENDERER_LOCALNAME_KEY));

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/PassthroughRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/PassthroughRenderer.java
@@ -22,8 +22,10 @@ import java.util.Map;
 
 import jakarta.faces.FacesException;
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.html.HtmlEvents.HtmlDocumentElementEvent;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
+import jakarta.faces.event.BehaviorEvent.FacesComponentEvent;
 import jakarta.faces.render.Renderer;
 
 import org.glassfish.mojarra.renderkit.Attribute;
@@ -57,7 +59,13 @@ public class PassthroughRenderer extends HtmlBasicRenderer {
 
         writeIdAttributeIfNecessary(context, writer, component);
 
-        RenderKitUtils.renderPassThruAttributes(context, writer, component, ATTRIBUTES);
+        // A passthrough element is a ClientBehaviorHolder whose default event is "click". Pass the
+        // client behaviors through so non-default DOM events (e.g. mouseover) are rendered here, and
+        // render the default click/action behavior separately - both are queued as CSP-safe event
+        // listeners that encodeEnd() flushes via flushPendingBehaviorEventListeners().
+        RenderKitUtils.renderPassThruAttributes(context, writer, component, null, false, ATTRIBUTES,
+                HtmlDocumentElementEvent.click, FacesComponentEvent.action);
+        RenderKitUtils.renderOnclickEventListener(context, component, null, null, false);
 
     }
 

--- a/impl/src/main/ts/faces/ajax.ts
+++ b/impl/src/main/ts/faces/ajax.ts
@@ -762,7 +762,24 @@ export const ajax = (function () {
          */
         const getHiddenStateField = function getHiddenStateField(form: HTMLFormElement, hiddenStateFieldName: string, namingContainerPrefix?: string): Element | null {
             const fullHiddenStateFieldName = namingContainerPrefix ? namingContainerPrefix + hiddenStateFieldName : hiddenStateFieldName;
-            return getFormInputElementByName(form, fullHiddenStateFieldName);
+            const field = getFormInputElementByName(form, fullHiddenStateFieldName);
+
+            if (field) {
+                return field;
+            }
+
+            // In a namespaced view the field name is <namingContainerPrefix>jakarta.faces.ViewState<sep><counter>,
+            // which the exact-name lookup above misses when the prefix is not yet known. Fall back to the first
+            // form input whose name contains the state field name so the prefix can be derived from it.
+            for (const element of Array.from(form.elements)) {
+                const name = (element as HTMLInputElement).name;
+
+                if (name && name.indexOf(hiddenStateFieldName) >= 0) {
+                    return element;
+                }
+            }
+
+            return null;
         };
 
         /**

--- a/impl/src/main/ts/faces/api.ts
+++ b/impl/src/main/ts/faces/api.ts
@@ -137,8 +137,12 @@ export const getPartialViewState = function getPartialViewState(form: HTMLFormEl
         params.append(form.id, form.id);
     }
 
+    // ViewState/ClientWindow are always included; in a namespaced view their field names carry the
+    // view root container prefix (e.g. "vr:jakarta.faces.ViewState:0"), so match by substring.
+    const isAlwaysExecuted = (name: string): boolean => ALWAYS_EXECUTE_IDS.some(id => name.indexOf(id) >= 0);
+
     const addField = (name: string, value: string): void => {
-        const add = !partialExecuteIds || partialExecuteIds.includes(name) || containsNamedChild(partialExecuteDomElements, name);
+        const add = !partialExecuteIds || partialExecuteIds.includes(name) || isAlwaysExecuted(name) || containsNamedChild(partialExecuteDomElements, name);
         if (add) params.append(name, value);
     };
 

--- a/impl/src/test/ts/spec/faces.ajax.test.ts
+++ b/impl/src/test/ts/spec/faces.ajax.test.ts
@@ -2130,13 +2130,66 @@ describe("faces.ajax.request: multipart/form-data", () => {
 
 // faces.ajax.request: namingContainer prefix (Spec790 / portlet)
 // ----------------------------------------------------------------
-// Intentionally NOT covered by unit tests: namespaceParametersIfNecessary() only fires when
-// the form's ViewState element name has a UIViewRoot-container prefix
-// (e.g. "vr1:jakarta.faces.ViewState"). request() locates the viewstate via
-// `getHiddenStateField(form, VIEW_STATE_PARAM)` which uses HTMLFormElement.namedItem with the
-// bare name; in jsdom we have not been able to construct a form where that lookup succeeds
-// AND the found element's name has the prefix. The Faces TCK / integration tests cover this
-// path end-to-end against a live container.
+// When the UIViewRoot is a NamingContainer, the ViewState field name is prefixed with the view
+// root container client id, e.g. "MyNamingContainer:jakarta.faces.ViewState:0". request() must
+// still locate that field (without yet knowing the prefix) so it can derive the prefix and
+// namespace the partial-request params. Only namespaceParametersIfNecessary() — the prefixing of
+// relative render/execute target ids — remains covered by the Faces TCK / integration tests
+// against a live container.
+
+describe("faces.ajax.request: namespaced view (NamingContainer view root)", () => {
+    const PREFIX = "MyNamingContainer:";
+    let form: HTMLFormElement;
+    let button: HTMLButtonElement;
+
+    beforeEach(() => {
+        installMockXHR();
+
+        form = document.createElement("form");
+        form.id = PREFIX + "testForm";
+        form.method = "post";
+        form.action = "/test/action";
+
+        // In a namespaced view the field name is <prefix>jakarta.faces.ViewState<sep><counter>,
+        // which an exact-name lookup for "jakarta.faces.ViewState" would miss.
+        const viewState = Object.assign(document.createElement("input"), {
+            type: "hidden",
+            name: PREFIX + "jakarta.faces.ViewState:0",
+            value: "testViewState123",
+        });
+        form.appendChild(viewState);
+
+        button = document.createElement("button");
+        button.type = "button";
+        button.id = PREFIX + "testButton";
+        button.name = PREFIX + "testButton";
+        form.appendChild(button);
+
+        document.body.appendChild(form);
+    });
+
+    afterEach(() => {
+        form?.remove();
+        uninstallMockXHR();
+    });
+
+    test("finds the namespaced ViewState field instead of throwing 'no view state element'", () => {
+        expect(() => ajax().request(button, null)).not.toThrow();
+    });
+
+    test("derives the namespace prefix and namespaces the source and ajax params", () => {
+        ajax().request(button, null);
+        const body = decodeURIComponent(lastXHR().body!);
+        expect(body).toContain(PREFIX + "jakarta.faces.source=" + PREFIX + "testButton");
+        expect(body).toContain(PREFIX + "jakarta.faces.partial.ajax=true");
+    });
+
+    test("includes the namespaced ViewState value", () => {
+        ajax().request(button, null);
+        const body = decodeURIComponent(lastXHR().body!);
+        expect(body).toContain(PREFIX + "jakarta.faces.ViewState:0=testViewState123");
+    });
+});
 
 describe("faces.ajax.response: cloneAttributes dataset and XML branch", () => {
     let form: HTMLFormElement;


### PR DESCRIPTION
Regression fixes surfaced by the resurrected Faces TCK runs. Three independent fixes:

**1. f:ajax/client behaviors not rendering on `jsf:` passthrough elements** (ee1fad6)

The CSP rework (jakartaee/faces#1590) added `flushPendingBehaviorEventListeners` to `PassthroughRenderer.encodeEnd` but never queued the behaviors in `encodeBegin`, so `f:ajax` and other client behaviors on passthrough HTML5 elements (article, aside, nav, section, h1-h6, ...) emitted no event handler and never fired. `encodeBegin` now passes the client behaviors through the behavior-aware `renderPassThruAttributes` overload and renders the default click/action behavior explicitly; `HtmlResponseWriter.getElementName` no longer substitutes the passthrough localName for framework-generated `<script>`/`<style>` elements.

**2. Namespaced ViewState handling in faces.ajax** (f046806)

In a namespaced view (UIViewRoot is a NamingContainer, e.g. a portlet), the ViewState field is named `<prefix>jakarta.faces.ViewState<sep><counter>`. Two namespace-aware lookups were lost in the faces.js TypeScript migration (#5728) and optional-partial-submit rework (#5141), so `faces.ajax.request` threw "Form has no view state element". Restored the `form.elements` substring fallback in `getHiddenStateField` and substring matching for the always-included ViewState/ClientWindow params in `getPartialViewState`. Added Jest coverage for the namespaced path. Caught by the TCK Spec790 portlet-namespacing test.

**3. faces-config artifact injection via CDI InjectionTarget** (22a0007)

Resource injection (`@Resource`, `@Inject`) and `@PostConstruct` on faces-config-declared artifacts (factories, ActionListener, NavigationHandler, PhaseListener, ...) went through the container-provided InjectionProvider, which is not available in all environments. Now delegates to CDI's non-contextual InjectionTarget, the same mechanism FactoryFinderInstance already uses. Caught by the TCK Spec763 injection test.

---

https://github.com/jakartaee/faces/pull/2181

Will backport to 4.x once merged.
