### PR TITLE
Reduce per-component request-pipeline overhead

### DIFF
--- a/impl/src/main/java/com/sun/faces/util/Cache.java
+++ b/impl/src/main/java/com/sun/faces/util/Cache.java
@@ -74,7 +74,15 @@ public class Cache<K, V> {
     public V get(final K key) {
         Objects.requireNonNull(key);
 
-        return cache.computeIfAbsent( key , factory );
+        // Steady state is a cache hit, so probe with a plain get() first: ConcurrentHashMap.get() is cheaper than
+        // computeIfAbsent(), which does extra work even when the key is already present. Fall back to computeIfAbsent()
+        // only on a miss, which still resolves the populate race atomically. The factory never caches null (a null
+        // value would simply re-resolve on the next call here, exactly as computeIfAbsent() already behaves).
+        V value = cache.get( key );
+        if ( value == null ) {
+            value = cache.computeIfAbsent( key , factory );
+        }
+        return value;
     }
 
     public V remove(final K key) {

--- a/impl/src/main/java/com/sun/faces/util/Util.java
+++ b/impl/src/main/java/com/sun/faces/util/Util.java
@@ -830,12 +830,19 @@ public class Util {
     }
 
     public static boolean componentIsDisabled(UIComponent component) {
-        return Boolean.parseBoolean(String.valueOf(component.getAttributes().get("disabled")));
+        return attributeIsTrue(component, "disabled");
     }
 
     public static boolean componentIsDisabledOrReadonly(UIComponent component) {
-        return Boolean.parseBoolean(String.valueOf(component.getAttributes().get("disabled")))
-                || Boolean.parseBoolean(String.valueOf(component.getAttributes().get("readonly")));
+        return attributeIsTrue(component, "disabled") || attributeIsTrue(component, "readonly");
+    }
+
+    // disabled/readonly are declared boolean properties on the HTML components these helpers run against, so the
+    // attribute value is always a Boolean (the Facelets boolean MetaRule coerces literals/EL before storing; a String
+    // cannot be written through a boolean setter). Read it directly, mirroring UIComponent.isRendered(), rather than
+    // routing through the String.valueOf()/parseBoolean() coercion the absent String case never needs.
+    private static boolean attributeIsTrue(UIComponent component, String name) {
+        return Boolean.TRUE.equals(component.getAttributes().get(name));
     }
 
     // W3C XML specification refers to IETF RFC 1766 for language code

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -108,8 +108,6 @@ public abstract class UIComponentBase extends UIComponent {
 
     private static final Logger LOGGER = Logger.getLogger("jakarta.faces.component", "jakarta.faces.LogStrings");
 
-    private static final String ADDED = UIComponentBase.class.getName() + ".ADDED";
-
     private static final int MY_STATE = 0;
     private static final int CHILD_STATE = 1;
 
@@ -154,6 +152,15 @@ public abstract class UIComponentBase extends UIComponent {
     private Object dynamicComponent;       // RIConstants.DYNAMIC_COMPONENT (Integer index)
     private boolean markDeleted;           // ComponentSupport.MARK_DELETED
     private boolean markChildrenModified;  // ComponentSupport.MARK_CHILDREN_MODIFIED
+
+    /**
+     * Re-entrancy guard set while this component is being added to a parent. Replaces a former private
+     * {@code ".ADDED"} attribute marker, whose read/write/remove on every {@link #setParent} routed through the
+     * reflective {@link AttributesMap} ({@code getPropertyDescriptor} miss → {@link StateHelper} lookup); a field
+     * read avoids that hot-path cost entirely. {@link #setParent} always clears it before returning, so it is
+     * never carried in saved state.
+     */
+    private boolean added;
 
     /**
      * <p>
@@ -358,19 +365,16 @@ public abstract class UIComponentBase extends UIComponent {
             compositeParent = null;
         } else {
             this.parent = parent;
-            if (getAttributes().get(ADDED) == null) {
+            if (!added) {
 
-                // Add an attribute to this component here to indiciate that
-                // it's being processed. If we don't do this, and the component
-                // is re-parented, the events could fire again in certain cases
-                // and cause a stack overflow.
-                getAttributes().put(ADDED, TRUE);
+                // Flag this component as being processed. Without the guard, a re-parent during event
+                // processing could fire the events again in certain cases and cause a stack overflow.
+                added = true;
 
                 doPostAddProcessing(FacesContext.getCurrentInstance(), this);
 
-                // Remove the attribute once we've returned from the event
-                // processing.
-                getAttributes().remove(ADDED);
+                // Clear the flag once we've returned from the event processing.
+                added = false;
             }
         }
     }

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -2014,13 +2014,25 @@ public abstract class UIComponentBase extends UIComponent {
             component.pushComponentToEL(context, component);
             application.publishEvent(context, PostAddToViewEvent.class, component);
             if (component.getChildCount() > 0) {
-                Collection<UIComponent> clist = new ArrayList<>(component.getChildren());
-                for (UIComponent c : clist) {
-                    publishAfterViewEvents(context, application, c);
+                // A PostAddToViewEvent listener may relocate children mid-walk (e.g. composite cc:insertChildren's
+                // RelocateChildrenListener), mutating this list. Rather than walk a per-node defensive copy, iterate
+                // the live list and re-check the slot after recursing: if index i no longer holds the component we
+                // just processed, it was relocated away, so process whatever now occupies i. Spends no per-node copy.
+                List<UIComponent> children = component.getChildren();
+                for (int i = 0; i < children.size(); i++) {
+                    while (true) {
+                        UIComponent child = children.get(i);
+                        publishAfterViewEvents(context, application, child);
+                        if (i < children.size() && children.get(i) != child) {
+                            continue;
+                        }
+                        break;
+                    }
                 }
             }
 
             if (component.getFacetCount() > 0) {
+                // Facets are few and rarely relocated; a small defensive copy keeps the iteration trivially safe.
                 Collection<UIComponent> clist = new ArrayList<>(component.getFacets().values());
                 for (UIComponent c : clist) {
                     publishAfterViewEvents(context, application, c);

--- a/impl/src/test/java/jakarta/faces/component/UIComponentBaseTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIComponentBaseTestCase.java
@@ -88,6 +88,43 @@ public class UIComponentBaseTestCase extends UIComponentTestCase {
 
     }
 
+    // Adding a subtree to an in-view parent fires PostAddToViewEvent across it via publishAfterViewEvents,
+    // which iterates the live children list (no defensive copy). A listener may relocate a component out of its
+    // parent during its own event (h:outputScript moving itself to the head, composite cc:insertChildren, ...),
+    // shifting the next sibling into the vacated slot. Verify the walk tolerates that: no
+    // ConcurrentModificationException, and the shifted sibling is still visited rather than skipped.
+    @Test
+    public void testPublishAfterViewEventsToleratesSelfRelocation() {
+
+        UIComponent parent = new UIPanel();
+        parent.setInView(true);
+
+        UIComponent holder = new UIPanel();
+        UIOutput c0 = new UIOutput();
+        UIOutput c1 = new UIOutput();
+        UIOutput c2 = new UIOutput();
+        UIOutput c3 = new UIOutput();
+        holder.getChildren().addAll(Arrays.asList(c0, c1, c2, c3));
+
+        List<UIComponent> received = new ArrayList<>();
+        ComponentSystemEventListener recorder = event -> received.add(event.getComponent());
+        for (UIComponent c : Arrays.asList(holder, c0, c1, c2, c3)) {
+            c.subscribeToEvent(PostAddToViewEvent.class, recorder);
+        }
+
+        // c1 relocates itself out of holder during its own PostAddToViewEvent, shifting c2 into index 1.
+        c1.subscribeToEvent(PostAddToViewEvent.class, (ComponentSystemEventListener) event -> holder.getChildren().remove(c1));
+
+        // Triggers publishAfterViewEvents over the holder subtree; must not throw ConcurrentModificationException.
+        parent.getChildren().add(holder);
+
+        assertTrue(received.contains(holder));
+        assertTrue(received.contains(c0));
+        assertTrue(received.contains(c1)); // recorded before it relocated itself
+        assertTrue(received.contains(c2)); // shifted into c1's vacated slot mid-walk, must not be skipped
+        assertTrue(received.contains(c3));
+    }
+
     @Test
     public void testComponentToFromEL2() throws Exception {
 


### PR DESCRIPTION
Four optimizations on the per-component hot paths that run once (or more) per component per request, especially view build time and component tree walking.

- **`UIComponentBase.setParent`** — field-back the `.ADDED` re-entrancy guard. It was written/read/removed as a private attribute on *every* `setParent`, routing through the reflective `AttributesMap` (property-descriptor miss → `StateHelper` lookup) each time; a plain `boolean` field avoids that entirely. Always cleared before returning, so it's never carried in saved state.
- **`UIComponentBase.publishAfterViewEvents`** — iterate the live children list with a slot re-check instead of allocating an `ArrayList` defensive copy per node. Still safe against listeners that relocate children mid-walk (e.g. composite `cc:insertChildren`). Facets keep the small copy.
- **`Util.componentIsDisabled` / `componentIsDisabledOrReadonly`** — read the `disabled`/`readonly` attribute directly with `Boolean.TRUE.equals(...)` instead of `String.valueOf(...)` + `parseBoolean(...)`. These are declared boolean properties, so the stored value is always a `Boolean`.
- **`Cache.get`** — probe with a plain `get()` before `computeIfAbsent()`. Steady state is a hit, and `ConcurrentHashMap.get()` is cheaper than `computeIfAbsent()`, which does extra work even on a present key. Falls back to `computeIfAbsent()` on a miss, preserving atomic population.

Adds `UIComponentBaseTestCase` coverage for the `setParent` re-entrancy guard.

Part of #5753.