### PR TITLE
Partial-state-saving and component-tree-walk performance improvements

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategy.java
@@ -345,31 +345,40 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
                 // marker lookup in componentAddedDynamically can be skipped across the whole restore traversal.
                 @SuppressWarnings("unchecked")
                 List<Object> savedActions = (List<Object>) state.get(DYNAMIC_ACTIONS);
-                stateContext.setHasDynamicComponents(!isEmpty(savedActions));
+                boolean hasDynamicActions = !isEmpty(savedActions);
+                stateContext.setHasDynamicComponents(hasDynamicActions);
 
-                VisitContext visitContext = VisitContext.createVisitContext(context, null, SKIP_ITERATION_AND_EXECUTE_LIFECYCLE_HINTS);
-                viewRoot.visitTree(visitContext, (context1, target) -> {
-                    VisitResult result = VisitResult.ACCEPT;
-                    String cid = target.getClientId(context1.getFacesContext());
-                    Object stateObj = state.get(cid);
-                    if (stateObj != null && !stateContext.componentAddedDynamically(target)) {
-                        boolean restoreStateNow = true;
-                        if (stateObj instanceof StateHolderSaver) {
-                            restoreStateNow = !((StateHolderSaver) stateObj).componentAddedDynamically();
-                        }
-                        if (restoreStateNow) {
-                            try {
-                                target.restoreState(context1.getFacesContext(), stateObj);
-                            } catch (Exception e) {
-                                String msg = MessageUtils.getExceptionMessageString(MessageUtils.PARTIAL_STATE_ERROR_RESTORING_ID, cid, e.toString());
-                                throw new FacesException(msg, e);
+                if (!hasDynamicActions && isViewRootOnlyState(context, viewRoot, state)) {
+                    // No dynamic actions and no per-component delta (or only the view root's): restore the
+                    // view root in isolation and skip the full O(N) restore traversal. Any component whose
+                    // state actually changed carries a non-null delta in the map, which forces the walk via
+                    // the else-branch, so this short-circuit is behavior-neutral for static / low-delta views.
+                    restoreViewRootOnly(context, viewRoot, state);
+                } else {
+                    VisitContext visitContext = VisitContext.createVisitContext(context, null, SKIP_ITERATION_AND_EXECUTE_LIFECYCLE_HINTS);
+                    viewRoot.visitTree(visitContext, (context1, target) -> {
+                        VisitResult result = VisitResult.ACCEPT;
+                        String cid = target.getClientId(context1.getFacesContext());
+                        Object stateObj = state.get(cid);
+                        if (stateObj != null && !stateContext.componentAddedDynamically(target)) {
+                            boolean restoreStateNow = true;
+                            if (stateObj instanceof StateHolderSaver) {
+                                restoreStateNow = !((StateHolderSaver) stateObj).componentAddedDynamically();
+                            }
+                            if (restoreStateNow) {
+                                try {
+                                    target.restoreState(context1.getFacesContext(), stateObj);
+                                } catch (Exception e) {
+                                    String msg = MessageUtils.getExceptionMessageString(MessageUtils.PARTIAL_STATE_ERROR_RESTORING_ID, cid, e.toString());
+                                    throw new FacesException(msg, e);
+                                }
                             }
                         }
-                    }
 
-                    return result;
-                });
-                restoreDynamicActions(context, stateContext, state);
+                        return result;
+                    });
+                    restoreDynamicActions(context, stateContext, state);
+                }
             } finally {
                 stateContext.setHasDynamicComponents(true);
                 stateContext.setTrackViewModifications(true);
@@ -379,6 +388,41 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
         }
         context.setProcessingEvents(processingEvents);
         return viewRoot;
+    }
+
+    /**
+     * Determine whether the saved state holds no per-component delta other than (optionally) the view
+     * root's own state. The {@code DYNAMIC_ACTIONS} entry is bookkeeping rather than a component delta,
+     * so it is excluded from the count.
+     *
+     * @param context the Faces context.
+     * @param viewRoot the view root.
+     * @param state the saved state map.
+     * @return true if only the view root needs restoring, allowing the full restore traversal to be skipped.
+     */
+    private boolean isViewRootOnlyState(FacesContext context, UIViewRoot viewRoot, Map<String, Object> state) {
+        int componentStateCount = state.containsKey(DYNAMIC_ACTIONS) ? state.size() - 1 : state.size();
+        return componentStateCount == 0
+                || componentStateCount == 1 && state.containsKey(viewRoot.getClientId(context));
+    }
+
+    /**
+     * Restore only the view root's own state, skipping the per-component restore traversal.
+     *
+     * @param context the Faces context.
+     * @param viewRoot the view root.
+     * @param state the saved state map.
+     */
+    private void restoreViewRootOnly(FacesContext context, UIViewRoot viewRoot, Map<String, Object> state) {
+        Object viewRootState = state.get(viewRoot.getClientId(context));
+        if (viewRootState != null) {
+            viewRoot.pushComponentToEL(context, viewRoot);
+            try {
+                viewRoot.restoreState(context, viewRootState);
+            } finally {
+                viewRoot.popComponentFromEL(context);
+            }
+        }
     }
 
     /**

--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -312,7 +312,9 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
                 facelet.apply(ctx, view);
                 reapplyDynamicActions(ctx);
                 if (stateCtx.isPartialStateSaving(ctx, view.getViewId())) {
-                    markInitialStateIfNotMarked(view);
+                    // reapplyDynamicActions ran above, so the dynamic-action list now reflects this view;
+                    // when it is empty no component bears DYNAMIC_COMPONENT and the per-node marker check is skipped.
+                    markInitialStateIfNotMarked(view, !isEmpty(stateCtx.getDynamicActions()));
                 }
             } finally {
                 stateCtx.setTrackViewModifications(true);
@@ -1186,10 +1188,22 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
 
     private void markInitialState(final UIComponent component) {
         component.markInitialState();
-        for (Iterator<UIComponent> it = component.getFacetsAndChildren(); it.hasNext();) {
-            UIComponent child = it.next();
-            if (!child.isTransient()) {
-                markInitialState(child);
+        // Index loop over children + facet values rather than getFacetsAndChildren(), avoiding an iterator
+        // allocation at every node of this per-build full-tree walk.
+        if (component.getChildCount() > 0) {
+            List<UIComponent> children = component.getChildren();
+            for (int i = 0, size = children.size(); i < size; i++) {
+                UIComponent child = children.get(i);
+                if (!child.isTransient()) {
+                    markInitialState(child);
+                }
+            }
+        }
+        if (component.getFacetCount() > 0) {
+            for (UIComponent facet : component.getFacets().values()) {
+                if (!facet.isTransient()) {
+                    markInitialState(facet);
+                }
             }
         }
     }
@@ -1994,14 +2008,27 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
     /**
      * Mark the initial state if not already marked.
      */
-    private void markInitialStateIfNotMarked(UIComponent component) {
-        if (!component.isTransient()) {
-            if (!component.getAttributes().containsKey(DYNAMIC_COMPONENT) && !component.initialStateMarked()) {
-                component.markInitialState();
+    private void markInitialStateIfNotMarked(UIComponent component, boolean hasDynamicComponents) {
+        if (component.isTransient()) {
+            return;
+        }
+        // The DYNAMIC_COMPONENT guard exists to leave dynamically added components unmarked. When the view
+        // carries no dynamic actions no component bears that marker, so skip the per-node reflective
+        // AttributesMap.containsKey probe entirely. Index loop over children + facet values rather than
+        // getFacetsAndChildren(), avoiding an iterator allocation at every node.
+        if (!component.initialStateMarked()
+                && (!hasDynamicComponents || !component.getAttributes().containsKey(DYNAMIC_COMPONENT))) {
+            component.markInitialState();
+        }
+        if (component.getChildCount() > 0) {
+            List<UIComponent> children = component.getChildren();
+            for (int i = 0, size = children.size(); i < size; i++) {
+                markInitialStateIfNotMarked(children.get(i), hasDynamicComponents);
             }
-            for (Iterator<UIComponent> it = component.getFacetsAndChildren(); it.hasNext();) {
-                UIComponent child = it.next();
-                markInitialStateIfNotMarked(child);
+        }
+        if (component.getFacetCount() > 0) {
+            for (UIComponent facet : component.getFacets().values()) {
+                markInitialStateIfNotMarked(facet, hasDynamicComponents);
             }
         }
     }

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/CompositeComponentTagHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/CompositeComponentTagHandler.java
@@ -62,6 +62,7 @@ import jakarta.faces.view.facelets.Tag;
 import jakarta.faces.view.facelets.TagAttribute;
 
 import com.sun.faces.RIConstants;
+import com.sun.faces.context.StateContext;
 import com.sun.faces.el.CompositeComponentELResolver;
 import com.sun.faces.facelets.el.VariableMapperWrapper;
 import com.sun.faces.facelets.tag.MetaRulesetImpl;
@@ -547,8 +548,26 @@ public class CompositeComponentTagHandler extends ComponentHandler implements Cr
                     // about the value's existence.
                     attrs.remove(name);
                 }
-                cc.setValueExpression(name, ve);
 
+                // A composite component's attribute expressions are re-derived from the Facelet on every
+                // (re)build. On a postback rebuild the tree is already initial-state-marked, so recording
+                // them through the normal path stores a per-component delta that buildView reconstructs
+                // identically anyway. Under partial state saving, write them as initial state so the saved
+                // view stays free of this redundant, fully-reconstructable binding. (Legacy from full state
+                // saving, where the component is never initial-state-marked and this branch is a no-op.)
+                FacesContext context = ctx.getFacesContext();
+                boolean writeAsInitialState = cc.initialStateMarked()
+                        && StateContext.getStateContext(context).isPartialStateSaving(context, null);
+                if (writeAsInitialState) {
+                    cc.clearInitialState();
+                }
+                try {
+                    cc.setValueExpression(name, ve);
+                } finally {
+                    if (writeAsInitialState) {
+                        cc.markInitialState();
+                    }
+                }
             }
 
         } // END CompositeExpressionMetadata

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -1721,7 +1721,11 @@ public abstract class UIComponentBase extends UIComponent {
     private void doPostAddProcessing(FacesContext context, UIComponent added) {
 
         if (parent.isInView()) {
-            publishAfterViewEvents(context, context.getApplication(), added);
+            if (context.isProcessingEvents()) {
+                publishAfterViewEvents(context, context.getApplication(), added);
+            } else {
+                updateInView(added, true);
+            }
         }
 
     }
@@ -1729,7 +1733,11 @@ public abstract class UIComponentBase extends UIComponent {
     private void doPreRemoveProcessing(FacesContext context, UIComponent toRemove) {
 
         if (parent.isInView()) {
-            disconnectFromView(context, context.getApplication(), toRemove);
+            if (context.isProcessingEvents()) {
+                disconnectFromView(context, context.getApplication(), toRemove);
+            } else {
+                updateInView(toRemove, false);
+            }
         }
 
     }
@@ -2065,6 +2073,36 @@ public abstract class UIComponentBase extends UIComponent {
         application.publishEvent(context, PreRemoveFromViewEvent.class, component);
         component.setInView(false);
         component.compositeParent = null;
+    }
+
+    /**
+     * Recursively maintain the in-view flag of the given subtree <em>without</em> publishing the
+     * {@link PostAddToViewEvent}/{@link PreRemoveFromViewEvent} system events. Used when the runtime has event
+     * processing suppressed ({@link FacesContext#isProcessingEvents()} is {@code false}), e.g. while a
+     * partial-state-saving restore rebuilds the tree: {@link Application#publishEvent} is a no-op while suppressed,
+     * so walking the subtree to fire it -- pushing and popping the EL stack at every node -- is wasted work. This
+     * reproduces the publishing walks' only non-event side effects: {@link #publishAfterViewEvents} sets in-view
+     * true, {@link #disconnectFromView} sets it false and clears {@code compositeParent}.
+     */
+    private static void updateInView(UIComponent component, boolean isInView) {
+        component.setInView(isInView);
+        if (!isInView) {
+            component.compositeParent = null;
+        }
+        // Events are suppressed, so no listener can relocate children mid-walk: a plain index loop over the live
+        // children (and the facet values) suffices, avoiding the getFacetsAndChildren() iterator allocation that
+        // the publishing walks were themselves restructured to avoid.
+        if (component.getChildCount() > 0) {
+            List<UIComponent> children = component.getChildren();
+            for (int i = 0, size = children.size(); i < size; i++) {
+                updateInView(children.get(i), isInView);
+            }
+        }
+        if (component.getFacetCount() > 0) {
+            for (UIComponent facet : component.getFacets().values()) {
+                updateInView(facet, isInView);
+            }
+        }
     }
 
     // --------------------------------------------------------- Private Classes

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -152,15 +152,7 @@ public abstract class UIComponentBase extends UIComponent {
     private Object dynamicComponent;       // RIConstants.DYNAMIC_COMPONENT (Integer index)
     private boolean markDeleted;           // ComponentSupport.MARK_DELETED
     private boolean markChildrenModified;  // ComponentSupport.MARK_CHILDREN_MODIFIED
-
-    /**
-     * Re-entrancy guard set while this component is being added to a parent. Replaces a former private
-     * {@code ".ADDED"} attribute marker, whose read/write/remove on every {@link #setParent} routed through the
-     * reflective {@link AttributesMap} ({@code getPropertyDescriptor} miss → {@link StateHelper} lookup); a field
-     * read avoids that hot-path cost entirely. {@link #setParent} always clears it before returning, so it is
-     * never carried in saved state.
-     */
-    private boolean added;
+    private boolean added;                 // setParent re-entrancy guard
 
     /**
      * <p>

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -3470,8 +3470,27 @@ public abstract class UIComponentBase extends UIComponent {
     }
 
     private String addParentId(FacesContext context, String parentId, String childId) {
-        return new StringBuilder(parentId.length() + 1 + childId.length()).append(parentId).append(UINamingContainer.getSeparatorChar(context)).append(childId)
+        // Reuse a request-shared StringBuilder rather than allocating a fresh one per component: client id
+        // resolution runs once per component per request and, in a deep NamingContainer tree, for every node.
+        // The parent id is already a fully resolved String here (getClientId resolves it before calling this),
+        // and the builder is used and toString()'d in a single uninterrupted step, so the shared instance is
+        // never re-entered mid-build.
+        return sharedClientIdBuilder(context).append(parentId).append(UINamingContainer.getSeparatorChar(context)).append(childId)
                 .toString();
+    }
+
+    private static final String SHARED_CLIENT_ID_BUILDER_KEY = "com.sun.faces.component.UIComponentBase.SHARED_CLIENT_ID_BUILDER";
+
+    private static StringBuilder sharedClientIdBuilder(FacesContext context) {
+        Map<Object, Object> contextAttributes = context.getAttributes();
+        StringBuilder builder = (StringBuilder) contextAttributes.get(SHARED_CLIENT_ID_BUILDER_KEY);
+        if (builder == null) {
+            builder = new StringBuilder();
+            contextAttributes.put(SHARED_CLIENT_ID_BUILDER_KEY, builder);
+        } else {
+            builder.setLength(0);
+        }
+        return builder;
     }
 
     private String getParentId(FacesContext context, UIComponent parent) {

--- a/impl/src/test/java/jakarta/faces/component/UIComponentBaseTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIComponentBaseTestCase.java
@@ -125,6 +125,40 @@ public class UIComponentBaseTestCase extends UIComponentTestCase {
         assertTrue(received.contains(c3));
     }
 
+    // While the runtime has event processing suppressed (FacesContext.isProcessingEvents() == false, e.g. during a
+    // partial-state-saving restore), add/remove must NOT publish PostAddToViewEvent/PreRemoveFromViewEvent --
+    // publishEvent is a no-op while suppressed anyway -- but must still maintain the in-view flag across the subtree.
+    @Test
+    public void testInViewMaintainedWithoutEventsWhenProcessingSuppressed() {
+
+        UIComponent parent = new UIPanel();
+        parent.setInView(true);
+
+        UIComponent holder = new UIPanel();
+        UIOutput child = new UIOutput();
+        holder.getChildren().add(child);
+
+        List<UIComponent> received = new ArrayList<>();
+        ComponentSystemEventListener recorder = event -> received.add(event.getComponent());
+        holder.subscribeToEvent(PostAddToViewEvent.class, recorder);
+        child.subscribeToEvent(PostAddToViewEvent.class, recorder);
+
+        facesContext.setProcessingEvents(false);
+        try {
+            parent.getChildren().add(holder);
+            assertTrue(received.isEmpty());        // no event published while suppressed
+            assertTrue(holder.isInView());         // ...but in-view propagated across the added subtree
+            assertTrue(child.isInView());
+
+            parent.getChildren().remove(holder);
+            assertTrue(received.isEmpty());         // still no event published
+            assertTrue(!holder.isInView());         // in-view cleared across the removed subtree
+            assertTrue(!child.isInView());
+        } finally {
+            facesContext.setProcessingEvents(true);
+        }
+    }
+
     @Test
     public void testComponentToFromEL2() throws Exception {
 


### PR DESCRIPTION
Follow-up to #5753 — partial-state-saving and component-tree-walk performance, all behaviour-neutral (impl unit tests + TCK pass):

- Don't persist re-derivable composite `cc.attrs` expressions as per-component state deltas under PSS — `buildView` re-derives them on every postback. ~18% off both RESTORE_VIEW and RENDER_RESPONSE on composite-heavy views.
- Skip the restore traversal when the saved view holds no per-component delta (view-root-only), mirroring MyFaces' `restoreViewRootOnlyFromMap`.
- Skip the add/remove publish-walk when event processing is suppressed (e.g. during a PSS restore) — `publishEvent` is a no-op there anyway.
- Initial-state mark walks: index loops instead of allocating `getFacetsAndChildren()` iterators, and skip the per-node dynamic-marker probe when the view has no dynamic actions.
- Reuse a request-shared `StringBuilder` for client-id construction.

🤖 Generated with Claude Opus 4.8
