### PR TITLE
Backport #5777 and #5778 into 4.0

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategy.java
@@ -345,31 +345,40 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
                 // marker lookup in componentAddedDynamically can be skipped across the whole restore traversal.
                 @SuppressWarnings("unchecked")
                 List<Object> savedActions = (List<Object>) state.get(DYNAMIC_ACTIONS);
-                stateContext.setHasDynamicComponents(!isEmpty(savedActions));
+                boolean hasDynamicActions = !isEmpty(savedActions);
+                stateContext.setHasDynamicComponents(hasDynamicActions);
 
-                VisitContext visitContext = VisitContext.createVisitContext(context, null, SKIP_ITERATION_AND_EXECUTE_LIFECYCLE_HINTS);
-                viewRoot.visitTree(visitContext, (context1, target) -> {
-                    VisitResult result = VisitResult.ACCEPT;
-                    String cid = target.getClientId(context1.getFacesContext());
-                    Object stateObj = state.get(cid);
-                    if (stateObj != null && !stateContext.componentAddedDynamically(target)) {
-                        boolean restoreStateNow = true;
-                        if (stateObj instanceof StateHolderSaver) {
-                            restoreStateNow = !((StateHolderSaver) stateObj).componentAddedDynamically();
-                        }
-                        if (restoreStateNow) {
-                            try {
-                                target.restoreState(context1.getFacesContext(), stateObj);
-                            } catch (Exception e) {
-                                String msg = MessageUtils.getExceptionMessageString(MessageUtils.PARTIAL_STATE_ERROR_RESTORING_ID, cid, e.toString());
-                                throw new FacesException(msg, e);
+                if (!hasDynamicActions && isViewRootOnlyState(context, viewRoot, state)) {
+                    // No dynamic actions and no per-component delta (or only the view root's): restore the
+                    // view root in isolation and skip the full O(N) restore traversal. Any component whose
+                    // state actually changed carries a non-null delta in the map, which forces the walk via
+                    // the else-branch, so this short-circuit is behavior-neutral for static / low-delta views.
+                    restoreViewRootOnly(context, viewRoot, state);
+                } else {
+                    VisitContext visitContext = VisitContext.createVisitContext(context, null, SKIP_ITERATION_AND_EXECUTE_LIFECYCLE_HINTS);
+                    viewRoot.visitTree(visitContext, (context1, target) -> {
+                        VisitResult result = VisitResult.ACCEPT;
+                        String cid = target.getClientId(context1.getFacesContext());
+                        Object stateObj = state.get(cid);
+                        if (stateObj != null && !stateContext.componentAddedDynamically(target)) {
+                            boolean restoreStateNow = true;
+                            if (stateObj instanceof StateHolderSaver) {
+                                restoreStateNow = !((StateHolderSaver) stateObj).componentAddedDynamically();
+                            }
+                            if (restoreStateNow) {
+                                try {
+                                    target.restoreState(context1.getFacesContext(), stateObj);
+                                } catch (Exception e) {
+                                    String msg = MessageUtils.getExceptionMessageString(MessageUtils.PARTIAL_STATE_ERROR_RESTORING_ID, cid, e.toString());
+                                    throw new FacesException(msg, e);
+                                }
                             }
                         }
-                    }
 
-                    return result;
-                });
-                restoreDynamicActions(context, stateContext, state);
+                        return result;
+                    });
+                    restoreDynamicActions(context, stateContext, state);
+                }
             } finally {
                 stateContext.setHasDynamicComponents(true);
                 stateContext.setTrackViewModifications(true);
@@ -379,6 +388,41 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
         }
         context.setProcessingEvents(processingEvents);
         return viewRoot;
+    }
+
+    /**
+     * Determine whether the saved state holds no per-component delta other than (optionally) the view
+     * root's own state. The {@code DYNAMIC_ACTIONS} entry is bookkeeping rather than a component delta,
+     * so it is excluded from the count.
+     *
+     * @param context the Faces context.
+     * @param viewRoot the view root.
+     * @param state the saved state map.
+     * @return true if only the view root needs restoring, allowing the full restore traversal to be skipped.
+     */
+    private boolean isViewRootOnlyState(FacesContext context, UIViewRoot viewRoot, Map<String, Object> state) {
+        int componentStateCount = state.containsKey(DYNAMIC_ACTIONS) ? state.size() - 1 : state.size();
+        return componentStateCount == 0
+                || componentStateCount == 1 && state.containsKey(viewRoot.getClientId(context));
+    }
+
+    /**
+     * Restore only the view root's own state, skipping the per-component restore traversal.
+     *
+     * @param context the Faces context.
+     * @param viewRoot the view root.
+     * @param state the saved state map.
+     */
+    private void restoreViewRootOnly(FacesContext context, UIViewRoot viewRoot, Map<String, Object> state) {
+        Object viewRootState = state.get(viewRoot.getClientId(context));
+        if (viewRootState != null) {
+            viewRoot.pushComponentToEL(context, viewRoot);
+            try {
+                viewRoot.restoreState(context, viewRootState);
+            } finally {
+                viewRoot.popComponentFromEL(context);
+            }
+        }
     }
 
     /**

--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -312,7 +312,9 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
                 facelet.apply(ctx, view);
                 reapplyDynamicActions(ctx);
                 if (stateCtx.isPartialStateSaving(ctx, view.getViewId())) {
-                    markInitialStateIfNotMarked(view);
+                    // reapplyDynamicActions ran above, so the dynamic-action list now reflects this view;
+                    // when it is empty no component bears DYNAMIC_COMPONENT and the per-node marker check is skipped.
+                    markInitialStateIfNotMarked(view, !isEmpty(stateCtx.getDynamicActions()));
                 }
             } finally {
                 stateCtx.setTrackViewModifications(true);
@@ -1186,10 +1188,22 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
 
     private void markInitialState(final UIComponent component) {
         component.markInitialState();
-        for (Iterator<UIComponent> it = component.getFacetsAndChildren(); it.hasNext();) {
-            UIComponent child = it.next();
-            if (!child.isTransient()) {
-                markInitialState(child);
+        // Index loop over children + facet values rather than getFacetsAndChildren(), avoiding an iterator
+        // allocation at every node of this per-build full-tree walk.
+        if (component.getChildCount() > 0) {
+            List<UIComponent> children = component.getChildren();
+            for (int i = 0, size = children.size(); i < size; i++) {
+                UIComponent child = children.get(i);
+                if (!child.isTransient()) {
+                    markInitialState(child);
+                }
+            }
+        }
+        if (component.getFacetCount() > 0) {
+            for (UIComponent facet : component.getFacets().values()) {
+                if (!facet.isTransient()) {
+                    markInitialState(facet);
+                }
             }
         }
     }
@@ -1994,14 +2008,27 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
     /**
      * Mark the initial state if not already marked.
      */
-    private void markInitialStateIfNotMarked(UIComponent component) {
-        if (!component.isTransient()) {
-            if (!component.getAttributes().containsKey(DYNAMIC_COMPONENT) && !component.initialStateMarked()) {
-                component.markInitialState();
+    private void markInitialStateIfNotMarked(UIComponent component, boolean hasDynamicComponents) {
+        if (component.isTransient()) {
+            return;
+        }
+        // The DYNAMIC_COMPONENT guard exists to leave dynamically added components unmarked. When the view
+        // carries no dynamic actions no component bears that marker, so skip the per-node reflective
+        // AttributesMap.containsKey probe entirely. Index loop over children + facet values rather than
+        // getFacetsAndChildren(), avoiding an iterator allocation at every node.
+        if (!component.initialStateMarked()
+                && (!hasDynamicComponents || !component.getAttributes().containsKey(DYNAMIC_COMPONENT))) {
+            component.markInitialState();
+        }
+        if (component.getChildCount() > 0) {
+            List<UIComponent> children = component.getChildren();
+            for (int i = 0, size = children.size(); i < size; i++) {
+                markInitialStateIfNotMarked(children.get(i), hasDynamicComponents);
             }
-            for (Iterator<UIComponent> it = component.getFacetsAndChildren(); it.hasNext();) {
-                UIComponent child = it.next();
-                markInitialStateIfNotMarked(child);
+        }
+        if (component.getFacetCount() > 0) {
+            for (UIComponent facet : component.getFacets().values()) {
+                markInitialStateIfNotMarked(facet, hasDynamicComponents);
             }
         }
     }

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/CompositeComponentTagHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/CompositeComponentTagHandler.java
@@ -62,6 +62,7 @@ import jakarta.faces.view.facelets.Tag;
 import jakarta.faces.view.facelets.TagAttribute;
 
 import com.sun.faces.RIConstants;
+import com.sun.faces.context.StateContext;
 import com.sun.faces.el.CompositeComponentELResolver;
 import com.sun.faces.facelets.el.VariableMapperWrapper;
 import com.sun.faces.facelets.tag.MetaRulesetImpl;
@@ -547,8 +548,26 @@ public class CompositeComponentTagHandler extends ComponentHandler implements Cr
                     // about the value's existence.
                     attrs.remove(name);
                 }
-                cc.setValueExpression(name, ve);
 
+                // A composite component's attribute expressions are re-derived from the Facelet on every
+                // (re)build. On a postback rebuild the tree is already initial-state-marked, so recording
+                // them through the normal path stores a per-component delta that buildView reconstructs
+                // identically anyway. Under partial state saving, write them as initial state so the saved
+                // view stays free of this redundant, fully-reconstructable binding. (Legacy from full state
+                // saving, where the component is never initial-state-marked and this branch is a no-op.)
+                FacesContext context = ctx.getFacesContext();
+                boolean writeAsInitialState = cc.initialStateMarked()
+                        && StateContext.getStateContext(context).isPartialStateSaving(context, null);
+                if (writeAsInitialState) {
+                    cc.clearInitialState();
+                }
+                try {
+                    cc.setValueExpression(name, ve);
+                } finally {
+                    if (writeAsInitialState) {
+                        cc.markInitialState();
+                    }
+                }
             }
 
         } // END CompositeExpressionMetadata

--- a/impl/src/main/java/com/sun/faces/util/Util.java
+++ b/impl/src/main/java/com/sun/faces/util/Util.java
@@ -805,12 +805,19 @@ public class Util {
     }
 
     public static boolean componentIsDisabled(UIComponent component) {
-        return Boolean.parseBoolean(String.valueOf(component.getAttributes().get("disabled")));
+        return attributeIsTrue(component, "disabled");
     }
 
     public static boolean componentIsDisabledOrReadonly(UIComponent component) {
-        return Boolean.parseBoolean(String.valueOf(component.getAttributes().get("disabled")))
-                || Boolean.parseBoolean(String.valueOf(component.getAttributes().get("readonly")));
+        return attributeIsTrue(component, "disabled") || attributeIsTrue(component, "readonly");
+    }
+
+    // disabled/readonly are declared boolean properties on the HTML components these helpers run against, so the
+    // attribute value is always a Boolean (the Facelets boolean MetaRule coerces literals/EL before storing; a String
+    // cannot be written through a boolean setter). Read it directly, mirroring UIComponent.isRendered(), rather than
+    // routing through the String.valueOf()/parseBoolean() coercion the absent String case never needs.
+    private static boolean attributeIsTrue(UIComponent component, String name) {
+        return Boolean.TRUE.equals(component.getAttributes().get(name));
     }
 
     // W3C XML specification refers to IETF RFC 1766 for language code

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -107,8 +107,6 @@ public abstract class UIComponentBase extends UIComponent {
 
     private static Logger LOGGER = Logger.getLogger("jakarta.faces.component", "jakarta.faces.LogStrings");
 
-    private static final String ADDED = UIComponentBase.class.getName() + ".ADDED";
-
     private static final int MY_STATE = 0;
     private static final int CHILD_STATE = 1;
 
@@ -153,6 +151,7 @@ public abstract class UIComponentBase extends UIComponent {
     private Object dynamicComponent;       // RIConstants.DYNAMIC_COMPONENT (Integer index)
     private boolean markDeleted;           // ComponentSupport.MARK_DELETED
     private boolean markChildrenModified;  // ComponentSupport.MARK_CHILDREN_MODIFIED
+    private boolean added;                 // setParent re-entrancy guard
 
     /**
      * <p>
@@ -357,19 +356,16 @@ public abstract class UIComponentBase extends UIComponent {
             compositeParent = null;
         } else {
             this.parent = parent;
-            if (getAttributes().get(ADDED) == null) {
+            if (!added) {
 
-                // Add an attribute to this component here to indiciate that
-                // it's being processed. If we don't do this, and the component
-                // is re-parented, the events could fire again in certain cases
-                // and cause a stack overflow.
-                getAttributes().put(ADDED, TRUE);
+                // Flag this component as being processed. Without the guard, a re-parent during event
+                // processing could fire the events again in certain cases and cause a stack overflow.
+                added = true;
 
                 doPostAddProcessing(FacesContext.getCurrentInstance(), this);
 
-                // Remove the attribute once we've returned from the event
-                // processing.
-                getAttributes().remove(ADDED);
+                // Clear the flag once we've returned from the event processing.
+                added = false;
             }
         }
     }
@@ -1716,7 +1712,11 @@ public abstract class UIComponentBase extends UIComponent {
     private void doPostAddProcessing(FacesContext context, UIComponent added) {
 
         if (parent.isInView()) {
-            publishAfterViewEvents(context, context.getApplication(), added);
+            if (context.isProcessingEvents()) {
+                publishAfterViewEvents(context, context.getApplication(), added);
+            } else {
+                updateInView(added, true);
+            }
         }
 
     }
@@ -1724,7 +1724,11 @@ public abstract class UIComponentBase extends UIComponent {
     private void doPreRemoveProcessing(FacesContext context, UIComponent toRemove) {
 
         if (parent.isInView()) {
-            disconnectFromView(context, context.getApplication(), toRemove);
+            if (context.isProcessingEvents()) {
+                disconnectFromView(context, context.getApplication(), toRemove);
+            } else {
+                updateInView(toRemove, false);
+            }
         }
 
     }
@@ -2013,13 +2017,25 @@ public abstract class UIComponentBase extends UIComponent {
             component.pushComponentToEL(context, component);
             application.publishEvent(context, PostAddToViewEvent.class, component);
             if (component.getChildCount() > 0) {
-                Collection<UIComponent> clist = new ArrayList<>(component.getChildren());
-                for (UIComponent c : clist) {
-                    publishAfterViewEvents(context, application, c);
+                // A PostAddToViewEvent listener may relocate children mid-walk (e.g. composite cc:insertChildren's
+                // RelocateChildrenListener), mutating this list. Rather than walk a per-node defensive copy, iterate
+                // the live list and re-check the slot after recursing: if index i no longer holds the component we
+                // just processed, it was relocated away, so process whatever now occupies i. Spends no per-node copy.
+                List<UIComponent> children = component.getChildren();
+                for (int i = 0; i < children.size(); i++) {
+                    while (true) {
+                        UIComponent child = children.get(i);
+                        publishAfterViewEvents(context, application, child);
+                        if (i < children.size() && children.get(i) != child) {
+                            continue;
+                        }
+                        break;
+                    }
                 }
             }
 
             if (component.getFacetCount() > 0) {
+                // Facets are few and rarely relocated; a small defensive copy keeps the iteration trivially safe.
                 Collection<UIComponent> clist = new ArrayList<>(component.getFacets().values());
                 for (UIComponent c : clist) {
                     publishAfterViewEvents(context, application, c);
@@ -2048,6 +2064,36 @@ public abstract class UIComponentBase extends UIComponent {
         application.publishEvent(context, PreRemoveFromViewEvent.class, component);
         component.setInView(false);
         component.compositeParent = null;
+    }
+
+    /**
+     * Recursively maintain the in-view flag of the given subtree <em>without</em> publishing the
+     * {@link PostAddToViewEvent}/{@link PreRemoveFromViewEvent} system events. Used when the runtime has event
+     * processing suppressed ({@link FacesContext#isProcessingEvents()} is {@code false}), e.g. while a
+     * partial-state-saving restore rebuilds the tree: {@link Application#publishEvent} is a no-op while suppressed,
+     * so walking the subtree to fire it -- pushing and popping the EL stack at every node -- is wasted work. This
+     * reproduces the publishing walks' only non-event side effects: {@link #publishAfterViewEvents} sets in-view
+     * true, {@link #disconnectFromView} sets it false and clears {@code compositeParent}.
+     */
+    private static void updateInView(UIComponent component, boolean isInView) {
+        component.setInView(isInView);
+        if (!isInView) {
+            component.compositeParent = null;
+        }
+        // Events are suppressed, so no listener can relocate children mid-walk: a plain index loop over the live
+        // children (and the facet values) suffices, avoiding the getFacetsAndChildren() iterator allocation that
+        // the publishing walks were themselves restructured to avoid.
+        if (component.getChildCount() > 0) {
+            List<UIComponent> children = component.getChildren();
+            for (int i = 0, size = children.size(); i < size; i++) {
+                updateInView(children.get(i), isInView);
+            }
+        }
+        if (component.getFacetCount() > 0) {
+            for (UIComponent facet : component.getFacets().values()) {
+                updateInView(facet, isInView);
+            }
+        }
     }
 
     // --------------------------------------------------------- Private Classes
@@ -3415,8 +3461,27 @@ public abstract class UIComponentBase extends UIComponent {
     }
 
     private String addParentId(FacesContext context, String parentId, String childId) {
-        return new StringBuilder(parentId.length() + 1 + childId.length()).append(parentId).append(UINamingContainer.getSeparatorChar(context)).append(childId)
+        // Reuse a request-shared StringBuilder rather than allocating a fresh one per component: client id
+        // resolution runs once per component per request and, in a deep NamingContainer tree, for every node.
+        // The parent id is already a fully resolved String here (getClientId resolves it before calling this),
+        // and the builder is used and toString()'d in a single uninterrupted step, so the shared instance is
+        // never re-entered mid-build.
+        return sharedClientIdBuilder(context).append(parentId).append(UINamingContainer.getSeparatorChar(context)).append(childId)
                 .toString();
+    }
+
+    private static final String SHARED_CLIENT_ID_BUILDER_KEY = "com.sun.faces.component.UIComponentBase.SHARED_CLIENT_ID_BUILDER";
+
+    private static StringBuilder sharedClientIdBuilder(FacesContext context) {
+        Map<Object, Object> contextAttributes = context.getAttributes();
+        StringBuilder builder = (StringBuilder) contextAttributes.get(SHARED_CLIENT_ID_BUILDER_KEY);
+        if (builder == null) {
+            builder = new StringBuilder();
+            contextAttributes.put(SHARED_CLIENT_ID_BUILDER_KEY, builder);
+        } else {
+            builder.setLength(0);
+        }
+        return builder;
     }
 
     private String getParentId(FacesContext context, UIComponent parent) {

--- a/impl/src/test/java/jakarta/faces/component/UIComponentBaseTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIComponentBaseTestCase.java
@@ -87,6 +87,77 @@ public class UIComponentBaseTestCase extends UIComponentTestCase {
 
     }
 
+    // Adding a subtree to an in-view parent fires PostAddToViewEvent across it via publishAfterViewEvents,
+    // which iterates the live children list (no defensive copy). A listener may relocate a component out of its
+    // parent during its own event (h:outputScript moving itself to the head, composite cc:insertChildren, ...),
+    // shifting the next sibling into the vacated slot. Verify the walk tolerates that: no
+    // ConcurrentModificationException, and the shifted sibling is still visited rather than skipped.
+    @Test
+    public void testPublishAfterViewEventsToleratesSelfRelocation() {
+
+        UIComponent parent = new UIPanel();
+        parent.setInView(true);
+
+        UIComponent holder = new UIPanel();
+        UIOutput c0 = new UIOutput();
+        UIOutput c1 = new UIOutput();
+        UIOutput c2 = new UIOutput();
+        UIOutput c3 = new UIOutput();
+        holder.getChildren().addAll(Arrays.asList(c0, c1, c2, c3));
+
+        List<UIComponent> received = new ArrayList<>();
+        ComponentSystemEventListener recorder = event -> received.add(event.getComponent());
+        for (UIComponent c : Arrays.asList(holder, c0, c1, c2, c3)) {
+            c.subscribeToEvent(PostAddToViewEvent.class, recorder);
+        }
+
+        // c1 relocates itself out of holder during its own PostAddToViewEvent, shifting c2 into index 1.
+        c1.subscribeToEvent(PostAddToViewEvent.class, (ComponentSystemEventListener) event -> holder.getChildren().remove(c1));
+
+        // Triggers publishAfterViewEvents over the holder subtree; must not throw ConcurrentModificationException.
+        parent.getChildren().add(holder);
+
+        assertTrue(received.contains(holder));
+        assertTrue(received.contains(c0));
+        assertTrue(received.contains(c1)); // recorded before it relocated itself
+        assertTrue(received.contains(c2)); // shifted into c1's vacated slot mid-walk, must not be skipped
+        assertTrue(received.contains(c3));
+    }
+
+    // While the runtime has event processing suppressed (FacesContext.isProcessingEvents() == false, e.g. during a
+    // partial-state-saving restore), add/remove must NOT publish PostAddToViewEvent/PreRemoveFromViewEvent --
+    // publishEvent is a no-op while suppressed anyway -- but must still maintain the in-view flag across the subtree.
+    @Test
+    public void testInViewMaintainedWithoutEventsWhenProcessingSuppressed() {
+
+        UIComponent parent = new UIPanel();
+        parent.setInView(true);
+
+        UIComponent holder = new UIPanel();
+        UIOutput child = new UIOutput();
+        holder.getChildren().add(child);
+
+        List<UIComponent> received = new ArrayList<>();
+        ComponentSystemEventListener recorder = event -> received.add(event.getComponent());
+        holder.subscribeToEvent(PostAddToViewEvent.class, recorder);
+        child.subscribeToEvent(PostAddToViewEvent.class, recorder);
+
+        facesContext.setProcessingEvents(false);
+        try {
+            parent.getChildren().add(holder);
+            assertTrue(received.isEmpty());        // no event published while suppressed
+            assertTrue(holder.isInView());         // ...but in-view propagated across the added subtree
+            assertTrue(child.isInView());
+
+            parent.getChildren().remove(holder);
+            assertTrue(received.isEmpty());         // still no event published
+            assertTrue(!holder.isInView());         // in-view cleared across the removed subtree
+            assertTrue(!child.isInView());
+        } finally {
+            facesContext.setProcessingEvents(true);
+        }
+    }
+
     @Test
     public void testComponentToFromEL2() throws Exception {
 


### PR DESCRIPTION
Backports the partial-state-saving / component-tree-walk performance work from #5777 and #5778 into 4.0. Follow-up to #5753.

Omits #5777's Cache `get()`-probe commit — 4.0's `Cache.get()` already probes with `get()` before `putIfAbsent` (it never switched to `computeIfAbsent`), so that change is a no-op on 4.0. Everything else applies as on 4.1.

🤖 Generated with Claude Opus 4.8
