### PR TITLE
Backport #5785 into 4.0

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/applicationimpl/Events.java
+++ b/impl/src/main/java/com/sun/faces/application/applicationimpl/Events.java
@@ -261,51 +261,83 @@ public class Events {
 
     private SystemEvent processListenersAccountingForAdds(List<SystemEventListener> listeners, SystemEvent event, Object source, EventInfo eventInfo) {
 
-        if (listeners != null && !listeners.isEmpty()) {
+        if (listeners == null || listeners.isEmpty()) {
+            return event;
+        }
 
-            // copy listeners
-            // go thru copy completely
-            // compare copy to original
-            // if original differs from copy, make a new copy.
-            // The new copy consists of the original list - processed
-
-            SystemEventListener listenersCopy[] = new SystemEventListener[listeners.size()];
-            int i = 0;
-            for (i = 0; i < listenersCopy.length; i++) {
-                listenersCopy[i] = listeners.get(i);
+        // Fast path: invoke the listeners by walking the live list directly, re-reading size() each step so a
+        // listener that subscribes another listener while being invoked (an append -- the only change the
+        // listener list undergoes during dispatch) is still invoked, in order, exactly once. This avoids the
+        // per-event SystemEventListener[] copy and HashMap that the snapshot path allocates on EVERY published
+        // system event -- the hot path for PostAddToViewEvent during bulk dynamic add/remove. A non-append
+        // change (the listener list shrinking mid-invoke, which Faces' view-event dispatch does not do) falls
+        // back to the snapshot path.
+        int size = listeners.size();
+        for (int i = 0; i < listeners.size(); i++) {
+            if (listeners.size() < size) {
+                return processListenersOnSnapshot(listeners, event, source, eventInfo);
             }
-
-            Map<SystemEventListener, Boolean> processedListeners = new HashMap<>(listeners.size());
-            boolean processedSomeEvents = false, originalDiffersFromCopy = false;
-
-            do {
-                i = 0;
-                originalDiffersFromCopy = false;
-                if (0 < listenersCopy.length) {
-                    for (i = 0; i < listenersCopy.length; i++) {
-                        SystemEventListener curListener = listenersCopy[i];
-                        if (curListener != null && curListener.isListenerForSource(source)) {
-                            if (event == null) {
-                                event = eventInfo.createSystemEvent(source);
-                            }
-                            assert event != null;
-                            if (!processedListeners.containsKey(curListener) && event.isAppropriateListener(curListener)) {
-                                processedSomeEvents = true;
-                                event.processListener(curListener);
-                                processedListeners.put(curListener, Boolean.TRUE);
-                            }
-                        }
-                    }
-                    if (originalDiffersFromCopy(listeners, listenersCopy)) {
-                        originalDiffersFromCopy = true;
-                        listenersCopy = copyListWithExclusions(listeners, processedListeners);
-                    }
+            size = listeners.size();
+            SystemEventListener curListener = listeners.get(i);
+            if (curListener != null && curListener.isListenerForSource(source)) {
+                if (event == null) {
+                    event = eventInfo.createSystemEvent(source);
                 }
-            } while (originalDiffersFromCopy && processedSomeEvents);
+                if (event.isAppropriateListener(curListener)) {
+                    event.processListener(curListener);
+                }
+            }
         }
 
         return event;
+    }
 
+    // Snapshot fallback preserving the original copy + processed-set accounting (tolerates listeners being added
+    // to or removed from the list while they are being invoked). Reached only if the live listener list shrinks
+    // mid-dispatch, which Faces' view-event dispatch does not produce.
+    private SystemEvent processListenersOnSnapshot(List<SystemEventListener> listeners, SystemEvent event, Object source, EventInfo eventInfo) {
+
+        // copy listeners
+        // go thru copy completely
+        // compare copy to original
+        // if original differs from copy, make a new copy.
+        // The new copy consists of the original list - processed
+
+        SystemEventListener[] listenersCopy = new SystemEventListener[listeners.size()];
+        int i = 0;
+        for (i = 0; i < listenersCopy.length; i++) {
+            listenersCopy[i] = listeners.get(i);
+        }
+
+        Map<SystemEventListener, Boolean> processedListeners = new HashMap<>(listeners.size());
+        boolean processedSomeEvents = false, originalDiffersFromCopy = false;
+
+        do {
+            i = 0;
+            originalDiffersFromCopy = false;
+            if (0 < listenersCopy.length) {
+                for (i = 0; i < listenersCopy.length; i++) {
+                    SystemEventListener curListener = listenersCopy[i];
+                    if (curListener != null && curListener.isListenerForSource(source)) {
+                        if (event == null) {
+                            event = eventInfo.createSystemEvent(source);
+                        }
+                        assert event != null;
+                        if (!processedListeners.containsKey(curListener) && event.isAppropriateListener(curListener)) {
+                            processedSomeEvents = true;
+                            event.processListener(curListener);
+                            processedListeners.put(curListener, Boolean.TRUE);
+                        }
+                    }
+                }
+                if (originalDiffersFromCopy(listeners, listenersCopy)) {
+                    originalDiffersFromCopy = true;
+                    listenersCopy = copyListWithExclusions(listeners, processedListeners);
+                }
+            }
+        } while (originalDiffersFromCopy && processedSomeEvents);
+
+        return event;
     }
 
     private boolean originalDiffersFromCopy(Collection<SystemEventListener> original, SystemEventListener copy[]) {

--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -1763,7 +1763,9 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
         // Actions are recorded raw (append-only); prune to the net per-clientId effect so a collapsed subtree does
         // not replay its now-cancelled add/remove pairs.
         List<ComponentStruct> actions = StateContext.pruneDynamicActions(stateContext.getDynamicActions());
-        if (actions != null) {
+        // Only walk the tree to build the index when there is at least one action to replay; pruneDynamicActions
+        // returns a non-null empty list for the common no-dynamic-component postback, which must not pay an O(n) walk.
+        if (!isEmpty(actions)) {
             // Index the tree once (O(n)) so each replayed action resolves its parent/child in O(1), keeping replay
             // O(n); kept in sync as we add/remove below.
             Map<String, UIComponent> componentIndex = buildClientIdIndex(context, context.getViewRoot());

--- a/impl/src/main/java/com/sun/faces/cdi/CdiUtils.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CdiUtils.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -113,6 +114,22 @@ public final class CdiUtils {
     private static final Map<BeanManager, Bean<?>> FACES_CONTEXT_PRODUCER_BEANS =
             synchronizedMap(new WeakHashMap<>());
 
+    /**
+     * Target-class / id keyed caches of the resolved managed converter, validator and behavior {@link Bean}s
+     * per {@link BeanManager}. The by-class converter lookup otherwise walks the superclass chain building a
+     * {@link FacesConverter} qualifier + {@link BeanLookupKey} at each level (and the by-id paths build two to
+     * four such keys) on every call -- per cell during render. Keying directly on the target {@code Class} or
+     * id collapses that to a single cheap map lookup. The resolved {@link Bean} is stable post-bootstrap;
+     * {@link BeanManager#getReference} stays per-call so scope semantics are preserved. Misses are cached as
+     * {@link #NO_BEAN}. Cleared on shutdown together with {@link #RESOLVED_BEANS} (same stale-Bean concern).
+     */
+    private static final Map<BeanManager, ConcurrentMap<Object, Bean<?>>> CONVERTER_BEANS_BY_KEY =
+            synchronizedMap(new WeakHashMap<>());
+    private static final Map<BeanManager, ConcurrentMap<Object, Bean<?>>> VALIDATOR_BEANS_BY_KEY =
+            synchronizedMap(new WeakHashMap<>());
+    private static final Map<BeanManager, ConcurrentMap<Object, Bean<?>>> BEHAVIOR_BEANS_BY_KEY =
+            synchronizedMap(new WeakHashMap<>());
+
     private static final Bean<?> NO_BEAN = new NoBean();
 
     /**
@@ -128,6 +145,9 @@ public final class CdiUtils {
     public static void clearCaches() {
         RESOLVED_BEANS.clear();
         FACES_CONTEXT_PRODUCER_BEANS.clear();
+        CONVERTER_BEANS_BY_KEY.clear();
+        VALIDATOR_BEANS_BY_KEY.clear();
+        BEHAVIOR_BEANS_BY_KEY.clear();
     }
 
     /**
@@ -144,16 +164,18 @@ public final class CdiUtils {
      * @return the converter, or null if we could not match one.
      */
     public static Converter<?> createConverter(BeanManager beanManager, String value) {
-        Converter<?> managedConverter = createConverter(beanManager, FacesConverter.Literal.of(value, Object.class, true));
+        Bean<?> bean = cachedBean(CONVERTER_BEANS_BY_KEY, beanManager, value,
+                () -> resolveConverterBean(beanManager, FacesConverter.Literal.of(value, Object.class, true)));
 
-        if (managedConverter != null) {
-            ApplicationAssociate associate = ApplicationAssociate.getCurrentInstance();
-            associate.getAnnotationManager().applyConverterAnnotations(FacesContext.getCurrentInstance(), managedConverter); // #4913
-
-            return new CdiConverter(value, Object.class, managedConverter);
+        if (bean == null) {
+            return null;
         }
 
-        return null;
+        Converter<?> managedConverter = (Converter<?>) getReferenceInstance(beanManager, bean.getBeanClass(), bean);
+        ApplicationAssociate associate = ApplicationAssociate.getCurrentInstance();
+        associate.getAnnotationManager().applyConverterAnnotations(FacesContext.getCurrentInstance(), managedConverter); // #4913
+
+        return new CdiConverter(value, Object.class, managedConverter);
     }
 
     /**
@@ -164,34 +186,59 @@ public final class CdiUtils {
      * @return the converter, or null if we could not match one.
      */
     public static Converter<?> createConverter(BeanManager beanManager, Class<?> forClass) {
-        Converter<?> managedConverter = null;
+        Bean<?> bean = cachedBean(CONVERTER_BEANS_BY_KEY, beanManager, forClass,
+                () -> resolveConverterBeanForClass(beanManager, forClass));
 
-        for (Class<?> forClassOrSuperclass = forClass; managedConverter == null && forClassOrSuperclass != null
+        if (bean == null) {
+            return null;
+        }
+
+        Converter<?> managedConverter = (Converter<?>) getReferenceInstance(beanManager, bean.getBeanClass(), bean);
+        ApplicationAssociate associate = ApplicationAssociate.getCurrentInstance();
+        associate.getAnnotationManager().applyConverterAnnotations(FacesContext.getCurrentInstance(), managedConverter); // #4913
+
+        return new CdiConverter("", forClass, managedConverter);
+    }
+
+    private static Bean<?> resolveConverterBeanForClass(BeanManager beanManager, Class<?> forClass) {
+        for (Class<?> forClassOrSuperclass = forClass; forClassOrSuperclass != null
                 && forClassOrSuperclass != Object.class; forClassOrSuperclass = forClassOrSuperclass.getSuperclass()) {
-            managedConverter = createConverter(beanManager, FacesConverter.Literal.of("", forClassOrSuperclass, true));
+            Bean<?> bean = resolveConverterBean(beanManager, FacesConverter.Literal.of("", forClassOrSuperclass, true));
+            if (bean != null) {
+                return bean;
+            }
         }
-
-        if (managedConverter != null) {
-            ApplicationAssociate associate = ApplicationAssociate.getCurrentInstance();
-            associate.getAnnotationManager().applyConverterAnnotations(FacesContext.getCurrentInstance(), managedConverter); // #4913
-
-            return new CdiConverter("", forClass, managedConverter);
-        }
-
         return null;
     }
 
-    private static Converter<?> createConverter(BeanManager beanManager, Annotation qualifier) {
-
-        // Try to find parameterized converter first
-        Converter<?> managedConverter = (Converter<?>) getBeanReferenceByType(beanManager, CONVERTER_TYPE, qualifier);
-
-        if (managedConverter == null) {
-            // No parameterized converter, try raw converter
-            managedConverter = getBeanReference(beanManager, Converter.class, qualifier);
+    private static Bean<?> resolveConverterBean(BeanManager beanManager, Annotation qualifier) {
+        // Try the parameterized converter type first, then the raw converter type.
+        Bean<?> bean = resolveBeanUncached(beanManager, CONVERTER_TYPE, null, qualifier);
+        if (bean == null) {
+            bean = resolveBeanUncached(beanManager, Converter.class, null, qualifier);
         }
+        return bean;
+    }
 
-        return managedConverter;
+    /**
+     * Returns the resolved managed {@link Bean} for {@code key}, computing it via {@code resolver} and caching
+     * the outcome (a miss as {@link #NO_BEAN}) on first use. {@code getReference} is left to the caller so
+     * scope stays per-invocation.
+     */
+    private static Bean<?> cachedBean(Map<BeanManager, ConcurrentMap<Object, Bean<?>>> cacheByManager,
+            BeanManager beanManager, Object key, Supplier<Bean<?>> resolver) {
+        ConcurrentMap<Object, Bean<?>> cache = cacheByManager.computeIfAbsent(beanManager, k -> new ConcurrentHashMap<>());
+        Bean<?> cached = cache.get(key);
+        if (cached != null) {
+            return cached == NO_BEAN ? null : cached;
+        }
+        Bean<?> bean = resolver.get();
+        cache.put(key, bean == null ? NO_BEAN : bean);
+        return bean;
+    }
+
+    private static Object getReferenceInstance(BeanManager beanManager, Type type, Bean<?> bean) {
+        return beanManager.getReference(bean, type, beanManager.createCreationalContext(bean));
     }
 
     /**
@@ -202,15 +249,15 @@ public final class CdiUtils {
      * @return the behavior, or null if we could not match one.
      */
     public static Behavior createBehavior(BeanManager beanManager, String value) {
-        Behavior delegatingBehavior = null;
+        Bean<?> bean = cachedBean(BEHAVIOR_BEANS_BY_KEY, beanManager, value,
+                () -> resolveBeanUncached(beanManager, Behavior.class, null, FacesBehavior.Literal.of(value, true)));
 
-        Behavior managedBehavior = getBeanReference(beanManager, Behavior.class, FacesBehavior.Literal.of(value, true));
-
-        if (managedBehavior != null) {
-            delegatingBehavior = new CdiBehavior(value, managedBehavior);
+        if (bean == null) {
+            return null;
         }
 
-        return delegatingBehavior;
+        Behavior managedBehavior = (Behavior) getReferenceInstance(beanManager, bean.getBeanClass(), bean);
+        return new CdiBehavior(value, managedBehavior);
     }
 
     /**
@@ -221,41 +268,33 @@ public final class CdiUtils {
      * @return the validator, or null if we could not match one.
      */
     public static Validator<?> createValidator(BeanManager beanManager, String value) {
+        Bean<?> bean = cachedBean(VALIDATOR_BEANS_BY_KEY, beanManager, value,
+                () -> resolveValidatorBean(beanManager, value));
 
+        if (bean == null) {
+            return null;
+        }
+
+        Validator<?> managedValidator = (Validator<?>) getReferenceInstance(beanManager, bean.getBeanClass(), bean);
+        return new CdiValidator(value, managedValidator);
+    }
+
+    private static Bean<?> resolveValidatorBean(BeanManager beanManager, String value) {
+        // Try the parameterized validator type first, then the raw type.
         Annotation qualifier = FacesValidator.Literal.of(value, false, true);
-
-        // Try to find parameterized validator first
-        Validator<?> managedValidator = (Validator<?>) getBeanReferenceByType(beanManager, VALIDATOR_TYPE, qualifier);
-
-        if (managedValidator == null) {
-            // No parameterized validator, try raw validator
-            managedValidator = getBeanReference(beanManager, Validator.class, qualifier);
+        Bean<?> bean = resolveBeanUncached(beanManager, VALIDATOR_TYPE, null, qualifier);
+        if (bean == null) {
+            bean = resolveBeanUncached(beanManager, Validator.class, null, qualifier);
         }
-
-        if (managedValidator == null) {
-            // Still nothing found, try default qualifier and value as bean name.
+        if (bean == null) {
+            // Still nothing found: try the default qualifier with value as the bean name.
             qualifier = FacesValidator.Literal.of("", false, true);
-            managedValidator = (Validator<?>) getBeanReferenceByType(
-                    beanManager,
-                    VALIDATOR_TYPE,
-                    value,
-                    qualifier);
+            bean = resolveBeanUncached(beanManager, VALIDATOR_TYPE, value, qualifier);
+            if (bean == null) {
+                bean = resolveBeanUncached(beanManager, Validator.class, value, qualifier);
+            }
         }
-                
-        if (managedValidator == null) {
-            // No parameterized validator, try raw validator
-            managedValidator = getBeanReference(
-                beanManager,
-                Validator.class,
-                value,
-                qualifier);
-        }
-
-        if (managedValidator != null) {
-            return new CdiValidator(value, managedValidator);
-        }
-
-        return null;
+        return bean;
     }
 
     public static void addAnnotatedTypes(BeforeBeanDiscovery beforeBean, BeanManager beanManager, Class<?>... types) {
@@ -306,15 +345,25 @@ public final class CdiUtils {
         if (cached != null) {
             return cached == NO_BEAN ? null : cached;
         }
+        Bean<?> resolved = resolveBeanUncached(beanManager, type, beanName, qualifiers);
+        cache.put(key, resolved == null ? NO_BEAN : resolved);
+        return resolved;
+    }
+
+    /**
+     * The raw {@code getBeans} + {@code resolve} (with optional bean-name filtering), without the
+     * {@link #RESOLVED_BEANS} cache. The Faces-artifact paths (converter/validator/behavior) cache the
+     * resolved {@link Bean} themselves keyed by class/id, so they resolve through this directly rather than
+     * also populating {@link #RESOLVED_BEANS} with entries they would never read again.
+     */
+    private static Bean<?> resolveBeanUncached(BeanManager beanManager, Type type, String beanName, Annotation... qualifiers) {
         Set<Bean<?>> beans = beanManager.getBeans(type, qualifiers);
         if (beanName != null) {
             beans = beans.stream()
                 .filter(bean -> beanName.equals(getBeanName(bean)))
                 .collect(toSet());
         }
-        Bean<?> resolved = beanManager.resolve(beans);
-        cache.put(key, resolved == null ? NO_BEAN : resolved);
-        return resolved;
+        return beanManager.resolve(beans);
     }
 
     /**

--- a/impl/src/main/java/com/sun/faces/context/StateContext.java
+++ b/impl/src/main/java/com/sun/faces/context/StateContext.java
@@ -291,6 +291,24 @@ public class StateContext {
         if (rawActions == null) {
             return null;
         }
+        // Collapsing an ADD that a later REMOVE cancels (and coalescing a REMOVE with a re-ADD) for the same
+        // client id can only happen when the list holds both an ADD and a REMOVE. A homogeneous list -- all
+        // ADDs or all REMOVEs, i.e. the common bulk add or bulk clear in an action -- has nothing to collapse:
+        // each action is already a distinct net add/remove. Skip the per-id LinkedHashMap for it.
+        boolean hasAdd = false, hasRemove = false;
+        for (ComponentStruct action : rawActions) {
+            if (ADD.equals(action.getAction())) {
+                hasAdd = true;
+            } else if (REMOVE.equals(action.getAction())) {
+                hasRemove = true;
+            }
+            if (hasAdd && hasRemove) {
+                break;
+            }
+        }
+        if (!hasAdd || !hasRemove) {
+            return rawActions;
+        }
         // value[0] = effective REMOVE for the client id (or null); value[1] = effective ADD (or null)
         Map<String, ComponentStruct[]> netByClientId = new LinkedHashMap<>();
         for (ComponentStruct action : rawActions) {

--- a/impl/src/test/java/com/sun/faces/application/applicationimpl/EventsTest.java
+++ b/impl/src/test/java/com/sun/faces/application/applicationimpl/EventsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.faces.application.applicationimpl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.faces.application.applicationimpl.events.EventInfo;
+
+import jakarta.faces.event.SystemEvent;
+import jakarta.faces.event.SystemEventListener;
+
+/**
+ * Pins the dispatch contract of {@code Events.processListenersAccountingForAdds}: every matching listener is
+ * invoked exactly once, a listener subscribed while the listeners are being invoked is picked up, and a
+ * listener not for the source is skipped. The fast path preserves this behaviour without the per-event copy
+ * and map the original snapshot algorithm allocated on every published event.
+ */
+class EventsTest {
+
+    private static SystemEvent invoke(List<SystemEventListener> listeners, SystemEvent event, Object source) throws Exception {
+        Method method = Events.class.getDeclaredMethod("processListenersAccountingForAdds",
+                List.class, SystemEvent.class, Object.class, EventInfo.class);
+        method.setAccessible(true);
+        return (SystemEvent) method.invoke(new Events(), listeners, event, source, mock(EventInfo.class));
+    }
+
+    private static SystemEventListener listenerForSource() {
+        SystemEventListener listener = mock(SystemEventListener.class);
+        when(listener.isListenerForSource(any())).thenReturn(true);
+        return listener;
+    }
+
+    @Test
+    void everyMatchingListenerIsInvokedExactlyOnce() throws Exception {
+        SystemEventListener a = listenerForSource(), b = listenerForSource(), c = listenerForSource();
+        List<SystemEventListener> listeners = new ArrayList<>(List.of(a, b, c));
+        SystemEvent event = mock(SystemEvent.class);
+        when(event.isAppropriateListener(any())).thenReturn(true);
+
+        invoke(listeners, event, new Object());
+
+        verify(event, times(1)).processListener(a);
+        verify(event, times(1)).processListener(b);
+        verify(event, times(1)).processListener(c);
+    }
+
+    @Test
+    void aListenerSubscribedDuringDispatchIsAlsoInvoked() throws Exception {
+        SystemEventListener first = listenerForSource();
+        SystemEventListener subscribedDuringDispatch = listenerForSource();
+        List<SystemEventListener> listeners = new ArrayList<>();
+        listeners.add(first);
+
+        SystemEvent event = mock(SystemEvent.class);
+        when(event.isAppropriateListener(any())).thenReturn(true);
+        // Invoking 'first' subscribes another view listener; it must still be invoked, exactly once.
+        doAnswer(invocation -> {
+            listeners.add(subscribedDuringDispatch);
+            return null;
+        }).when(event).processListener(first);
+
+        invoke(listeners, event, new Object());
+
+        verify(event, times(1)).processListener(first);
+        verify(event, times(1)).processListener(subscribedDuringDispatch);
+    }
+
+    @Test
+    void aListenerNotForTheSourceIsSkipped() throws Exception {
+        SystemEventListener matching = listenerForSource();
+        SystemEventListener nonMatching = mock(SystemEventListener.class);
+        when(nonMatching.isListenerForSource(any())).thenReturn(false);
+        List<SystemEventListener> listeners = new ArrayList<>(List.of(matching, nonMatching));
+        SystemEvent event = mock(SystemEvent.class);
+        when(event.isAppropriateListener(any())).thenReturn(true);
+
+        invoke(listeners, event, new Object());
+
+        verify(event, times(1)).processListener(matching);
+        verify(event, never()).processListener(nonMatching);
+    }
+}

--- a/impl/src/test/java/com/sun/faces/application/view/FaceletViewHandlingStrategyTest.java
+++ b/impl/src/test/java/com/sun/faces/application/view/FaceletViewHandlingStrategyTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.faces.application.view;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.sun.faces.context.StateContext;
+import com.sun.faces.util.ComponentStruct;
+
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.component.visit.VisitCallback;
+import jakarta.faces.component.visit.VisitContext;
+import jakarta.faces.context.FacesContext;
+
+class FaceletViewHandlingStrategyTest {
+
+    /** A view root that records whether its subtree was walked. */
+    private static final class RecordingViewRoot extends UIViewRoot {
+        boolean visited;
+
+        @Override
+        public boolean visitTree(VisitContext context, VisitCallback callback) {
+            visited = true;
+            return super.visitTree(context, callback);
+        }
+    }
+
+    /**
+     * Regression guard for the dynamic-action restore O(n) fix (PR #5783). A postback with no dynamic
+     * add/remove must not build the {@code clientId -> component} index, i.e. must not walk the view.
+     *
+     * <p>Once the {@code AddRemoveListener} is installed (every partial-state-saving postback),
+     * {@code getDynamicActions()} returns a non-null <em>empty</em> list and {@code pruneDynamicActions}
+     * preserves that, so the guard in {@code reapplyDynamicActions} must be {@code !isEmpty(actions)} —
+     * a bare {@code actions != null} walks the whole tree on every postback for nothing.
+     */
+    @Test
+    void reapplyDynamicActionsSkipsTreeWalkWhenNoDynamicActions() throws Exception {
+        RecordingViewRoot viewRoot = new RecordingViewRoot();
+        FacesContext context = mock(FacesContext.class);
+        when(context.getViewRoot()).thenReturn(viewRoot);
+
+        StateContext stateContext = mock(StateContext.class);
+        when(stateContext.getDynamicActions()).thenReturn(new ArrayList<ComponentStruct>());
+
+        // Constructor-free instance: the real constructor wires up webConfig/factories we don't need here.
+        FaceletViewHandlingStrategy strategy = mock(FaceletViewHandlingStrategy.class);
+        Method reapplyDynamicActions = FaceletViewHandlingStrategy.class
+                .getDeclaredMethod("reapplyDynamicActions", FacesContext.class);
+        reapplyDynamicActions.setAccessible(true);
+
+        try (MockedStatic<StateContext> mocked = mockStatic(StateContext.class)) {
+            mocked.when(() -> StateContext.getStateContext(context)).thenReturn(stateContext);
+            // Exercise the real prune so the test sees the genuine non-null empty list that caused the bug.
+            mocked.when(() -> StateContext.pruneDynamicActions(any())).thenCallRealMethod();
+
+            reapplyDynamicActions.invoke(strategy, context);
+        }
+
+        assertFalse(viewRoot.visited, "reapplyDynamicActions walked the view despite having no dynamic actions");
+    }
+}

--- a/impl/src/test/java/com/sun/faces/cdi/CdiLookupCountTest.java
+++ b/impl/src/test/java/com/sun/faces/cdi/CdiLookupCountTest.java
@@ -105,6 +105,41 @@ public class CdiLookupCountTest {
         assertEquals(4, bm.getBeansByType.get(), "getBeans calls per createConverter(Class) for Long");
     }
 
+    @Test
+    public void createConverter_byClass_repeatedCalls_areCached() {
+        CountingBeanManager bm = new CountingBeanManager();
+
+        for (int i = 0; i < 10; i++) {
+            CdiUtils.createConverter(bm, Long.class);
+        }
+
+        // Only the first call walks Long -> Number (4 lookups); the other 9 hit the class-keyed cache.
+        // This is the per-cell render path (renderer calls createConverter(value.getClass()) every render).
+        assertEquals(4, bm.getBeansByType.get(), "Only first createConverter(Class) call hits BeanManager");
+    }
+
+    @Test
+    public void createValidator_byId_repeatedCalls_areCached() {
+        CountingBeanManager bm = new CountingBeanManager();
+
+        for (int i = 0; i < 10; i++) {
+            CdiUtils.createValidator(bm, "jakarta.faces.Required");
+        }
+
+        assertEquals(4, bm.getBeansByType.get(), "Only first createValidator(String) call hits BeanManager");
+    }
+
+    @Test
+    public void createBehavior_byId_repeatedCalls_areCached() {
+        CountingBeanManager bm = new CountingBeanManager();
+
+        for (int i = 0; i < 10; i++) {
+            CdiUtils.createBehavior(bm, "jakarta.faces.Ajax");
+        }
+
+        assertEquals(1, bm.getBeansByType.get(), "Only first createBehavior(String) call hits BeanManager");
+    }
+
     /**
      * Simulates a typical render of one input bound to an Integer property: the renderer calls
      * {@code application.createConverter(Integer.class)} per render, plus

--- a/impl/src/test/java/com/sun/faces/context/StateContextTest.java
+++ b/impl/src/test/java/com/sun/faces/context/StateContextTest.java
@@ -19,6 +19,7 @@ import static com.sun.faces.util.ComponentStruct.ADD;
 import static com.sun.faces.util.ComponentStruct.REMOVE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static java.util.stream.Collectors.toList;
 
@@ -90,6 +91,29 @@ class StateContextTest {
     }
 
     // ------------------------------------------------------------------ helpers
+
+    @Test
+    void allAddsIsReturnedAsIsWithoutBuildingTheNetMap() {
+        // The common bulk-add postback (all ADDs) must short-circuit: the raw list is already its own pruned
+        // form, so pruneDynamicActions returns it unchanged rather than rebuilding it through the per-client-id
+        // LinkedHashMap on every save and reapply.
+        List<ComponentStruct> raw = actions(add("a"), add("b"), add("c"));
+        assertSame(raw, StateContext.pruneDynamicActions(raw));
+    }
+
+    @Test
+    void allRemovesIsReturnedAsIsWithoutBuildingTheNetMap() {
+        // Symmetric to the bulk-add case: a bulk clear (all REMOVEs) is homogeneous, nothing to collapse.
+        List<ComponentStruct> raw = actions(remove("a"), remove("b"), remove("c"));
+        assertSame(raw, StateContext.pruneDynamicActions(raw));
+    }
+
+    @Test
+    void aSingleRemoveStillEngagesTheNetCollapse() {
+        // Sanity that the short-circuit does not swallow the collapse path: with any REMOVE present the
+        // add/remove coalescing still runs (here the trailing REMOVE cancels the earlier ADD of 'a').
+        assertNet(actions(add("a"), add("b"), remove("a")), "ADD:b");
+    }
 
     private static void assertNet(List<ComponentStruct> raw, String... expected) {
         List<ComponentStruct> pruned = StateContext.pruneDynamicActions(raw);


### PR DESCRIPTION
Backports #5785 into 4.0 (3 commits cherry-picked from 4.1).

1. **Dynamic-action index rebuilt on every postback** — regression fix for #5783, which is on 4.0 via #5784. Guards the `clientId`-index build with `!isEmpty(actions)`.
2. **Reduce per-event/per-action allocation** on the dynamic add/remove path (live-list event dispatch + `pruneDynamicActions` short-circuit).
3. **Cache resolved converter/validator/behavior CDI beans** by class/id.

One cosmetic conflict in `Events.java` (4.0's old C-style array syntax); resolved by taking the rewritten method. Final diff content-identical to the merged 4.1 PR. Compiled and tested under JDK 11 — full `impl` module builds, all affected tests green (EventsTest, FaceletViewHandlingStrategyTest, StateContextTest, CdiLookupCountTest).

Part of #5753 
