### PR TITLE
Emit a development-stage warning when a component binding is not request scoped

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/applicationimpl/ComponentBindingScopeChecker.java
+++ b/impl/src/main/java/com/sun/faces/application/applicationimpl/ComponentBindingScopeChecker.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.faces.application.applicationimpl;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.sun.faces.util.FacesLogger;
+
+import jakarta.el.ValueExpression;
+import jakarta.faces.application.FacesMessage;
+import jakarta.faces.application.ProjectStage;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * Development-stage diagnostic that flags a component {@code binding} whose target retains the bound component across
+ * requests &mdash; the tell-tale sign that the binding resolves to a bean broader than request scope (session,
+ * application, view, conversation, flow, a {@code static} field, a session map, ...). Component bindings must be request
+ * scoped per the Jakarta Faces specification section 3.1.5 (Component Bindings): a {@code UIComponent} instance belongs
+ * to a single request's view tree and depends on running inside a single thread, so a wider scope causes duplicate
+ * component id errors, stale state and concurrency hazards.
+ * <p>
+ * Detection is scope-agnostic and symptom-based: every binding-resolved component is stamped with the sequence number
+ * of the request that first produced it, and a later request resolving the <em>same</em> instance is what triggers the
+ * warning. It never inspects whether the getter returned {@code null}: a correctly request-scoped bean may legitimately
+ * build its component in {@code @PostConstruct} (a non-null first getter), and that case must not be flagged. Only
+ * instance identity surviving a request boundary is. The stamp is held in the request map (the servlet request, i.e. the
+ * CDI request-scope boundary) rather than the {@code FacesContext}, so a single request that spans more than one
+ * {@code FacesContext} (servlet forward/include, error dispatch) is correctly treated as one request.
+ */
+final class ComponentBindingScopeChecker {
+
+    private static final Logger LOGGER = FacesLogger.APPLICATION.getLogger();
+
+    /**
+     * Maps each binding-resolved component to the sequence number of the request that first produced it. A weak key
+     * does not contribute to reachability, so this map never retains a component (or the tree it points at): a correctly
+     * request-scoped binding's component dies with its view at end of request exactly as it would without the map, and
+     * its now-cleared entry is expunged on the next access; only a too-broadly-scoped binding leaves a live entry, and
+     * then because the offending bean keeps the component alive, not this map. The value is a plain {@code Long} so it
+     * cannot resurrect the key. Comparison is by identity because {@link UIComponent} does not override
+     * {@code equals}/{@code hashCode}. The map and the sequence are intentionally JVM-global (shared across web
+     * applications); a dev diagnostic needs nothing more, since identity comparison and a monotonic sequence stay
+     * correct regardless.
+     */
+    private static final Map<UIComponent, Long> FIRST_SEEN_REQUEST = Collections.synchronizedMap(new WeakHashMap<>());
+
+    private static final AtomicLong REQUEST_SEQUENCE = new AtomicLong();
+
+    private static final String REQUEST_SEQUENCE_KEY = ComponentBindingScopeChecker.class.getName() + ".REQUEST_SEQUENCE";
+
+    private static final String MESSAGE_ID = "faces.component.binding.not.request.scoped";
+    private static final String MESSAGE_SUMMARY_ID = MESSAGE_ID + "_summary";
+    private static final String MESSAGE_DETAIL_ID = MESSAGE_ID + "_detail";
+
+    private ComponentBindingScopeChecker() {
+    }
+
+    /**
+     * Warns, in {@link ProjectStage#Development} only, when {@code component} (resolved from a binding expression) was
+     * already produced by an earlier request. The warning is logged and, unless an identical one is already queued,
+     * enqueued as a {@link FacesMessage} so it also surfaces on the page through {@code <h:messages>}.
+     *
+     * @param context the current faces context
+     * @param bindingExpression the {@code binding} value expression that produced the component
+     * @param component the resolved component, possibly {@code null}
+     */
+    static void check(FacesContext context, ValueExpression bindingExpression, UIComponent component) {
+        if (component == null || !context.isProjectStage(ProjectStage.Development)) {
+            return;
+        }
+
+        long currentRequest = currentRequestSequence(context);
+        Long firstSeenRequest = FIRST_SEEN_REQUEST.put(component, currentRequest);
+
+        if (firstSeenRequest != null && firstSeenRequest != currentRequest) {
+            String expression = bindingExpression.getExpressionString();
+            String summary = FacesLogger.APPLICATION.interpolateMessage(context, MESSAGE_SUMMARY_ID, new Object[] { expression });
+            String detail = FacesLogger.APPLICATION.interpolateMessage(context, MESSAGE_DETAIL_ID, new Object[0]);
+            LOGGER.log(Level.WARNING, MESSAGE_ID, new Object[] { summary, detail });
+
+            FacesMessage message = new FacesMessage(FacesMessage.SEVERITY_WARN, summary, detail);
+            if (!alreadyQueued(context, message)) {
+                context.addMessage(null, message);
+            }
+        }
+    }
+
+    private static boolean alreadyQueued(FacesContext context, FacesMessage message) {
+        for (FacesMessage queued : context.getMessageList()) {
+            if (message.getSummary().equals(queued.getSummary())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static long currentRequestSequence(FacesContext context) {
+        Map<String, Object> requestMap = context.getExternalContext().getRequestMap();
+        Long sequence = (Long) requestMap.get(REQUEST_SEQUENCE_KEY);
+
+        if (sequence == null) {
+            sequence = REQUEST_SEQUENCE.incrementAndGet();
+            requestMap.put(REQUEST_SEQUENCE_KEY, sequence);
+        }
+
+        return sequence;
+    }
+}

--- a/impl/src/main/java/com/sun/faces/application/applicationimpl/InstanceFactory.java
+++ b/impl/src/main/java/com/sun/faces/application/applicationimpl/InstanceFactory.java
@@ -654,6 +654,8 @@ public class InstanceFactory {
             throw new FacesException(ex);
         }
 
+        ComponentBindingScopeChecker.check(ctx, componentExpression, c);
+
         return c;
 
     }

--- a/impl/src/main/resources/com/sun/faces/LogStrings.properties
+++ b/impl/src/main/resources/com/sun/faces/LogStrings.properties
@@ -128,3 +128,6 @@ faces.lifecycle.invalid.referer=JSF1099: Referer [sic] header value {0} does not
 faces.lifecycle.invalid.origin=JSF1100: Origin [sic] header value {0} does not appear to be a protected view. Preventing display of viewId {1}
 faces.externalcontext.flash.force.write.cookie.failed=JSF1102: The system was configured to force writing the flash cookie, but the write failed.
 faces.metadata.invalid.location=JSF1103: The metadata facet must be a direct child of the view in viewId {0}
+faces.component.binding.not.request.scoped=JSF1104: {0} {1}
+faces.component.binding.not.request.scoped_summary=Component binding {0} resolved to a component that has survived across requests.
+faces.component.binding.not.request.scoped_detail=Component bindings must be request scoped per the Jakarta Faces specification section 3.1.5: a UIComponent belongs to a single request''s view tree and depends on running inside a single thread, so binding it to a wider scope can cause duplicate component id errors, stale state and concurrency bugs. Either bind to a request scoped (or unscoped) target; or, if you only need to populate the component, populate it from an f:event type="postAddToView" listener through event.getComponent() without retaining a reference; or look it up on demand via UIViewRoot.findComponent(id).

--- a/impl/src/test/java/com/sun/faces/application/applicationimpl/ComponentBindingScopeCheckerTest.java
+++ b/impl/src/test/java/com/sun/faces/application/applicationimpl/ComponentBindingScopeCheckerTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.faces.application.applicationimpl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import jakarta.el.ValueExpression;
+import jakarta.faces.application.Application;
+import jakarta.faces.application.FacesMessage;
+import jakarta.faces.application.ProjectStage;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIOutput;
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.FacesContext;
+
+class ComponentBindingScopeCheckerTest {
+
+    @Test
+    void warnsOnceWhenSameComponentSurvivesAcrossRequests() {
+        UIComponent leaked = new UIOutput();
+        ValueExpression binding = binding("#{sessionBean.component}");
+        List<FacesMessage> messages = new ArrayList<>();
+
+        try (MockedStatic<FacesContext> staticContext = mockStatic(FacesContext.class)) {
+            check(staticContext, request(true, messages), binding, leaked);
+            assertTrue(messages.isEmpty(), "First sighting must not warn");
+
+            check(staticContext, request(true, messages), binding, leaked);
+            assertEquals(1, messages.size(), "Cross-request reuse of the same instance must warn");
+            assertEquals(FacesMessage.SEVERITY_WARN, messages.get(0).getSeverity());
+            // Summary and detail must both resolve from the LogStrings bundle, not fall back to the raw message id.
+            assertTrue(messages.get(0).getSummary().contains("survived across requests"), messages.get(0).getSummary());
+            assertTrue(messages.get(0).getDetail().contains("findComponent"), messages.get(0).getDetail());
+
+            check(staticContext, request(true, messages), binding, leaked);
+            assertEquals(1, messages.size(), "A further request must not enqueue a duplicate page message");
+        }
+    }
+
+    @Test
+    void doesNotWarnOnReEvaluationWithinTheSameRequest() {
+        UIComponent component = new UIOutput();
+        ValueExpression binding = binding("#{requestBean.component}");
+        List<FacesMessage> messages = new ArrayList<>();
+
+        try (MockedStatic<FacesContext> staticContext = mockStatic(FacesContext.class)) {
+            FacesContext sameRequest = request(true, messages);
+            check(staticContext, sameRequest, binding, component);
+            check(staticContext, sameRequest, binding, component);
+            assertTrue(messages.isEmpty(), "Same instance within one request is normal, must not warn");
+        }
+    }
+
+    @Test
+    void doesNotWarnForDistinctComponentInstancesAcrossRequests() {
+        ValueExpression binding = binding("#{requestBean.component}");
+        List<FacesMessage> messages = new ArrayList<>();
+
+        try (MockedStatic<FacesContext> staticContext = mockStatic(FacesContext.class)) {
+            check(staticContext, request(true, messages), binding, new UIOutput());
+            check(staticContext, request(true, messages), binding, new UIOutput());
+            assertTrue(messages.isEmpty(), "A fresh instance each request is the request-scoped case, must not warn");
+        }
+    }
+
+    @Test
+    void doesNotWarnOutsideDevelopmentStage() {
+        UIComponent leaked = new UIOutput();
+        ValueExpression binding = binding("#{sessionBean.component}");
+        List<FacesMessage> messages = new ArrayList<>();
+
+        try (MockedStatic<FacesContext> staticContext = mockStatic(FacesContext.class)) {
+            check(staticContext, request(false, messages), binding, leaked);
+            check(staticContext, request(false, messages), binding, leaked);
+            assertTrue(messages.isEmpty(), "Must be silent outside Development stage");
+        }
+    }
+
+    // ---- helpers ----
+
+    private static void check(MockedStatic<FacesContext> staticContext, FacesContext context, ValueExpression binding, UIComponent component) {
+        staticContext.when(FacesContext::getCurrentInstance).thenReturn(context);
+        ComponentBindingScopeChecker.check(context, binding, component);
+    }
+
+    /**
+     * A mock {@link FacesContext} standing in for one request: its own request map (so each gets a distinct request
+     * sequence) and a shared message list that {@code addMessage} appends to and {@code getMessageList} returns.
+     */
+    private static FacesContext request(boolean development, List<FacesMessage> messages) {
+        Map<String, Object> requestMap = new HashMap<>();
+        ExternalContext externalContext = mock(ExternalContext.class);
+        when(externalContext.getRequestMap()).thenReturn(requestMap);
+
+        Application application = mock(Application.class);
+        when(application.getMessageBundle()).thenReturn(null);
+
+        FacesContext context = mock(FacesContext.class);
+        when(context.isProjectStage(ProjectStage.Development)).thenReturn(development);
+        when(context.getExternalContext()).thenReturn(externalContext);
+        when(context.getApplication()).thenReturn(application);
+        when(context.getMessageList()).thenReturn(messages);
+        doAnswer(invocation -> messages.add(invocation.getArgument(1))).when(context).addMessage(isNull(), any(FacesMessage.class));
+        return context;
+    }
+
+    private static ValueExpression binding(String expressionString) {
+        ValueExpression binding = mock(ValueExpression.class);
+        when(binding.getExpressionString()).thenReturn(expressionString);
+        return binding;
+    }
+}


### PR DESCRIPTION
Closes #5789.

## What
A `ProjectStage.Development` diagnostic that warns when a component `binding=` resolves to a component that has **survived across requests** — the symptom of a binding target broader than request scope, which Jakarta Faces spec §3.1.5 forbids ("UIComponent instances depend on running inside of a single thread").

## Why
Binding a component into a `@SessionScoped`/`@ApplicationScoped`/`@ViewScoped` (etc.) bean reuses the same `UIComponent` instance across requests → duplicate-id errors, stale state, memory leaks, concurrency hazards. Mojarra accepted it silently; the failures surface far from the cause.

## How
- Hook: `Application.createComponent(ValueExpression, …)` — the single chokepoint for declarative `binding=` (`InstanceFactory.createComponentApplyAnnotations`), gated to Development.
- Detection is symptom-based and scope-agnostic: each binding-resolved component is stamped (weak-keyed, by identity) with a per-request sequence held in the **servlet request** map; a later request resolving the same instance triggers the warning. It never inspects whether the getter returned `null`, so a request-scoped bean that builds its component in `@PostConstruct` is correctly not flagged. Catches every over-long holder — CDI scopes, legacy managed beans, a `static` field, a session map, OmniFaces scopes.
- Emitted as a `JSF1104` WARNING log and a Development-stage `FacesMessage` (surfaced via `<h:messages>`), deduped per request. Summary and detail are defined once in `LogStrings` and shared by both channels. The remedy names three fixes: request-scope the target; or hand the component to an `<f:event type="postAddToView">` listener and populate via `event.getComponent()` without retaining it; or look it up via `UIViewRoot.findComponent(id)`.

## Tests
`ComponentBindingScopeCheckerTest` — cross-request reuse warns once (+ dedupe), same-request re-evaluation doesn't, a fresh instance per request doesn't, silent outside Development. Full impl suite green.

## Notes
- Declarative `binding=` only; programmatic `setValueExpression("binding", …)` is out of scope.
- Production cost: one `isProjectStage` check per binding-component creation.
- The `WeakHashMap<UIComponent, Long>` never retains a tree — a weak key doesn't contribute to reachability, so a request-scoped component dies with its view as normal; only a leaked binding leaves a live entry, kept alive by the offending bean, not the map.

🤖 Generated with Claude Opus 4.8
