### PR TITLE
Trim per-component overhead on the dynamic add/remove path

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategy.java
@@ -180,10 +180,19 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
             UIComponent child = componentIndex.get(struct.getClientId());
 
             /*
+             * The buildView reapply that runs earlier in restoreView preserves programmatically-added
+             * children across the facelet refresh in their original order, so the child often already sits
+             * correctly under its parent. In that case skip the remove + re-add: getChildren().remove and
+             * getChildren().add each scan for the child (O(n) indexOf), i.e. O(n^2) over a large dynamic
+             * subtree, only to reproduce the position it already holds.
+             */
+            boolean alreadyInPlace = child != null && struct.getFacetName() == null && child.getParent() == parent;
+
+            /*
              * If Facelets engine restored the child before us we are going to use it, but we need to remove it before we can add it
              * in the correct place.
              */
-            if (child != null) {
+            if (child != null && !alreadyInPlace) {
                 if (struct.getFacetName() == null) {
                     parent.getChildren().remove(child);
                 } else {
@@ -214,7 +223,10 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
              * Now if we have the child we are going to add it back in.
              */
             if (child != null) {
-                if (struct.getFacetName() != null) {
+                if (alreadyInPlace) {
+                    // Child survived the facelet refresh under this parent; leave it where it is. The
+                    // bookkeeping below still runs.
+                } else if (struct.getFacetName() != null) {
                     parent.getFacets().put(struct.getFacetName(), child);
                     child.getAttributes().put(DYNAMIC_COMPONENT, child.getParent().getChildren().indexOf(child));
                 } else {

--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -1803,7 +1803,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
                     parent.getFacets().remove(struct.getFacetName());
                     parent.getFacets().put(struct.getFacetName(), child);
                     child.getClientId();
-                } else {
+                } else if (child.getParent() != parent) {
                     int childIndex = -1;
                     if (child.getAttributes().containsKey(DYNAMIC_COMPONENT)) {
                         childIndex = (Integer) child.getAttributes().get(DYNAMIC_COMPONENT);
@@ -1821,6 +1821,12 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
                     // Position the child was added at; avoids an O(n) getChildren().indexOf(child) per dynamic add.
                     child.getAttributes().put(DYNAMIC_COMPONENT, storedIndex);
                 }
+                // else: the child survived the facelet refresh already attached under this parent
+                // (markForDeletion deletes only facelet-created MARK_CREATED siblings, never the
+                // programmatically-added ones) and the refresh preserves their relative order, so it is
+                // already in place. Re-inserting it would erase+re-add via getChildren().add — an O(n)
+                // indexOf per action, i.e. O(n^2) over a large dynamic subtree — only to reproduce the
+                // position it already holds. Leave it; the bookkeeping below still runs.
                 stateContext.getDynamicComponents().put(struct.getClientId(), child);
                 if (child.getChildCount() == 0 && child.getFacetCount() == 0) {
                     componentIndex.put(struct.getClientId(), child);

--- a/impl/src/main/java/com/sun/faces/context/StateContext.java
+++ b/impl/src/main/java/com/sun/faces/context/StateContext.java
@@ -673,16 +673,8 @@ public class StateContext {
         @Override
         protected void handleAdd(FacesContext context, UIComponent component) {
             if (component.getParent() != null && component.getParent().isInView()) {
-                String id = component.getId();
-
-                /*
-                 * Since adding a component, can mean you are really reparenting it, we need to make sure the OLD clientId is not
-                 * cached, we do that by setting the id.
-                 */
-                if (id != null) {
-                    component.setId(id);
-                }
-
+                // The stale clientId that a reparent could leave behind is already invalidated by
+                // UIComponentBase.setParent, which runs before this event, so no setId is needed here.
                 String facetName = findFacetNameForComponent(component);
                 if (facetName != null) {
                     incrementDynamicChildCount(context, component.getParent());

--- a/impl/src/main/java/com/sun/faces/context/StateContext.java
+++ b/impl/src/main/java/com/sun/faces/context/StateContext.java
@@ -626,12 +626,10 @@ public class StateContext {
          */
         @Override
         public List<ComponentStruct> getDynamicActions() {
-            synchronized (this) {
-                if (dynamicActions == null) {
-                    dynamicActions = new ArrayList<>();
-                }
+            if (dynamicActions == null) {
+                dynamicActions = new ArrayList<>();
             }
-            
+
             return dynamicActions;
         }
 
@@ -642,12 +640,10 @@ public class StateContext {
          */
         @Override
         public HashMap<String, UIComponent> getDynamicComponents() {
-            synchronized (this) {
-                if (dynamicComponents == null) {
-                    dynamicComponents = new HashMap<>();
-                }
+            if (dynamicComponents == null) {
+                dynamicComponents = new HashMap<>();
             }
-            
+
             return dynamicComponents;
         }
 

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -1662,7 +1662,9 @@ public abstract class UIComponentBase extends UIComponent {
         return NOT_MARKER;
     }
 
-    private void markerPut(Object key, Object value) {
+    // Returns true if the key is a marker (so AttributesMap can skip the getPropertyDescriptor probe:
+    // a framework marker is never a JavaBean property, so the lookup is guaranteed to miss).
+    private boolean markerPut(Object key, Object value) {
         if (MARK_CREATED.equals(key)) {
             markCreated = (String) value;
         } else if (KEY.equals(key)) {
@@ -1675,10 +1677,13 @@ public abstract class UIComponentBase extends UIComponent {
             markDeleted = Boolean.TRUE.equals(value);
         } else if (MARK_CHILDREN_MODIFIED.equals(key)) {
             markChildrenModified = Boolean.TRUE.equals(value);
+        } else {
+            return false;
         }
+        return true;
     }
 
-    private void markerRemove(Object key) {
+    private boolean markerRemove(Object key) {
         if (MARK_CREATED.equals(key)) {
             markCreated = null;
         } else if (KEY.equals(key)) {
@@ -1691,7 +1696,10 @@ public abstract class UIComponentBase extends UIComponent {
             markDeleted = false;
         } else if (MARK_CHILDREN_MODIFIED.equals(key)) {
             markChildrenModified = false;
+        } else {
+            return false;
         }
+        return true;
     }
 
     // Full-state restore deserializes the tree without re-running buildView, so the marker fields are synced
@@ -2273,7 +2281,7 @@ public abstract class UIComponentBase extends UIComponent {
             }
 
             // Keep the field cache in sync; the value is still stored in the attributes map below.
-            component.markerPut(keyValue, value);
+            boolean marker = component.markerPut(keyValue, value);
 
             if (ATTRIBUTES_THAT_ARE_SET_KEY.equals(keyValue)) {
                 if (component.attributesThatAreSet == null) {
@@ -2284,7 +2292,8 @@ public abstract class UIComponentBase extends UIComponent {
                 return null;
             }
 
-            PropertyDescriptor pd = getPropertyDescriptor(keyValue);
+            // A marker key is never a JavaBean property; skip the descriptor probe and store it directly.
+            PropertyDescriptor pd = marker ? null : getPropertyDescriptor(keyValue);
             if (pd != null) {
                 try {
                     Object result = null;
@@ -2337,11 +2346,11 @@ public abstract class UIComponentBase extends UIComponent {
             if (key == null) {
                 throw new NullPointerException();
             }
-            component.markerRemove(key);
+            boolean marker = component.markerRemove(key);
             if (ATTRIBUTES_THAT_ARE_SET_KEY.equals(key)) {
                 return null;
             }
-            PropertyDescriptor pd = getPropertyDescriptor(key);
+            PropertyDescriptor pd = marker ? null : getPropertyDescriptor(key);
             if (pd != null) {
                 throw new IllegalArgumentException(key);
             } else {

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -348,6 +348,8 @@ public abstract class UIComponentBase extends UIComponent {
         cachedRenderer = null;
         // The parent chain changed, so the cached NamingContainer ancestor is no longer valid.
         namingContainerAncestor = null;
+        // The client id is derived from the parent chain, so a reparent invalidates it too.
+        clientId = null;
 
         if (parent == null) {
             if (this.parent != null) {


### PR DESCRIPTION
Part of #5753. Four independent, low-risk reductions of per-component cost on the dynamic add/remove path (programmatic `getChildren().add()/remove()` after `markInitialState`), which `dynamic-toggle-ajax` in `test/perf` exercises. These trim genuine overhead without changing *where* the work happens — the deliberate phase placement (see Result) is left intact.

## Commits

1. **Skip remove+re-add of already-in-place dynamic children on restore** — the `buildView` reapply already preserves programmatically-added children in their original order, so a dynamic child usually already sits correctly under its parent. The remove+re-add then cost an O(n) `getChildren().remove` + O(n) `add` per action — O(n²) over a large dynamic subtree — only to reproduce the position it already held. Detect the already-in-place case and leave it; the bookkeeping still runs.

2. **Skip the property-descriptor probe on attribute marker writes** — `AttributesMap.put`/`remove` ran `getPropertyDescriptor` for every key, but a framework marker (`DYNAMIC_COMPONENT`, `MARK_CREATED`, `MARK_DELETED`, …) is never a JavaBean property, so the lookup always missed. `markerPut`/`markerRemove` now report whether the key was a marker, letting put/remove skip the descriptor probe and store directly. Behavior-unchanged: markers already fell through to the state-map branch.

3. **Drop synchronization from the dynamic-action getters** — `getDynamicActions`/`getDynamicComponents` wrapped their lazy-init in `synchronized(this)`, taken per add/remove while recording and per struct while replaying on restore. The lock guarded only the null-init while every `add`/`put`/`get` runs unsynchronized, so it never provided real thread-safety; the listener is request-thread-confined anyway (fresh view + `StateContext` + listener per request under PSS). Spun off #5789.

4. **Invalidate cached clientId in `setParent`; drop dynamic-add `setId`** — a component's clientId is derived from its parent chain, yet `setParent` invalidated the cached Renderer and NamingContainer ancestor but left the clientId string stale across a reparent. `StateContext.handleAdd` compensated with a per-add `setId(id)` purely to clear that cache, dragging `validateId` and an id state-write along on every add. Clear clientId in `setParent` (where the parent chain changes, consistent with the adjacent cache clears) and drop the now-redundant `setId`. Also fixes the latent stale-clientId-on-reparent case outside the dynamic path.

## Result
These reductions trim per-component overhead along the dynamic add/remove path — both where Mojarra *records* a mutation and where it *replays* one — without moving *where* the work happens. The deliberate phase placement stays intact:

- **MyFaces** persists each toggled subtree as full component state and eagerly reconstructs it during RESTORE_VIEW (`handleDynamicAddedRemovedComponents`), so its restore is heavy and its render is near-pure encoding.
- **Mojarra** persists a compact `ComponentStruct` add/remove list: it *records* each mutation when the action makes it (INVOKE_APPLICATION, via the `StateContext` listener) and *re-applies the Facelet + replays the actions* at RENDER (`RenderResponsePhase` → `buildView` populated-branch → `reapplyDynamicActions`), re-evaluating structural EL against the post-action model. Restore stays light, and because the *populate* (not the action) is what's deferred, a navigating/redirecting action — which skips RENDER — never pays the render-time reconstruction for a view it abandons. Note: this design existed since #2339 and has not been rearchitected since. It's just performance-optimized.

A per-phase JFR sample profile of `dynamic-toggle-ajax` (equal duration, equal request volume) shows the split: MyFaces spends ~20% of its CPU in RESTORE vs Mojarra's ~6% (MyFaces ~2× heavier restore), with Mojarra's offset landing in INVOKE (mutation recording) and RENDER (the Facelet re-apply + action replay, atop the navigation-agnostic `AttributesMap` encode tax tracked separately). These four changes shave per-component cost on both ends of that path — `validateId`/`setId`, the O(n) remove+re-add, the marker descriptor probe, the per-add synchronization — leaving the sound restore-vs-render trade unchanged.

## Testing
Full `impl` test suite green; `PerfBenchIT` (`dynamic-toggle-ajax`) green (validates the ajax responses, i.e. dynamic add/remove correctness). The equivalent four changes ported to 5.0 (`master` + the `jakarta.faces` API) pass the **full Jakarta Faces 5.0 TCK**.

🤖 Generated with Claude Opus 4.8

