### PR TITLE
Backport #5791 and #5793 into 4.0

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/applicationimpl/Events.java
+++ b/impl/src/main/java/com/sun/faces/application/applicationimpl/Events.java
@@ -182,7 +182,7 @@ public class Events {
         if (source instanceof SystemEventListenerHolder) {
 
             List<SystemEventListener> listeners = ((SystemEventListenerHolder) source).getListenersForEventClass(systemEventClass);
-            if (null == listeners) {
+            if (listeners == null || listeners.isEmpty()) {
                 return null;
             }
             EventInfo eventInfo = compSysEventHelper.getEventInfo(systemEventClass, source.getClass());

--- a/impl/src/main/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategy.java
@@ -180,10 +180,19 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
             UIComponent child = componentIndex.get(struct.getClientId());
 
             /*
+             * The buildView reapply that runs earlier in restoreView preserves programmatically-added
+             * children across the facelet refresh in their original order, so the child often already sits
+             * correctly under its parent. In that case skip the remove + re-add: getChildren().remove and
+             * getChildren().add each scan for the child (O(n) indexOf), i.e. O(n^2) over a large dynamic
+             * subtree, only to reproduce the position it already holds.
+             */
+            boolean alreadyInPlace = child != null && struct.getFacetName() == null && child.getParent() == parent;
+
+            /*
              * If Facelets engine restored the child before us we are going to use it, but we need to remove it before we can add it
              * in the correct place.
              */
-            if (child != null) {
+            if (child != null && !alreadyInPlace) {
                 if (struct.getFacetName() == null) {
                     parent.getChildren().remove(child);
                 } else {
@@ -214,7 +223,10 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
              * Now if we have the child we are going to add it back in.
              */
             if (child != null) {
-                if (struct.getFacetName() != null) {
+                if (alreadyInPlace) {
+                    // Child survived the facelet refresh under this parent; leave it where it is. The
+                    // bookkeeping below still runs.
+                } else if (struct.getFacetName() != null) {
                     parent.getFacets().put(struct.getFacetName(), child);
                     child.getAttributes().put(DYNAMIC_COMPONENT, child.getParent().getChildren().indexOf(child));
                 } else {

--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -1803,7 +1803,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
                     parent.getFacets().remove(struct.getFacetName());
                     parent.getFacets().put(struct.getFacetName(), child);
                     child.getClientId();
-                } else {
+                } else if (child.getParent() != parent) {
                     int childIndex = -1;
                     if (child.getAttributes().containsKey(DYNAMIC_COMPONENT)) {
                         childIndex = (Integer) child.getAttributes().get(DYNAMIC_COMPONENT);
@@ -1821,6 +1821,12 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
                     // Position the child was added at; avoids an O(n) getChildren().indexOf(child) per dynamic add.
                     child.getAttributes().put(DYNAMIC_COMPONENT, storedIndex);
                 }
+                // else: the child survived the facelet refresh already attached under this parent
+                // (markForDeletion deletes only facelet-created MARK_CREATED siblings, never the
+                // programmatically-added ones) and the refresh preserves their relative order, so it is
+                // already in place. Re-inserting it would erase+re-add via getChildren().add — an O(n)
+                // indexOf per action, i.e. O(n^2) over a large dynamic subtree — only to reproduce the
+                // position it already holds. Leave it; the bookkeeping below still runs.
                 stateContext.getDynamicComponents().put(struct.getClientId(), child);
                 if (child.getChildCount() == 0 && child.getFacetCount() == 0) {
                     componentIndex.put(struct.getClientId(), child);

--- a/impl/src/main/java/com/sun/faces/context/StateContext.java
+++ b/impl/src/main/java/com/sun/faces/context/StateContext.java
@@ -673,16 +673,8 @@ public class StateContext {
         @Override
         protected void handleAdd(FacesContext context, UIComponent component) {
             if (component.getParent() != null && component.getParent().isInView()) {
-                String id = component.getId();
-
-                /*
-                 * Since adding a component, can mean you are really reparenting it, we need to make sure the OLD clientId is not
-                 * cached, we do that by setting the id.
-                 */
-                if (id != null) {
-                    component.setId(id);
-                }
-
+                // The stale clientId that a reparent could leave behind is already invalidated by
+                // UIComponentBase.setParent, which runs before this event, so no setId is needed here.
                 String facetName = findFacetNameForComponent(component);
                 if (facetName != null) {
                     incrementDynamicChildCount(context, component.getParent());

--- a/impl/src/main/java/com/sun/faces/context/StateContext.java
+++ b/impl/src/main/java/com/sun/faces/context/StateContext.java
@@ -626,12 +626,10 @@ public class StateContext {
          */
         @Override
         public List<ComponentStruct> getDynamicActions() {
-            synchronized (this) {
-                if (dynamicActions == null) {
-                    dynamicActions = new ArrayList<>();
-                }
+            if (dynamicActions == null) {
+                dynamicActions = new ArrayList<>();
             }
-            
+
             return dynamicActions;
         }
 
@@ -642,12 +640,10 @@ public class StateContext {
          */
         @Override
         public HashMap<String, UIComponent> getDynamicComponents() {
-            synchronized (this) {
-                if (dynamicComponents == null) {
-                    dynamicComponents = new HashMap<>();
-                }
+            if (dynamicComponents == null) {
+                dynamicComponents = new HashMap<>();
             }
-            
+
             return dynamicComponents;
         }
 

--- a/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
@@ -389,7 +389,7 @@ public class RenderKitUtils {
             behaviors = Collections.emptyMap();
         }
 
-        List<String> setAttributes = (List<String>) component.getAttributes().get(ATTRIBUTES_THAT_ARE_SET_KEY);
+        List<String> setAttributes = getAttributesThatAreSet(component);
 
         if (setAttributes != null && canBeOptimized(component, behaviors)) {
             renderPassThruAttributesOptimized(context, writer, component, attributes, setAttributes, behaviors);
@@ -399,6 +399,39 @@ public class RenderKitUtils {
             // attached to multiple events. We make no assumptions and loop through
             renderPassThruAttributesUnoptimized(context, writer, component, attributes, setAttributes, behaviors);
         }
+    }
+
+    /**
+     * Returns the names of the attributes that have been explicitly set on the given component, either as a literal value
+     * or as a value expression, or {@code null} when none have been set. This is the same list that
+     * {@link #renderPassThruAttributes} consults to skip reflective reads of attributes that were never set.
+     */
+    @SuppressWarnings("unchecked")
+    public static List<String> getAttributesThatAreSet(UIComponent component) {
+        return (List<String>) component.getAttributes().get(ATTRIBUTES_THAT_ARE_SET_KEY);
+    }
+
+    /**
+     * Returns the value of the named attribute, avoiding a reflective property read for an attribute that was never set.
+     * <p>
+     * This is only safe for attributes whose setters record into {@code setAttributes} (i.e. those rendered through the
+     * pass-through machinery) and only for the standard components that maintain that list; for any other component the
+     * value is read directly, mirroring the fall-back in {@link #renderPassThruAttributes}. In particular {@code styleClass}
+     * is never tracked (it is rendered inline as {@code class}, not via the pass-through loop) and must not be passed here.
+     */
+    public static Object getAttributeIfSet(UIComponent component, List<String> setAttributes, String name) {
+        if (component.getClass().getName().startsWith(OPTIMIZED_PACKAGE)) {
+            return setAttributes != null && setAttributes.contains(name) ? component.getAttributes().get(name) : null;
+        }
+        return component.getAttributes().get(name);
+    }
+
+    /**
+     * Convenience variant of {@link #getAttributeIfSet(UIComponent, List, String)} for a single read; callers reading
+     * several attributes should fetch {@link #getAttributesThatAreSet} once and use the three-argument form instead.
+     */
+    public static Object getAttributeIfSet(UIComponent component, String name) {
+        return getAttributeIfSet(component, getAttributesThatAreSet(component), name);
     }
 
     private static void renderValueChangeEventListener(FacesContext context, UIComponent component, String clientId,

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/ButtonRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/ButtonRenderer.java
@@ -104,7 +104,7 @@ public class ButtonRenderer extends HtmlBasicRenderer {
             writer.writeURIAttribute("src", RenderKitUtils.getImageSource(context, component, "image"), "image");
             writer.writeAttribute("name", clientId, "clientId");
 
-            String alt = (String) component.getAttributes().get("alt");
+            String alt = (String) RenderKitUtils.getAttributeIfSet(component, "alt");
             if (alt != null) {
                 writer.writeAttribute("alt", alt, "alt");
             }

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/CommandLinkRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/CommandLinkRenderer.java
@@ -122,7 +122,7 @@ public class CommandLinkRenderer extends LinkRenderer {
             writer.endElement("a");
 
             if (ResourceHandlerImpl.resolveCurrentNonce(context) != null) {
-                String target = (String) component.getAttributes().get("target");
+                String target = (String) RenderKitUtils.getAttributeIfSet(component, "target");
                 if (target != null) {
                     target = target.trim();
                 } else {
@@ -169,7 +169,7 @@ public class CommandLinkRenderer extends LinkRenderer {
         RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, command);
 
         if (ResourceHandlerImpl.resolveCurrentNonce(context) == null) {
-            String target = (String) command.getAttributes().get("target");
+            String target = (String) RenderKitUtils.getAttributeIfSet(command, "target");
             if (target != null) {
                 target = target.trim();
             } else {

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/GroupRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/GroupRenderer.java
@@ -45,7 +45,7 @@ public class GroupRenderer extends HtmlBasicRenderer {
             return;
         }
         // Render a span around this group if necessary
-        String style = (String) component.getAttributes().get("style");
+        String style = (String) RenderKitUtils.getAttributeIfSet(component, "style");
         String styleClass = (String) component.getAttributes().get("styleClass");
         ResponseWriter writer = context.getResponseWriter();
 
@@ -123,7 +123,7 @@ public class GroupRenderer extends HtmlBasicRenderer {
      */
     private boolean divOrSpan(UIComponent component) {
 
-        return shouldWriteIdAttribute(component) || component.getAttributes().get("style") != null || component.getAttributes().get("styleClass") != null;
+        return shouldWriteIdAttribute(component) || RenderKitUtils.getAttributeIfSet(component, "style") != null || component.getAttributes().get("styleClass") != null;
 
     }
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/ImageRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/ImageRenderer.java
@@ -64,7 +64,7 @@ public class ImageRenderer extends HtmlBasicRenderer {
         writeIdAttributeIfNecessary(context, writer, component);
         writer.writeURIAttribute("src", RenderKitUtils.getImageSource(context, component, "value"), "value");
         // if we're writing XHTML and we have a null alt attribute
-        if (writer.getContentType().equals(RIConstants.XHTML_CONTENT_TYPE) && null == component.getAttributes().get("alt")) {
+        if (writer.getContentType().equals(RIConstants.XHTML_CONTENT_TYPE) && null == RenderKitUtils.getAttributeIfSet(component, "alt")) {
             // write out an empty alt
             writer.writeAttribute("alt", "", "alt");
         }

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/MessageRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/MessageRenderer.java
@@ -20,6 +20,7 @@ package com.sun.faces.renderkit.html_basic;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.List;
 
 import com.sun.faces.renderkit.RenderKitUtils;
 
@@ -148,11 +149,12 @@ public class MessageRenderer extends HtmlBasicRenderer {
             severityStyleClass = (String) component.getAttributes().get("fatalClass");
         }
 
-        String style = (String) component.getAttributes().get("style");
+        List<String> setAttributes = RenderKitUtils.getAttributesThatAreSet(component);
+        String style = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "style");
         String styleClass = (String) component.getAttributes().get("styleClass");
-        String dir = (String) component.getAttributes().get("dir");
-        String lang = (String) component.getAttributes().get("lang");
-        String title = (String) component.getAttributes().get("title");
+        String dir = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "dir");
+        String lang = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "lang");
+        String title = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "title");
 
         // if we have style and severityStyle
         if (style != null && severityStyle != null) {

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/MessagesRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/MessagesRenderer.java
@@ -179,7 +179,7 @@ public class MessagesRenderer extends HtmlBasicRenderer {
             boolean wroteTooltip = false;
             if (isTooltip) {
                 writer.startElement("span", component);
-                String title = (String) component.getAttributes().get("title");
+                String title = (String) RenderKitUtils.getAttributeIfSet(component, "title");
                 if (title == null || title.length() == 0) {
                     writer.writeAttribute("title", detail, "title");
                 }

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutcomeTargetButtonRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutcomeTargetButtonRenderer.java
@@ -56,7 +56,7 @@ public class OutcomeTargetButtonRenderer extends OutcomeTargetRenderer {
             writer.writeAttribute("type", "image", "type");
             writer.writeURIAttribute("src", RenderKitUtils.getImageSource(context, component, "image"), "image");
 
-            String alt = (String) component.getAttributes().get("alt");
+            String alt = (String) RenderKitUtils.getAttributeIfSet(component, "alt");
             if (alt == null) {
                 writer.writeAttribute("alt", alt, "alt");
             }
@@ -124,7 +124,7 @@ public class OutcomeTargetButtonRenderer extends OutcomeTargetRenderer {
 
     protected String getOnclick(UIComponent component, String targetURI) {
 
-        String onclick = (String) component.getAttributes().get("onclick");
+        String onclick = (String) RenderKitUtils.getAttributeIfSet(component, "onclick");
 
         if (onclick != null) {
             onclick = onclick.trim();

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutcomeTargetLinkRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutcomeTargetLinkRenderer.java
@@ -157,12 +157,13 @@ public class OutcomeTargetLinkRenderer extends OutcomeTargetRenderer {
         // target/onclick should be pass through, but right now, due to command Link,
         // they all share the same base properties file which marks them as non
         // pass-through
-        String target = (String) component.getAttributes().get("target");
+        List<String> setAttributes = RenderKitUtils.getAttributesThatAreSet(component);
+        String target = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "target");
         if (target != null && target.length() > 0) {
             writer.writeAttribute("target", target, "target");
         }
 
-        String onclick = (String) component.getAttributes().get("onclick");
+        String onclick = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "onclick");
         if (onclick != null && onclick.length() > 0) {
             writer.writeAttribute("onclick", onclick, "onclick");
         }

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutputLinkRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutputLinkRenderer.java
@@ -191,7 +191,7 @@ public class OutputLinkRenderer extends LinkRenderer {
         RenderKitUtils.renderPassThruAttributes(context, writer, component, ATTRIBUTES);
         RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, component);
 
-        String target = (String) component.getAttributes().get("target");
+        String target = (String) RenderKitUtils.getAttributeIfSet(component, "target");
         if (target != null && target.trim().length() != 0) {
             writer.writeAttribute("target", target, "target");
         }

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutputMessageRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutputMessageRenderer.java
@@ -92,11 +92,12 @@ public class OutputMessageRenderer extends HtmlBasicInputRenderer {
         ResponseWriter writer = context.getResponseWriter();
         assert writer != null;
 
-        String style = (String) component.getAttributes().get("style");
+        List<String> setAttributes = RenderKitUtils.getAttributesThatAreSet(component);
+        String style = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "style");
         String styleClass = (String) component.getAttributes().get("styleClass");
-        String lang = (String) component.getAttributes().get("lang");
-        String dir = (String) component.getAttributes().get("dir");
-        String title = (String) component.getAttributes().get("title");
+        String lang = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "lang");
+        String dir = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "dir");
+        String title = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "title");
         boolean wroteSpan = false;
         if (styleClass != null || style != null || dir != null || lang != null || title != null || shouldWriteIdAttribute(component)) {
             writer.startElement("span", component);

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/RadioRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/RadioRenderer.java
@@ -299,7 +299,7 @@ public class RadioRenderer extends SelectManyCheckboxListRenderer implements Com
                 writer.writeAttribute("class", styleClass, "class");
             }
 
-            String style = (String) component.getAttributes().get("style");
+            String style = (String) RenderKitUtils.getAttributeIfSet(component, "style");
             if (style != null) {
                 writer.writeAttribute("style", style, "style");
             }

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/ScriptStyleBaseRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/ScriptStyleBaseRenderer.java
@@ -23,6 +23,7 @@ import java.util.logging.Logger;
 
 import com.sun.faces.application.ApplicationAssociate;
 import com.sun.faces.util.FacesLogger;
+import com.sun.faces.renderkit.RenderKitUtils;
 
 import jakarta.faces.application.FacesMessage;
 import jakarta.faces.application.ProjectStage;
@@ -69,7 +70,7 @@ public abstract class ScriptStyleBaseRenderer extends Renderer implements Compon
         UIComponent component = event.getComponent();
         FacesContext context = FacesContext.getCurrentInstance();
 
-        String target = verifyTarget((String) component.getAttributes().get("target"));
+        String target = verifyTarget((String) RenderKitUtils.getAttributeIfSet(component, "target"));
         if (target != null) {
             // We're checking for a composite component here as if the resource
             // is relocated, it may still require it's composite component context

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/SelectManyCheckboxListRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/SelectManyCheckboxListRenderer.java
@@ -74,7 +74,7 @@ public class SelectManyCheckboxListRenderer extends MenuRenderer {
                 newTableRow = alignStr.equalsIgnoreCase("pageDirection");
             }
         }
-        if (null != (borderObj = component.getAttributes().get("border"))) {
+        if (null != (borderObj = RenderKitUtils.getAttributeIfSet(component, "border"))) {
             border = (Integer) borderObj;
         }
 
@@ -183,7 +183,7 @@ public class SelectManyCheckboxListRenderer extends MenuRenderer {
                 writeIdAttributeIfNecessary(context, writer, component);
             }
             String styleClass = (String) component.getAttributes().get("styleClass");
-            String style = (String) component.getAttributes().get("style");
+            String style = (String) RenderKitUtils.getAttributeIfSet(component, "style");
             if (styleClass != null) {
                 writer.writeAttribute("class", styleClass, "class");
             }

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/TextRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/TextRenderer.java
@@ -21,6 +21,7 @@ package com.sun.faces.renderkit.html_basic;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import jakarta.faces.application.FacesMessage;
@@ -80,11 +81,12 @@ public class TextRenderer extends HtmlBasicInputRenderer {
         boolean shouldWriteIdAttribute = false;
         boolean isOutput = false;
 
-        String style = (String) component.getAttributes().get("style");
+        List<String> setAttributes = RenderKitUtils.getAttributesThatAreSet(component);
+        String style = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "style");
         String styleClass = (String) component.getAttributes().get("styleClass");
-        String dir = (String) component.getAttributes().get("dir");
-        String lang = (String) component.getAttributes().get("lang");
-        String title = (String) component.getAttributes().get("title");
+        String dir = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "dir");
+        String lang = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "lang");
+        String title = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "title");
         Map<String, Object> passthroughAttributes = component.getPassThroughAttributes(false);
         boolean hasPassthroughAttributes = null != passthroughAttributes && !passthroughAttributes.isEmpty();
         if (component instanceof UIInput) {

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/TextRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/TextRenderer.java
@@ -65,6 +65,14 @@ public class TextRenderer extends HtmlBasicInputRenderer {
         return Collections.unmodifiableMap(map);
     }
 
+    private final boolean allowTextChildren;
+
+    // ------------------------------------------------------------ Constructors
+
+    public TextRenderer() {
+        allowTextChildren = WebConfiguration.getInstance().isOptionEnabled(WebConfiguration.BooleanWebContextInitParameter.AllowTextChildren);
+    }
+
     // ---------------------------------------------------------- Public Methods
 
     @Override
@@ -177,9 +185,7 @@ public class TextRenderer extends HtmlBasicInputRenderer {
 
     @Override
     public void encodeChildren(FacesContext context, UIComponent component) throws IOException {
-        boolean renderChildren = WebConfiguration.getInstance().isOptionEnabled(WebConfiguration.BooleanWebContextInitParameter.AllowTextChildren);
-
-        if (!renderChildren) {
+        if (!allowTextChildren) {
             return;
         }
 

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -347,6 +347,8 @@ public abstract class UIComponentBase extends UIComponent {
         cachedRenderer = null;
         // The parent chain changed, so the cached NamingContainer ancestor is no longer valid.
         namingContainerAncestor = null;
+        // The client id is derived from the parent chain, so a reparent invalidates it too.
+        clientId = null;
 
         if (parent == null) {
             if (this.parent != null) {

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -111,19 +111,20 @@ public abstract class UIComponentBase extends UIComponent {
     private static final int CHILD_STATE = 1;
 
     /**
-     * <p>
-     * Each entry is an map of <code>PropertyDescriptor</code>s describing the properties of a concrete {@link UIComponent}
-     * implementation, keyed by the corresponding <code>java.lang.Class</code>.
-     * </p>
-     *
-     */
-    private Map<Class<?>, Map<String, PropertyDescriptor>> descriptors;
-
-    /**
-     * Reference to the map of <code>PropertyDescriptor</code>s for this class in the <code>descriptors<code>
-     * <code>Map<code>.
+     * This class's <code>PropertyDescriptor</code>s (keyed by property name) within the application-scoped descriptors
+     * cache &mdash; the {@code Map<Class, Map<String, PropertyDescriptor>>} kept in the application map (see
+     * {@link #populateDescriptorsMapIfNecessary}).
      */
     private Map<String, PropertyDescriptor> propertyDescriptorMap;
+
+    /**
+     * This class's read methods (keyed by property name) within the application-scoped read-methods cache &mdash; the
+     * {@code Map<Class, Map<String, Method>>} kept in the application map alongside the descriptors cache (see
+     * {@link #populateDescriptorsMapIfNecessary}). It holds the access-suppressed read {@link Method}s strongly, which
+     * keeps the suppression durable (a {@link PropertyDescriptor}'s read method is handed back via a soft reference that
+     * can be regenerated) and lets the hot attribute-read path skip re-suppressing and re-caching it per component.
+     */
+    private Map<String, Method> readMethodMap;
 
     private Map<Class<? extends SystemEvent>, List<SystemEventListener>> listenersByEventClass;
 
@@ -1629,6 +1630,10 @@ public abstract class UIComponentBase extends UIComponent {
         return propertyDescriptorMap;
     }
 
+    Map<String, Method> getReadMethodMap() {
+        return readMethodMap;
+    }
+
     // ---- Field-backed Facelets markers (authoritative cache for AttributesMap) ----
     // The marker fields are the single source of truth: AttributesMap.put/remove keep them in sync, and
     // AttributesMap.get/containsKey read them WITHOUT touching the state map -- so the per-component
@@ -2151,7 +2156,9 @@ public abstract class UIComponentBase extends UIComponent {
 
         // private Map<String, Object> attributes;
         private transient Map<String, PropertyDescriptor> pdMap;
-        private transient ConcurrentMap<String, Method> readMap;
+        // Per-class, application-scoped cache of access-suppressed read methods (see UIComponentBase.readMethodMap);
+        // a hit skips the PropertyDescriptor lookup, the access-check suppression and the reflective getter discovery.
+        private transient Map<String, Method> readMap;
         private transient UIComponentBase component;
         private static final long serialVersionUID = -6773035086539772945L;
 
@@ -2161,6 +2168,7 @@ public abstract class UIComponentBase extends UIComponent {
 
             this.component = (UIComponentBase) component;
             pdMap = this.component.getDescriptorMap();
+            readMap = this.component.getReadMethodMap();
         }
 
         @Override
@@ -2203,9 +2211,9 @@ public abstract class UIComponentBase extends UIComponent {
             // Resolved lazily: the property-backed fast path below never needs it.
             Map<String, Object> attributes = null;
             if (null == result) {
-                // A previously-resolved property getter is cached by name. Invoke it directly and skip the
-                // per-read PropertyDescriptor lookup -- the descriptor is only needed to discover the getter
-                // once. This is the hot path when the same component is rendered repeatedly (UIData/UIRepeat rows).
+                // The access-suppressed property getter is cached per class by name. Invoke it directly and skip the
+                // per-read PropertyDescriptor lookup and access-check suppression -- the descriptor is only needed to
+                // discover the getter once per class. This is the hot path for every property-backed attribute read.
                 Method readMethod = readMap == null ? null : readMap.get(key);
                 if (readMethod != null) {
                     result = invokeReadMethod(readMethod);
@@ -2214,11 +2222,7 @@ public abstract class UIComponentBase extends UIComponent {
                     if (pd != null) {
                         readMethod = pd.getReadMethod();
                         if (readMethod != null) {
-                            if (null == readMap) {
-                                readMap = new ConcurrentHashMap<>();
-                            }
                             suppressAccessCheck(readMethod);
-                            readMap.putIfAbsent(key, readMethod);
                             result = invokeReadMethod(readMethod);
                         } else {
                             throw new IllegalArgumentException(key);
@@ -3409,10 +3413,14 @@ public abstract class UIComponentBase extends UIComponent {
 
     private static final String COMPONENT_DESCRIPTORS_MAP_KEY = "com.sun.faces.component.COMPONENT_DESCRIPTORS_MAP";
 
+    private static final String COMPONENT_READ_METHODS_MAP_KEY = "com.sun.faces.component.COMPONENT_READ_METHODS_MAP";
+
     @SuppressWarnings("unchecked")
     private void populateDescriptorsMapIfNecessary() {
         FacesContext facesContext = FacesContext.getCurrentInstance();
         Class<?> clazz = getClass();
+        Map<Class<?>, Map<String, PropertyDescriptor>> descriptors = null;
+        Map<Class<?>, Map<String, Method>> readMethods = null;
 
         /*
          * If we can find a valid FacesContext we are going to use it to get access to the property descriptor map.
@@ -3424,6 +3432,10 @@ public abstract class UIComponentBase extends UIComponent {
             descriptors = (Map<Class<?>, Map<String, PropertyDescriptor>>) applicationMap.computeIfAbsent(
                     COMPONENT_DESCRIPTORS_MAP_KEY, k -> new ConcurrentHashMap<>());
             propertyDescriptorMap = descriptors.get(clazz);
+
+            readMethods = (Map<Class<?>, Map<String, Method>>) applicationMap.computeIfAbsent(
+                    COMPONENT_READ_METHODS_MAP_KEY, k -> new ConcurrentHashMap<>());
+            readMethodMap = readMethods.get(clazz);
         }
 
         if (propertyDescriptorMap == null) {
@@ -3433,13 +3445,15 @@ public abstract class UIComponentBase extends UIComponent {
             PropertyDescriptor propertyDescriptors[] = getPropertyDescriptors();
             if (propertyDescriptors != null) {
                 propertyDescriptorMap = new HashMap<>(propertyDescriptors.length, 1.0f);
+                readMethodMap = new HashMap<>(propertyDescriptors.length, 1.0f);
                 for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
-                    // Suppress the access check up front (see AttributesMap.suppressAccessCheck); note the
-                    // hot path additionally suppresses it on the readMap-cached instance, since the method
-                    // handed back here may be regenerated before that cache is populated.
+                    // Suppress the access check once, here, and strongly cache the read method per class so the
+                    // suppression stays durable (PropertyDescriptor.getReadMethod hands it back via a soft reference
+                    // that can be regenerated) and the hot attribute-read path never re-suppresses or re-caches it.
                     Method readMethod = propertyDescriptor.getReadMethod();
                     if (readMethod != null) {
                         AttributesMap.suppressAccessCheck(readMethod);
+                        readMethodMap.put(propertyDescriptor.getName(), readMethod);
                     }
                     propertyDescriptorMap.put(propertyDescriptor.getName(), propertyDescriptor);
                 }
@@ -3450,6 +3464,9 @@ public abstract class UIComponentBase extends UIComponent {
 
                 if (descriptors != null) {
                     descriptors.putIfAbsent(clazz, propertyDescriptorMap);
+                }
+                if (readMethods != null) {
+                    readMethods.putIfAbsent(clazz, readMethodMap);
                 }
             }
         }

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -1661,7 +1661,9 @@ public abstract class UIComponentBase extends UIComponent {
         return NOT_MARKER;
     }
 
-    private void markerPut(Object key, Object value) {
+    // Returns true if the key is a marker (so AttributesMap can skip the getPropertyDescriptor probe:
+    // a framework marker is never a JavaBean property, so the lookup is guaranteed to miss).
+    private boolean markerPut(Object key, Object value) {
         if (MARK_CREATED.equals(key)) {
             markCreated = (String) value;
         } else if (KEY.equals(key)) {
@@ -1674,10 +1676,13 @@ public abstract class UIComponentBase extends UIComponent {
             markDeleted = Boolean.TRUE.equals(value);
         } else if (MARK_CHILDREN_MODIFIED.equals(key)) {
             markChildrenModified = Boolean.TRUE.equals(value);
+        } else {
+            return false;
         }
+        return true;
     }
 
-    private void markerRemove(Object key) {
+    private boolean markerRemove(Object key) {
         if (MARK_CREATED.equals(key)) {
             markCreated = null;
         } else if (KEY.equals(key)) {
@@ -1690,7 +1695,10 @@ public abstract class UIComponentBase extends UIComponent {
             markDeleted = false;
         } else if (MARK_CHILDREN_MODIFIED.equals(key)) {
             markChildrenModified = false;
+        } else {
+            return false;
         }
+        return true;
     }
 
     // Full-state restore deserializes the tree without re-running buildView, so the marker fields are synced
@@ -2272,7 +2280,7 @@ public abstract class UIComponentBase extends UIComponent {
             }
 
             // Keep the field cache in sync; the value is still stored in the attributes map below.
-            component.markerPut(keyValue, value);
+            boolean marker = component.markerPut(keyValue, value);
 
             if (ATTRIBUTES_THAT_ARE_SET_KEY.equals(keyValue)) {
                 if (component.attributesThatAreSet == null) {
@@ -2283,7 +2291,8 @@ public abstract class UIComponentBase extends UIComponent {
                 return null;
             }
 
-            PropertyDescriptor pd = getPropertyDescriptor(keyValue);
+            // A marker key is never a JavaBean property; skip the descriptor probe and store it directly.
+            PropertyDescriptor pd = marker ? null : getPropertyDescriptor(keyValue);
             if (pd != null) {
                 try {
                     Object result = null;
@@ -2336,11 +2345,11 @@ public abstract class UIComponentBase extends UIComponent {
             if (key == null) {
                 throw new NullPointerException();
             }
-            component.markerRemove(key);
+            boolean marker = component.markerRemove(key);
             if (ATTRIBUTES_THAT_ARE_SET_KEY.equals(key)) {
                 return null;
             }
-            PropertyDescriptor pd = getPropertyDescriptor(key);
+            PropertyDescriptor pd = marker ? null : getPropertyDescriptor(key);
             if (pd != null) {
                 throw new IllegalArgumentException(key);
             } else {

--- a/test/perf/src/main/java/org/eclipse/mojarra/test/perf/EncodeAllBenchServlet.java
+++ b/test/perf/src/main/java/org/eclipse/mojarra/test/perf/EncodeAllBenchServlet.java
@@ -38,11 +38,11 @@ import jakarta.servlet.http.HttpServletResponse;
  * counting writer; uses only standard {@code jakarta.faces} API, so the same endpoint runs on Mojarra
  * and MyFaces for an apples-to-apples render comparison.
  *
- * <p>{@code GET /renderresponse-bench?scenario=composite-unrolled&warmup=50&runs=2000} reports ns per
+ * <p>{@code GET /encodeall-bench?scenario=composite-unrolled&warmup=50&runs=2000} reports ns per
  * render and the output character count.
  */
-@WebServlet("/renderresponse-bench")
-public class RenderResponseBenchServlet extends HttpServlet {
+@WebServlet("/encodeall-bench")
+public class EncodeAllBenchServlet extends HttpServlet {
 
     private static final long serialVersionUID = 1L;
 
@@ -94,7 +94,7 @@ public class RenderResponseBenchServlet extends HttpServlet {
         response.setContentType("text/plain");
         response.setCharacterEncoding("UTF-8");
         response.getWriter().printf(
-                "# renderresponse-bench scenario=%s warmup=%d runs=%d chars=%d ns_per_render=%d total_ms=%d%n",
+                "# encodeall-bench scenario=%s warmup=%d runs=%d chars=%d ns_per_render=%d total_ms=%d%n",
                 scenario, warmup, runs, chars, elapsedNanos / runs, elapsedNanos / 1_000_000L);
     }
 

--- a/test/perf/src/test/java/org/eclipse/mojarra/test/perf/EncodeAllBenchIT.java
+++ b/test/perf/src/test/java/org/eclipse/mojarra/test/perf/EncodeAllBenchIT.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.openqa.selenium.WebDriver;
 
 /**
- * Drives {@link RenderResponseBenchServlet} so a JFR recording captures only the encode walk (no
+ * Drives {@link EncodeAllBenchServlet} so a JFR recording captures only the encode walk (no
  * buildView, no state save/restore). Run on Mojarra and on MyFaces (via the {@code -*-myfaces}
  * profiles) and diff the recordings to see where Mojarra's render does more work.
  *
@@ -41,7 +41,7 @@ import org.openqa.selenium.WebDriver;
  * composite-unrolled).
  */
 @EnabledIfSystemProperty(named = "render", matches = "true")
-class RenderResponseBenchIT extends BaseIT {
+class EncodeAllBenchIT extends BaseIT {
 
     private static final int WARMUP = getInteger("perf.warmup", 50);
     private static final int RUNS = getInteger("perf.runs", 2000);
@@ -71,11 +71,11 @@ class RenderResponseBenchIT extends BaseIT {
                 .connectTimeout(ofSeconds(10))
                 .build();
 
-        String url = baseURL + "renderresponse-bench?scenario=" + scenario + "&warmup=" + WARMUP + "&runs=" + RUNS;
+        String url = baseURL + "encodeall-bench?scenario=" + scenario + "&warmup=" + WARMUP + "&runs=" + RUNS;
         HttpRequest request = HttpRequest.newBuilder(URI.create(url)).timeout(ofSeconds(600)).GET().build();
         HttpResponse<String> response = client.send(request, ofString(UTF_8));
 
-        assertEquals(200, response.statusCode(), "renderresponse-bench");
+        assertEquals(200, response.statusCode(), "encodeall-bench");
         System.out.println();
         System.out.println(response.body());
     }


### PR DESCRIPTION
Backports #5791 and #5793 into 4.0 (cherry-picked, no conflicts). Part of #5753.

- **#5791** — trim per-component overhead on the dynamic add/remove path (restore skip, marker-write descriptor bypass, de-synchronized dynamic-action getters, clientId invalidation in setParent).
- **#5793** — per-component overhead in render and Facelets view build: cache property read methods per class, skip reflective reads of unset pass-through attributes, cache `AllowTextChildren` in the `TextRenderer` constructor, and skip the per-component event-info lookup when there are no listeners. Also renames `RenderResponseBenchIT` → `EncodeAllBenchIT` (test/perf).

Clean build on the 4.0 base — all impl unit tests (1162) and faces.js jest tests (347) pass.

🤖 Generated with Claude Opus 4.8
