### PR TITLE
Backport #5796 to 4.0: reduce attribute-handling reflective overhead

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -1361,7 +1361,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
         public boolean isRequired(FacesContext ctx) {
 
             ValueExpression rd = (ValueExpression) propertyDescriptor.getValue("required");
-            return rd != null ? Boolean.valueOf(rd.getValue(ctx.getELContext()).toString()) : false;
+            return rd != null && Util.toBoolean(rd.getValue(ctx.getELContext()), false);
 
         }
 

--- a/impl/src/main/java/com/sun/faces/facelets/tag/BeanPropertyTagRule.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/BeanPropertyTagRule.java
@@ -97,6 +97,16 @@ final class BeanPropertyTagRule extends MetaRule {
 
         // if the property is writable
         if (m != null) {
+            // Suppress the per-invoke reflective access check once on the (public) component setter that the
+            // returned Metadata invokes on every buildView. The Metadata is strongly held by the compiled tag
+            // handler's cached MetaRuleset, so the suppression stays durable across builds rather than being
+            // re-run per invoke. Mirrors the read-method suppression on the component side
+            // (UIComponentBase.AttributesMap). The module system may forbid it for a setter in a non-exported
+            // package, in which case the normal per-invoke access check simply remains.
+            try {
+                m.setAccessible(true);
+            } catch (RuntimeException accessNotSuppressed) {
+            }
             if (attribute.isLiteral()) {
                 return new LiteralPropertyMetadata(m, attribute);
             } else {

--- a/impl/src/main/java/com/sun/faces/facelets/tag/composite/InterfaceHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/composite/InterfaceHandler.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.sun.faces.application.view.FaceletViewHandlingStrategy;
+import com.sun.faces.util.Util;
 import com.sun.faces.facelets.tag.TagHandlerImpl;
 import com.sun.faces.facelets.tag.faces.ComponentSupport;
 import com.sun.faces.util.MessageUtils;
@@ -100,7 +101,7 @@ public class InterfaceHandler extends TagHandlerImpl {
             if (null != requiredValue) {
                 if (requiredValue instanceof ValueExpression) {
                     requiredValue = ((ValueExpression) requiredValue).getValue(context.getELContext());
-                    required = Boolean.parseBoolean(requiredValue.toString());
+                    required = Util.toBoolean(requiredValue, false);
                 }
             }
             if (required) {
@@ -145,7 +146,7 @@ public class InterfaceHandler extends TagHandlerImpl {
                 if (null != requiredValue) {
                     if (requiredValue instanceof ValueExpression) {
                         requiredValue = ((ValueExpression) requiredValue).getValue(context.getELContext());
-                        required = Boolean.parseBoolean(requiredValue.toString());
+                        required = Util.toBoolean(requiredValue, false);
                     }
                 }
                 if (required) {

--- a/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
@@ -436,6 +436,17 @@ public class RenderKitUtils {
         return getAttributeIfSet(component, getAttributesThatAreSet(component), name);
     }
 
+    /**
+     * Returns the boolean value of the named component attribute, coerced via {@link Util#toBoolean}: an absent
+     * attribute yields {@code defaultValue}, an already-{@code Boolean} value is returned directly (no
+     * {@code Boolean -> String -> boolean} round-trip), and a non-{@code Boolean} (e.g. a literal String on a non-typed
+     * component) is parsed. Use this in a renderer fallback when the concrete {@code Html*} type whose typed getter
+     * would return the {@code boolean} directly is not known.
+     */
+    public static boolean attributeIsTrue(UIComponent component, String name, boolean defaultValue) {
+        return Util.toBoolean(component.getAttributes().get(name), defaultValue);
+    }
+
     private static void renderValueChangeEventListener(FacesContext context, UIComponent component, String clientId,
             String componentEventName, String domEventName, boolean hasBehaviorForDefaultEvent, boolean incExec) throws IOException {
 

--- a/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
@@ -414,10 +414,12 @@ public class RenderKitUtils {
     /**
      * Returns the value of the named attribute, avoiding a reflective property read for an attribute that was never set.
      * <p>
-     * This is only safe for attributes whose setters record into {@code setAttributes} (i.e. those rendered through the
-     * pass-through machinery) and only for the standard components that maintain that list; for any other component the
-     * value is read directly, mirroring the fall-back in {@link #renderPassThruAttributes}. In particular {@code styleClass}
-     * is never tracked (it is rendered inline as {@code class}, not via the pass-through loop) and must not be passed here.
+     * This is only safe for attributes whose setters record into {@code setAttributes} and only for the standard
+     * components that maintain that list (those in {@code jakarta.faces.component}); for any other component the value
+     * is read directly, mirroring the fall-back in {@link #renderPassThruAttributes}. {@code styleClass} qualifies:
+     * although it is rendered inline as {@code class} rather than through the pass-through loop, its setter records into
+     * {@code setAttributes} like the pass-through attributes do, so it may be read through here to skip the reflective
+     * getter when it was never set -- the common case on large views.
      */
     public static Object getAttributeIfSet(UIComponent component, List<String> setAttributes, String name) {
         if (component.getClass().getName().startsWith(OPTIMIZED_PACKAGE)) {

--- a/impl/src/main/java/com/sun/faces/renderkit/SelectItemsIterator.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/SelectItemsIterator.java
@@ -16,6 +16,7 @@
 
 package com.sun.faces.renderkit;
 
+import com.sun.faces.util.Util;
 import java.io.IOException;
 import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
@@ -449,10 +450,10 @@ public final class SelectItemsIterator<T extends SelectItem> implements Iterator
                     setValue(itemValueResult != null ? itemValueResult : value);
                     setLabel(itemLabelResult != null ? itemLabelResult.toString() : value.toString());
                     setDescription(itemDescriptionResult != null ? itemDescriptionResult.toString() : null);
-                    setEscape(itemEscapedResult != null ? Boolean.valueOf(itemEscapedResult.toString()) : true);
-                    setDisabled(itemDisabledResult != null ? Boolean.valueOf(itemDisabledResult.toString()) : false);
+                    setEscape(Util.toBoolean(itemEscapedResult, true));
+                    setDisabled(Util.toBoolean(itemDisabledResult, false));
                     if (null != noSelectionOptionResult) {
-                        setNoSelectionOption(Boolean.valueOf(noSelectionOptionResult.toString()));
+                        setNoSelectionOption(Util.toBoolean(noSelectionOptionResult, false));
                     } else if (null != noSelectionValueResult) {
                         setNoSelectionOption(getValue().equals(noSelectionValueResult));
                     }

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/BaseTableRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/BaseTableRenderer.java
@@ -84,7 +84,7 @@ public abstract class BaseTableRenderer extends HtmlBasicRenderer {
 
         writer.startElement("table", table);
         writeIdAttributeIfNecessary(context, writer, table);
-        String styleClass = (String) table.getAttributes().get("styleClass");
+        String styleClass = (String) RenderKitUtils.getAttributeIfSet(table, "styleClass");
         if (styleClass != null) {
             writer.writeAttribute("class", styleClass, "styleClass");
         }

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/BaseTableRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/BaseTableRenderer.java
@@ -29,6 +29,8 @@ import com.sun.faces.util.Util;
 import jakarta.faces.component.UIColumn;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.UIData;
+import jakarta.faces.component.html.HtmlDataTable;
+import jakarta.faces.component.html.HtmlPanelGrid;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
 
@@ -84,10 +86,7 @@ public abstract class BaseTableRenderer extends HtmlBasicRenderer {
 
         writer.startElement("table", table);
         writeIdAttributeIfNecessary(context, writer, table);
-        String styleClass = (String) RenderKitUtils.getAttributeIfSet(table, "styleClass");
-        if (styleClass != null) {
-            writer.writeAttribute("class", styleClass, "styleClass");
-        }
+        writeStyleClassAttributeIfNecessary(writer, table);
         RenderKitUtils.renderPassThruAttributes(context, writer, table, attributes);
         writer.writeText("\n", table, null);
 
@@ -123,8 +122,10 @@ public abstract class BaseTableRenderer extends HtmlBasicRenderer {
 
         UIComponent caption = getFacet(table, "caption");
         if (caption != null) {
-            String captionClass = (String) table.getAttributes().get("captionClass");
-            String captionStyle = (String) table.getAttributes().get("captionStyle");
+            String captionClass = table instanceof HtmlDataTable ? ((HtmlDataTable) table).getCaptionClass()
+                    : table instanceof HtmlPanelGrid ? ((HtmlPanelGrid) table).getCaptionClass() : (String) table.getAttributes().get("captionClass");
+            String captionStyle = table instanceof HtmlDataTable ? ((HtmlDataTable) table).getCaptionStyle()
+                    : table instanceof HtmlPanelGrid ? ((HtmlPanelGrid) table).getCaptionStyle() : (String) table.getAttributes().get("captionStyle");
             writer.startElement("caption", table);
             if (captionClass != null) {
                 writer.writeAttribute("class", captionClass, "captionClass");
@@ -184,7 +185,8 @@ public abstract class BaseTableRenderer extends HtmlBasicRenderer {
         writer.startElement("tr", table);
 
         final String tableRowClass = info.rowClasses.length > 0 ? info.getCurrentRowClass() : null;
-        final String rowClass = (String) table.getAttributes().get("rowClass");
+        final String rowClass = table instanceof HtmlDataTable ? ((HtmlDataTable) table).getRowClass()
+                : table instanceof HtmlPanelGrid ? ((HtmlPanelGrid) table).getRowClass() : (String) table.getAttributes().get("rowClass");
 
         if (tableRowClass != null) {
             if (rowClass != null) {
@@ -347,7 +349,8 @@ public abstract class BaseTableRenderer extends HtmlBasicRenderer {
          */
         private static String[] getColumnClasses(UIComponent table) {
 
-            String values = (String) table.getAttributes().get("columnClasses");
+            String values = table instanceof HtmlDataTable ? ((HtmlDataTable) table).getColumnClasses()
+                    : table instanceof HtmlPanelGrid ? ((HtmlPanelGrid) table).getColumnClasses() : (String) table.getAttributes().get("columnClasses");
             if (values == null) {
                 return EMPTY_STRING_ARRAY;
             }
@@ -383,11 +386,11 @@ public abstract class BaseTableRenderer extends HtmlBasicRenderer {
                 }
             } else {
                 int count;
-                Object value = table.getAttributes().get("columns");
-                if (value != null && value instanceof Integer) {
-                    count = (Integer) value;
+                if (table instanceof HtmlPanelGrid) {
+                    count = ((HtmlPanelGrid) table).getColumns();
                 } else {
-                    count = 2;
+                    Object value = table.getAttributes().get("columns");
+                    count = value instanceof Integer ? (Integer) value : 2;
                 }
                 if (count < 1) {
                     count = 1;
@@ -439,7 +442,8 @@ public abstract class BaseTableRenderer extends HtmlBasicRenderer {
          */
         private static String[] getRowClasses(UIComponent table) {
 
-            String values = (String) table.getAttributes().get("rowClasses");
+            String values = table instanceof HtmlDataTable ? ((HtmlDataTable) table).getRowClasses()
+                    : table instanceof HtmlPanelGrid ? ((HtmlPanelGrid) table).getRowClasses() : (String) table.getAttributes().get("rowClasses");
             if (values == null) {
                 return EMPTY_STRING_ARRAY;
             }

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/BodyRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/BodyRenderer.java
@@ -55,7 +55,7 @@ public class BodyRenderer extends HtmlBasicRenderer {
         ResponseWriter writer = context.getResponseWriter();
         writer.startElement("body", component);
         writeIdAttributeIfNecessary(context, writer, component);
-        String styleClass = (String) component.getAttributes().get("styleClass");
+        String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
         if (styleClass != null && styleClass.length() != 0) {
             writer.writeAttribute("class", styleClass, "styleClass");
         }

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/BodyRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/BodyRenderer.java
@@ -55,10 +55,7 @@ public class BodyRenderer extends HtmlBasicRenderer {
         ResponseWriter writer = context.getResponseWriter();
         writer.startElement("body", component);
         writeIdAttributeIfNecessary(context, writer, component);
-        String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
-        if (styleClass != null && styleClass.length() != 0) {
-            writer.writeAttribute("class", styleClass, "styleClass");
-        }
+        writeStyleClassAttributeIfNecessary(writer, component);
         RenderKitUtils.renderPassThruAttributes(context, writer, component, BODY_ATTRIBUTES);
     }
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/ButtonRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/ButtonRenderer.java
@@ -25,6 +25,7 @@ import java.util.logging.Level;
 
 import jakarta.faces.component.UICommand;
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.html.HtmlCommandButton;
 import jakarta.faces.component.behavior.ClientBehaviorContext;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
@@ -95,7 +96,8 @@ public class ButtonRenderer extends HtmlBasicRenderer {
          * when we decide how to do script injection.
          */
 
-        String imageSrc = (String) component.getAttributes().get("image");
+        String imageSrc = component instanceof HtmlCommandButton ? ((HtmlCommandButton) component).getImage()
+                : (String) component.getAttributes().get("image");
         writer.startElement("input", component);
         writeIdAttributeIfNecessary(context, writer, component);
         String clientId = component.getClientId(context);
@@ -203,7 +205,7 @@ public class ButtonRenderer extends HtmlBasicRenderer {
      */
     private static boolean isReset(UIComponent component) {
 
-        return "reset".equals(component.getAttributes().get("type"));
+        return "reset".equals(component instanceof HtmlCommandButton ? ((HtmlCommandButton) component).getType() : component.getAttributes().get("type"));
 
     }
 
@@ -217,7 +219,8 @@ public class ButtonRenderer extends HtmlBasicRenderer {
      */
     private static String getButtonType(UIComponent component) {
 
-        String type = (String) component.getAttributes().get("type");
+        String type = component instanceof HtmlCommandButton ? ((HtmlCommandButton) component).getType()
+                : (String) component.getAttributes().get("type");
         if (type == null || !"reset".equals(type) && !"submit".equals(type) && !"button".equals(type)) {
             type = "submit";
             // This is needed in the decode method

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/ButtonRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/ButtonRenderer.java
@@ -121,7 +121,7 @@ public class ButtonRenderer extends HtmlBasicRenderer {
 
         RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, component);
 
-        String styleClass = (String) component.getAttributes().get("styleClass");
+        String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
         if (styleClass != null && styleClass.length() > 0) {
             writer.writeAttribute("class", styleClass, "styleClass");
         }

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/CheckboxRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/CheckboxRenderer.java
@@ -88,7 +88,6 @@ public class CheckboxRenderer extends HtmlBasicInputRenderer {
 
         ResponseWriter writer = context.getResponseWriter();
         assert writer != null;
-        String styleClass;
 
         writer.startElement("input", component);
         writeIdAttributeIfNecessary(context, writer, component);
@@ -98,9 +97,7 @@ public class CheckboxRenderer extends HtmlBasicInputRenderer {
         if (Boolean.valueOf(currentValue)) {
             writer.writeAttribute("checked", Boolean.TRUE, "value");
         }
-        if (null != (styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass"))) {
-            writer.writeAttribute("class", styleClass, "styleClass");
-        }
+        writeStyleClassAttributeIfNecessary(writer, component);
         RenderKitUtils.renderPassThruAttributes(context, writer, component, null, false, ATTRIBUTES, "click", "valueChange");
         RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, component);
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/CheckboxRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/CheckboxRenderer.java
@@ -98,7 +98,7 @@ public class CheckboxRenderer extends HtmlBasicInputRenderer {
         if (Boolean.valueOf(currentValue)) {
             writer.writeAttribute("checked", Boolean.TRUE, "value");
         }
-        if (null != (styleClass = (String) component.getAttributes().get("styleClass"))) {
+        if (null != (styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass"))) {
             writer.writeAttribute("class", styleClass, "styleClass");
         }
         RenderKitUtils.renderPassThruAttributes(context, writer, component, null, false, ATTRIBUTES, "click", "valueChange");

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/CommandLinkRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/CommandLinkRenderer.java
@@ -25,11 +25,13 @@ import java.util.logging.Level;
 
 import jakarta.faces.component.UICommand;
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.html.HtmlCommandLink;
 import jakarta.faces.component.behavior.ClientBehaviorContext;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
 import jakarta.faces.event.ActionEvent;
 
+import static com.sun.faces.util.Util.componentIsDisabled;
 import com.sun.faces.application.resource.ResourceHandlerImpl;
 import com.sun.faces.renderkit.Attribute;
 import com.sun.faces.renderkit.AttributeManager;
@@ -76,7 +78,8 @@ public class CommandLinkRenderer extends LinkRenderer {
             return;
         }
 
-        boolean componentDisabled = Boolean.TRUE.equals(component.getAttributes().get("disabled"));
+        boolean componentDisabled = component instanceof HtmlCommandLink ? ((HtmlCommandLink) component).isDisabled()
+                : componentIsDisabled(component);
 
         if (componentDisabled) {
             renderAsDisabled(context, component);
@@ -116,13 +119,14 @@ public class CommandLinkRenderer extends LinkRenderer {
         ResponseWriter writer = context.getResponseWriter();
         assert writer != null;
 
-        if (Boolean.TRUE.equals(component.getAttributes().get("disabled"))) {
+        if (component instanceof HtmlCommandLink ? ((HtmlCommandLink) component).isDisabled() : componentIsDisabled(component)) {
             writer.endElement("span");
         } else {
             writer.endElement("a");
 
             if (ResourceHandlerImpl.resolveCurrentNonce(context) != null) {
-                String target = (String) component.getAttributes().get("target");
+                String target = component instanceof HtmlCommandLink ? ((HtmlCommandLink) component).getTarget()
+                        : (String) component.getAttributes().get("target");
                 if (target != null) {
                     target = target.trim();
                 } else {
@@ -169,7 +173,8 @@ public class CommandLinkRenderer extends LinkRenderer {
         RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, command);
 
         if (ResourceHandlerImpl.resolveCurrentNonce(context) == null) {
-            String target = (String) command.getAttributes().get("target");
+            String target = command instanceof HtmlCommandLink ? ((HtmlCommandLink) command).getTarget()
+                    : (String) command.getAttributes().get("target");
             if (target != null) {
                 target = target.trim();
             } else {

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/FormRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/FormRenderer.java
@@ -33,6 +33,7 @@ import com.sun.faces.renderkit.RenderKitUtils;
 
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.UIForm;
+import jakarta.faces.component.html.HtmlForm;
 import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -100,11 +101,9 @@ public class FormRenderer extends HtmlBasicRenderer {
         writer.writeAttribute("name", clientId, "name");
         writer.writeAttribute("method", "post", null);
         writer.writeAttribute("action", getActionStr(context), null);
-        String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
-        if (styleClass != null) {
-            writer.writeAttribute("class", styleClass, "styleClass");
-        }
-        String acceptcharset = (String) component.getAttributes().get("acceptcharset");
+        writeStyleClassAttributeIfNecessary(writer, component);
+        String acceptcharset = component instanceof HtmlForm ? ((HtmlForm) component).getAcceptcharset()
+                : (String) component.getAttributes().get("acceptcharset");
         if (acceptcharset != null) {
             writer.writeAttribute("accept-charset", acceptcharset, "acceptcharset");
         }

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/FormRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/FormRenderer.java
@@ -100,7 +100,7 @@ public class FormRenderer extends HtmlBasicRenderer {
         writer.writeAttribute("name", clientId, "name");
         writer.writeAttribute("method", "post", null);
         writer.writeAttribute("action", getActionStr(context), null);
-        String styleClass = (String) component.getAttributes().get("styleClass");
+        String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
         if (styleClass != null) {
             writer.writeAttribute("class", styleClass, "styleClass");
         }

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/GridRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/GridRenderer.java
@@ -23,6 +23,7 @@ import com.sun.faces.renderkit.Attribute;
 import com.sun.faces.renderkit.AttributeManager;
 
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.html.HtmlPanelGrid;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
 
@@ -151,7 +152,8 @@ public class GridRenderer extends BaseTableRenderer {
 
         TableMetaInfo info = getMetaInfo(context, table);
         UIComponent header = getFacet(table, "header");
-        String headerClass = (String) table.getAttributes().get("headerClass");
+        String headerClass = table instanceof HtmlPanelGrid ? ((HtmlPanelGrid) table).getHeaderClass()
+                : (String) table.getAttributes().get("headerClass");
         if (header != null) {
             writer.startElement("thead", table);
             writer.writeText("\n", table, null);
@@ -177,7 +179,8 @@ public class GridRenderer extends BaseTableRenderer {
 
         TableMetaInfo info = getMetaInfo(context, table);
         UIComponent footer = getFacet(table, "footer");
-        String footerClass = (String) table.getAttributes().get("footerClass");
+        String footerClass = table instanceof HtmlPanelGrid ? ((HtmlPanelGrid) table).getFooterClass()
+                : (String) table.getAttributes().get("footerClass");
         if (footer != null) {
             writer.startElement("tfoot", table);
             writer.writeText("\n", table, null);

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/GroupRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/GroupRenderer.java
@@ -24,6 +24,7 @@ import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.html.HtmlPanelGroup;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
 
@@ -49,7 +50,8 @@ public class GroupRenderer extends HtmlBasicRenderer {
         ResponseWriter writer = context.getResponseWriter();
 
         if (divOrSpan(component, styleClass)) {
-            if ("block".equals(component.getAttributes().get("layout"))) {
+            if (component instanceof HtmlPanelGroup ? "block".equals(((HtmlPanelGroup) component).getLayout())
+                    : "block".equals(component.getAttributes().get("layout"))) {
                 writer.startElement("div", component);
             } else {
                 writer.startElement("span", component);
@@ -96,7 +98,8 @@ public class GroupRenderer extends HtmlBasicRenderer {
         ResponseWriter writer = context.getResponseWriter();
         String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
         if (divOrSpan(component, styleClass)) {
-            if ("block".equals(component.getAttributes().get("layout"))) {
+            if (component instanceof HtmlPanelGroup ? "block".equals(((HtmlPanelGroup) component).getLayout())
+                    : "block".equals(component.getAttributes().get("layout"))) {
                 writer.endElement("div");
             } else {
                 writer.endElement("span");

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/GroupRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/GroupRenderer.java
@@ -45,7 +45,7 @@ public class GroupRenderer extends HtmlBasicRenderer {
             return;
         }
         // Render a span around this group if necessary
-        String styleClass = (String) component.getAttributes().get("styleClass");
+        String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
         ResponseWriter writer = context.getResponseWriter();
 
         if (divOrSpan(component, styleClass)) {
@@ -94,7 +94,7 @@ public class GroupRenderer extends HtmlBasicRenderer {
 
         // Close our span element if necessary
         ResponseWriter writer = context.getResponseWriter();
-        String styleClass = (String) component.getAttributes().get("styleClass");
+        String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
         if (divOrSpan(component, styleClass)) {
             if ("block".equals(component.getAttributes().get("layout"))) {
                 writer.endElement("div");

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/HtmlBasicRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/HtmlBasicRenderer.java
@@ -40,6 +40,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.sun.faces.renderkit.RenderKitUtils;
 import com.sun.faces.util.FacesLogger;
 import com.sun.faces.util.MessageUtils;
 import com.sun.faces.util.Util;
@@ -611,7 +612,7 @@ public abstract class HtmlBasicRenderer extends Renderer {
 
     protected void writeStyleClassAttributeIfNecessary(ResponseWriter writer, UIComponent component) throws IOException {
 
-        String styleClass = (String) component.getAttributes().get("styleClass");
+        String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
         if (styleClass != null) {
             writer.writeAttribute("class", styleClass, "styleClass");
         }

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/HtmlBasicRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/HtmlBasicRenderer.java
@@ -618,6 +618,14 @@ public abstract class HtmlBasicRenderer extends Renderer {
         }
     }
 
+    protected void writeStyleAttributeIfNecessary(ResponseWriter writer, UIComponent component) throws IOException {
+
+        String style = (String) RenderKitUtils.getAttributeIfSet(component, "style");
+        if (style != null) {
+            writer.writeAttribute("style", style, "style");
+        }
+    }
+
     protected void rendererParamsNotNull(FacesContext context, UIComponent component) {
         notNull("context", context);
         notNull("component", component);

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/ImageRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/ImageRenderer.java
@@ -72,7 +72,7 @@ public class ImageRenderer extends HtmlBasicRenderer {
         RenderKitUtils.renderPassThruAttributes(context, writer, component, ATTRIBUTES);
         RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, component);
         String styleClass;
-        if (null != (styleClass = (String) component.getAttributes().get("styleClass"))) {
+        if (null != (styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass"))) {
             writer.writeAttribute("class", styleClass, "styleClass");
         }
         writer.endElement("img");

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/ImageRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/ImageRenderer.java
@@ -71,10 +71,7 @@ public class ImageRenderer extends HtmlBasicRenderer {
 
         RenderKitUtils.renderPassThruAttributes(context, writer, component, ATTRIBUTES);
         RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, component);
-        String styleClass;
-        if (null != (styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass"))) {
-            writer.writeAttribute("class", styleClass, "styleClass");
-        }
+        writeStyleClassAttributeIfNecessary(writer, component);
         writer.endElement("img");
         RenderKitUtils.flushPendingBehaviorEventListeners(context, component, null);
         if (logger.isLoggable(Level.FINER)) {

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/LabelRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/LabelRenderer.java
@@ -88,7 +88,7 @@ public class LabelRenderer extends HtmlBasicInputRenderer {
         }
 
         RenderKitUtils.renderPassThruAttributes(context, writer, component, ATTRIBUTES);
-        String styleClass = (String) component.getAttributes().get("styleClass");
+        String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
         if (null != styleClass) {
             writer.writeAttribute("class", styleClass, "styleClass");
         }

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/LabelRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/LabelRenderer.java
@@ -29,6 +29,7 @@ import com.sun.faces.renderkit.RenderKitUtils;
 
 import jakarta.faces.component.NamingContainer;
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.html.HtmlOutputLabel;
 import jakarta.faces.component.UINamingContainer;
 import jakarta.faces.component.search.SearchExpressionContext;
 import jakarta.faces.component.search.SearchExpressionHint;
@@ -65,7 +66,8 @@ public class LabelRenderer extends HtmlBasicInputRenderer {
         assert writer != null;
 
         String forClientId = null;
-        String forValue = (String) component.getAttributes().get("for");
+        String forValue = component instanceof HtmlOutputLabel ? ((HtmlOutputLabel) component).getFor()
+                : (String) component.getAttributes().get("for");
         if (forValue != null) {
             SearchExpressionContext searchExpressionContext = SearchExpressionContext.createSearchExpressionContext(context, component, EXPRESSION_HINTS, null);
 
@@ -88,10 +90,7 @@ public class LabelRenderer extends HtmlBasicInputRenderer {
         }
 
         RenderKitUtils.renderPassThruAttributes(context, writer, component, ATTRIBUTES);
-        String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
-        if (null != styleClass) {
-            writer.writeAttribute("class", styleClass, "styleClass");
-        }
+        writeStyleClassAttributeIfNecessary(writer, component);
 
         // render the curentValue as label text if specified.
         String value = getCurrentValue(context, component);
@@ -99,8 +98,8 @@ public class LabelRenderer extends HtmlBasicInputRenderer {
             logger.fine("Value to be rendered " + value);
         }
         if (value != null && value.length() != 0) {
-            Object val = component.getAttributes().get("escape");
-            boolean escape = val != null && Boolean.valueOf(val.toString());
+            boolean escape = component instanceof HtmlOutputLabel ? ((HtmlOutputLabel) component).isEscape()
+                    : RenderKitUtils.attributeIsTrue(component, "escape", false);
 
             if (escape) {
                 writer.writeText(value, component, "value");

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/MenuRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/MenuRenderer.java
@@ -650,11 +650,7 @@ public class MenuRenderer extends HtmlBasicInputRenderer {
         writeIdAttributeIfNecessary(context, writer, component);
         writer.writeAttribute("name", component.getClientId(context), "clientId");
 
-        // Render styleClass attribute if present.
-        String styleClass;
-        if ((styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass")) != null) {
-            writer.writeAttribute("class", styleClass, "styleClass");
-        }
+        writeStyleClassAttributeIfNecessary(writer, component);
 
         if (!getMultipleText(component).equals("")) {
             writer.writeAttribute("multiple", true, "multiple");

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/MenuRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/MenuRenderer.java
@@ -652,7 +652,7 @@ public class MenuRenderer extends HtmlBasicInputRenderer {
 
         // Render styleClass attribute if present.
         String styleClass;
-        if ((styleClass = (String) component.getAttributes().get("styleClass")) != null) {
+        if ((styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass")) != null) {
             writer.writeAttribute("class", styleClass, "styleClass");
         }
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/MessageRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/MessageRenderer.java
@@ -26,6 +26,7 @@ import com.sun.faces.renderkit.RenderKitUtils;
 
 import jakarta.faces.application.FacesMessage;
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.html.HtmlMessage;
 import jakarta.faces.component.UIMessage;
 import jakarta.faces.component.UIOutput;
 import jakarta.faces.context.FacesContext;
@@ -135,18 +136,20 @@ public class MessageRenderer extends HtmlBasicRenderer {
         // Default to summary if we have no detail
         String detail = null != (detail = curMessage.getDetail()) ? detail : summary;
 
-        if (curMessage.getSeverity() == FacesMessage.SEVERITY_INFO) {
-            severityStyle = (String) component.getAttributes().get("infoStyle");
-            severityStyleClass = (String) component.getAttributes().get("infoClass");
-        } else if (curMessage.getSeverity() == FacesMessage.SEVERITY_WARN) {
-            severityStyle = (String) component.getAttributes().get("warnStyle");
-            severityStyleClass = (String) component.getAttributes().get("warnClass");
-        } else if (curMessage.getSeverity() == FacesMessage.SEVERITY_ERROR) {
-            severityStyle = (String) component.getAttributes().get("errorStyle");
-            severityStyleClass = (String) component.getAttributes().get("errorClass");
-        } else if (curMessage.getSeverity() == FacesMessage.SEVERITY_FATAL) {
-            severityStyle = (String) component.getAttributes().get("fatalStyle");
-            severityStyleClass = (String) component.getAttributes().get("fatalClass");
+        HtmlMessage htmlMessage = component instanceof HtmlMessage ? (HtmlMessage) component : null;
+        FacesMessage.Severity severity = curMessage.getSeverity();
+        if (severity == FacesMessage.SEVERITY_INFO) {
+            severityStyle = htmlMessage != null ? htmlMessage.getInfoStyle() : (String) component.getAttributes().get("infoStyle");
+            severityStyleClass = htmlMessage != null ? htmlMessage.getInfoClass() : (String) component.getAttributes().get("infoClass");
+        } else if (severity == FacesMessage.SEVERITY_WARN) {
+            severityStyle = htmlMessage != null ? htmlMessage.getWarnStyle() : (String) component.getAttributes().get("warnStyle");
+            severityStyleClass = htmlMessage != null ? htmlMessage.getWarnClass() : (String) component.getAttributes().get("warnClass");
+        } else if (severity == FacesMessage.SEVERITY_ERROR) {
+            severityStyle = htmlMessage != null ? htmlMessage.getErrorStyle() : (String) component.getAttributes().get("errorStyle");
+            severityStyleClass = htmlMessage != null ? htmlMessage.getErrorClass() : (String) component.getAttributes().get("errorClass");
+        } else if (severity == FacesMessage.SEVERITY_FATAL) {
+            severityStyle = htmlMessage != null ? htmlMessage.getFatalStyle() : (String) component.getAttributes().get("fatalStyle");
+            severityStyleClass = htmlMessage != null ? htmlMessage.getFatalClass() : (String) component.getAttributes().get("fatalClass");
         }
 
         List<String> setAttributes = RenderKitUtils.getAttributesThatAreSet(component);
@@ -204,8 +207,8 @@ public class MessageRenderer extends HtmlBasicRenderer {
 
         }
 
-        Object val = component.getAttributes().get("tooltip");
-        boolean isTooltip = val != null && Boolean.valueOf(val.toString());
+        boolean isTooltip = htmlMessage != null ? htmlMessage.isTooltip()
+                : RenderKitUtils.attributeIsTrue(component, "tooltip", false);
 
         boolean wroteTooltip = false;
         if ((showSummary || showDetail) && isTooltip) {

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/MessageRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/MessageRenderer.java
@@ -151,7 +151,7 @@ public class MessageRenderer extends HtmlBasicRenderer {
 
         List<String> setAttributes = RenderKitUtils.getAttributesThatAreSet(component);
         String style = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "style");
-        String styleClass = (String) component.getAttributes().get("styleClass");
+        String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
         String dir = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "dir");
         String lang = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "lang");
         String title = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "title");

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/MessagesRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/MessagesRenderer.java
@@ -27,6 +27,7 @@ import com.sun.faces.renderkit.RenderKitUtils;
 
 import jakarta.faces.application.FacesMessage;
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.html.HtmlMessages;
 import jakarta.faces.component.UIMessages;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
@@ -98,10 +99,11 @@ public class MessagesRenderer extends HtmlBasicRenderer {
             return;
         }
 
-        String layout = (String) component.getAttributes().get("layout");
+        HtmlMessages htmlMessages = component instanceof HtmlMessages ? (HtmlMessages) component : null;
+        String layout = htmlMessages != null ? htmlMessages.getLayout()
+                : (String) component.getAttributes().get("layout");
         boolean showSummary = messages.isShowSummary();
         boolean showDetail = messages.isShowDetail();
-        String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
 
         boolean wroteTable = false;
 
@@ -117,9 +119,7 @@ public class MessagesRenderer extends HtmlBasicRenderer {
 
         // Render "table" or "ul" level attributes.
         writeIdAttributeIfNecessary(context, writer, component);
-        if (null != styleClass) {
-            writer.writeAttribute("class", styleClass, "styleClass");
-        }
+        writeStyleClassAttributeIfNecessary(writer, component);
         // style is rendered as a passthru attribute
         RenderKitUtils.renderPassThruAttributes(context, writer, component, ATTRIBUTES);
 
@@ -139,18 +139,19 @@ public class MessagesRenderer extends HtmlBasicRenderer {
             // Default to summary if we have no detail
             String detail = null != (detail = curMessage.getDetail()) ? detail : summary;
 
-            if (curMessage.getSeverity() == FacesMessage.SEVERITY_INFO) {
-                severityStyle = (String) component.getAttributes().get("infoStyle");
-                severityStyleClass = (String) component.getAttributes().get("infoClass");
-            } else if (curMessage.getSeverity() == FacesMessage.SEVERITY_WARN) {
-                severityStyle = (String) component.getAttributes().get("warnStyle");
-                severityStyleClass = (String) component.getAttributes().get("warnClass");
-            } else if (curMessage.getSeverity() == FacesMessage.SEVERITY_ERROR) {
-                severityStyle = (String) component.getAttributes().get("errorStyle");
-                severityStyleClass = (String) component.getAttributes().get("errorClass");
-            } else if (curMessage.getSeverity() == FacesMessage.SEVERITY_FATAL) {
-                severityStyle = (String) component.getAttributes().get("fatalStyle");
-                severityStyleClass = (String) component.getAttributes().get("fatalClass");
+            FacesMessage.Severity severity = curMessage.getSeverity();
+            if (severity == FacesMessage.SEVERITY_INFO) {
+                severityStyle = htmlMessages != null ? htmlMessages.getInfoStyle() : (String) component.getAttributes().get("infoStyle");
+                severityStyleClass = htmlMessages != null ? htmlMessages.getInfoClass() : (String) component.getAttributes().get("infoClass");
+            } else if (severity == FacesMessage.SEVERITY_WARN) {
+                severityStyle = htmlMessages != null ? htmlMessages.getWarnStyle() : (String) component.getAttributes().get("warnStyle");
+                severityStyleClass = htmlMessages != null ? htmlMessages.getWarnClass() : (String) component.getAttributes().get("warnClass");
+            } else if (severity == FacesMessage.SEVERITY_ERROR) {
+                severityStyle = htmlMessages != null ? htmlMessages.getErrorStyle() : (String) component.getAttributes().get("errorStyle");
+                severityStyleClass = htmlMessages != null ? htmlMessages.getErrorClass() : (String) component.getAttributes().get("errorClass");
+            } else if (severity == FacesMessage.SEVERITY_FATAL) {
+                severityStyle = htmlMessages != null ? htmlMessages.getFatalStyle() : (String) component.getAttributes().get("fatalStyle");
+                severityStyleClass = htmlMessages != null ? htmlMessages.getFatalClass() : (String) component.getAttributes().get("fatalClass");
             }
 
             // Done intializing local variables. Move on to rendering.
@@ -165,16 +166,15 @@ public class MessagesRenderer extends HtmlBasicRenderer {
                 writer.writeAttribute("style", severityStyle, "style");
             }
             if (severityStyleClass != null) {
-                styleClass = severityStyleClass;
-                writer.writeAttribute("class", styleClass, "styleClass");
+                writer.writeAttribute("class", severityStyleClass, "styleClass");
             }
 
             if (wroteTable) {
                 writer.startElement("td", component);
             }
 
-            Object val = component.getAttributes().get("tooltip");
-            boolean isTooltip = val != null && Boolean.valueOf(val.toString());
+            boolean isTooltip = htmlMessages != null ? htmlMessages.isTooltip()
+                    : RenderKitUtils.attributeIsTrue(component, "tooltip", false);
 
             boolean wroteTooltip = false;
             if (isTooltip) {

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/MessagesRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/MessagesRenderer.java
@@ -101,7 +101,7 @@ public class MessagesRenderer extends HtmlBasicRenderer {
         String layout = (String) component.getAttributes().get("layout");
         boolean showSummary = messages.isShowSummary();
         boolean showDetail = messages.isShowDetail();
-        String styleClass = (String) component.getAttributes().get("styleClass");
+        String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
 
         boolean wroteTable = false;
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutcomeTargetButtonRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutcomeTargetButtonRenderer.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import com.sun.faces.application.resource.ResourceHandlerImpl;
 import jakarta.faces.application.NavigationCase;
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.html.HtmlOutcomeTargetButton;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
 
@@ -51,7 +52,8 @@ public class OutcomeTargetButtonRenderer extends OutcomeTargetRenderer {
         writer.startElement("input", component);
         writeIdAttributeIfNecessary(context, writer, component);
 
-        String imageSrc = (String) component.getAttributes().get("image");
+        String imageSrc = component instanceof HtmlOutcomeTargetButton ? ((HtmlOutcomeTargetButton) component).getImage()
+                : (String) component.getAttributes().get("image");
         if (imageSrc != null) {
             writer.writeAttribute("type", "image", "type");
             writer.writeURIAttribute("src", RenderKitUtils.getImageSource(context, component, "image"), "image");
@@ -69,7 +71,8 @@ public class OutcomeTargetButtonRenderer extends OutcomeTargetRenderer {
 
         String label = getLabel(component);
 
-        if (!Util.componentIsDisabled(component)) {
+        boolean disabled = component instanceof HtmlOutcomeTargetButton ? ((HtmlOutcomeTargetButton) component).isDisabled() : Util.componentIsDisabled(component);
+        if (!disabled) {
             NavigationCase navCase = getNavigationCase(context, component);
 
             if (navCase == null) {
@@ -107,7 +110,8 @@ public class OutcomeTargetButtonRenderer extends OutcomeTargetRenderer {
 
         RenderKitUtils.flushPendingBehaviorEventListeners(context, component, null);
 
-        if (!Util.componentIsDisabled(component)) {
+        boolean disabled = component instanceof HtmlOutcomeTargetButton ? ((HtmlOutcomeTargetButton) component).isDisabled() : Util.componentIsDisabled(component);
+        if (!disabled) {
             NavigationCase navCase = getNavigationCase(context, component);
 
             if (navCase != null) {

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutcomeTargetButtonRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutcomeTargetButtonRenderer.java
@@ -88,7 +88,7 @@ public class OutcomeTargetButtonRenderer extends OutcomeTargetRenderer {
         // value should be used even for image type for accessibility (e.g., images disabled in browser)
         writer.writeAttribute("value", label, "value");
 
-        String styleClass = (String) component.getAttributes().get("styleClass");
+        String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
         if (styleClass != null && styleClass.length() > 0) {
             writer.writeAttribute("class", styleClass, "styleClass");
         }

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutcomeTargetLinkRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutcomeTargetLinkRenderer.java
@@ -29,6 +29,7 @@ import com.sun.faces.util.Util;
 import jakarta.faces.application.NavigationCase;
 import jakarta.faces.application.ProjectStage;
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.html.HtmlOutcomeTargetLink;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
 
@@ -54,7 +55,7 @@ public class OutcomeTargetLinkRenderer extends OutcomeTargetRenderer {
 
         NavigationCase navCase = null;
         boolean failedToResolveNavigationCase = false;
-        boolean disabled = Util.componentIsDisabled(component);
+        boolean disabled = component instanceof HtmlOutcomeTargetLink ? ((HtmlOutcomeTargetLink) component).isDisabled() : Util.componentIsDisabled(component);
 
         if (!disabled) {
             navCase = getNavigationCase(context, component);
@@ -84,7 +85,8 @@ public class OutcomeTargetLinkRenderer extends OutcomeTargetRenderer {
 
         ResponseWriter writer = context.getResponseWriter();
         assert writer != null;
-        String endElement = Util.componentIsDisabled(component) || context.getAttributes().remove(NO_NAV_CASE) != null ? "span" : "a";
+        boolean disabled = component instanceof HtmlOutcomeTargetLink ? ((HtmlOutcomeTargetLink) component).isDisabled() : Util.componentIsDisabled(component);
+        String endElement = disabled || context.getAttributes().remove(NO_NAV_CASE) != null ? "span" : "a";
         writer.endElement(endElement);
 
         RenderKitUtils.flushPendingBehaviorEventListeners(context, component, null);

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutputLinkRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutputLinkRenderer.java
@@ -31,6 +31,7 @@ import com.sun.faces.renderkit.RenderKitUtils;
 
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.UIOutput;
+import jakarta.faces.component.html.HtmlOutputLink;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
 
@@ -60,12 +61,8 @@ public class OutputLinkRenderer extends LinkRenderer {
         rendererParamsNotNull(context, component);
 
         UIOutput output = (UIOutput) component;
-        boolean componentDisabled = false;
-        if (output.getAttributes().get("disabled") != null) {
-            if (output.getAttributes().get("disabled").equals(Boolean.TRUE)) {
-                componentDisabled = true;
-            }
-        }
+        boolean componentDisabled = output instanceof HtmlOutputLink ? ((HtmlOutputLink) output).isDisabled()
+                : componentIsDisabled(output);
         if (componentDisabled) {
             renderAsDisabled(context, output);
         } else {
@@ -101,7 +98,7 @@ public class OutputLinkRenderer extends LinkRenderer {
         ResponseWriter writer = context.getResponseWriter();
         assert writer != null;
 
-        if (Boolean.TRUE.equals(component.getAttributes().get("disabled"))) {
+        if (component instanceof HtmlOutputLink ? ((HtmlOutputLink) component).isDisabled() : componentIsDisabled(component)) {
             writer.endElement("span");
         } else {
             // Write Anchor inline elements
@@ -121,7 +118,8 @@ public class OutputLinkRenderer extends LinkRenderer {
 
     protected String getFragment(UIComponent component) {
 
-        String fragment = (String) component.getAttributes().get("fragment");
+        String fragment = component instanceof HtmlOutputLink ? ((HtmlOutputLink) component).getFragment()
+                : (String) component.getAttributes().get("fragment");
         fragment = fragment != null ? fragment.trim() : "";
         if (fragment.length() > 0) {
             fragment = "#" + fragment;
@@ -132,7 +130,7 @@ public class OutputLinkRenderer extends LinkRenderer {
 
     @Override
     protected Object getValue(UIComponent component) {
-        if (componentIsDisabled(component)) {
+        if (component instanceof HtmlOutputLink ? ((HtmlOutputLink) component).isDisabled() : componentIsDisabled(component)) {
             return null;
         }
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutputMessageRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutputMessageRenderer.java
@@ -94,7 +94,7 @@ public class OutputMessageRenderer extends HtmlBasicInputRenderer {
 
         List<String> setAttributes = RenderKitUtils.getAttributesThatAreSet(component);
         String style = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "style");
-        String styleClass = (String) component.getAttributes().get("styleClass");
+        String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
         String lang = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "lang");
         String dir = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "dir");
         String title = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "title");

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutputMessageRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutputMessageRenderer.java
@@ -27,6 +27,7 @@ import java.util.List;
 import com.sun.faces.renderkit.RenderKitUtils;
 
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.html.HtmlOutputFormat;
 import jakarta.faces.component.UIParameter;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
@@ -121,8 +122,8 @@ public class OutputMessageRenderer extends HtmlBasicInputRenderer {
             }
         }
 
-        Object val = component.getAttributes().get("escape");
-        boolean escape = val != null && Boolean.valueOf(val.toString());
+        boolean escape = component instanceof HtmlOutputFormat ? ((HtmlOutputFormat) component).isEscape()
+                : RenderKitUtils.attributeIsTrue(component, "escape", false);
 
         if (escape) {
             writer.writeText(message, component, "value");

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/RadioRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/RadioRenderer.java
@@ -294,7 +294,7 @@ public class RadioRenderer extends SelectManyCheckboxListRenderer implements Com
             writer.writeAttribute("id", clientId, "id");
             writer.writeAttribute("value", clientId + UINamingContainer.getSeparatorChar(context) + value, "value");
 
-            String styleClass = (String) component.getAttributes().get("styleClass");
+            String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
             if (styleClass != null) {
                 writer.writeAttribute("class", styleClass, "class");
             }

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/RadioRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/RadioRenderer.java
@@ -34,6 +34,7 @@ import java.util.logging.Level;
 import jakarta.el.ELException;
 import jakarta.el.ValueExpression;
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.html.HtmlSelectOneRadio;
 import jakarta.faces.component.UINamingContainer;
 import jakarta.faces.component.UISelectItem;
 import jakarta.faces.component.UISelectOne;
@@ -176,7 +177,7 @@ public class RadioRenderer extends SelectManyCheckboxListRenderer implements Com
         Object itemValue = currentItem.getValue();
         Converter<?> converter = radio.getConverter();
         boolean checked = isChecked(context, radio, itemValue);
-        boolean disabled = Util.componentIsDisabled(radio);
+        boolean disabled = radio instanceof HtmlSelectOneRadio ? ((HtmlSelectOneRadio) radio).isDisabled() : Util.componentIsDisabled(radio);
 
         ResponseWriter writer = context.getResponseWriter();
         assert writer != null;
@@ -294,15 +295,8 @@ public class RadioRenderer extends SelectManyCheckboxListRenderer implements Com
             writer.writeAttribute("id", clientId, "id");
             writer.writeAttribute("value", clientId + UINamingContainer.getSeparatorChar(context) + value, "value");
 
-            String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
-            if (styleClass != null) {
-                writer.writeAttribute("class", styleClass, "class");
-            }
-
-            String style = (String) RenderKitUtils.getAttributeIfSet(component, "style");
-            if (style != null) {
-                writer.writeAttribute("style", style, "style");
-            }
+            writeStyleClassAttributeIfNecessary(writer, component);
+            writeStyleAttributeIfNecessary(writer, component);
         }
 
         if (disabled) {

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/SecretRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/SecretRenderer.java
@@ -82,7 +82,7 @@ public class SecretRenderer extends HtmlBasicInputRenderer {
         RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, component);
 
         String styleClass;
-        if (null != (styleClass = (String) component.getAttributes().get("styleClass"))) {
+        if (null != (styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass"))) {
             writer.writeAttribute("class", styleClass, "styleClass");
         }
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/SecretRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/SecretRenderer.java
@@ -21,6 +21,7 @@ package com.sun.faces.renderkit.html_basic;
 import java.io.IOException;
 
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.html.HtmlInputSecret;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
 
@@ -53,8 +54,9 @@ public class SecretRenderer extends HtmlBasicInputRenderer {
         ResponseWriter writer = context.getResponseWriter();
         assert writer != null;
 
-        String redisplay = String.valueOf(component.getAttributes().get("redisplay"));
-        if (redisplay == null || !redisplay.equals("true")) {
+        boolean redisplay = component instanceof HtmlInputSecret ? ((HtmlInputSecret) component).isRedisplay()
+                : RenderKitUtils.attributeIsTrue(component, "redisplay", false);
+        if (!redisplay) {
             currentValue = "";
         }
 
@@ -63,7 +65,8 @@ public class SecretRenderer extends HtmlBasicInputRenderer {
         writer.writeAttribute("type", "password", "type");
         writer.writeAttribute("name", component.getClientId(context), "clientId");
 
-        String autoComplete = (String) component.getAttributes().get("autocomplete");
+        String autoComplete = component instanceof HtmlInputSecret ? ((HtmlInputSecret) component).getAutocomplete()
+                : (String) component.getAttributes().get("autocomplete");
         if (autoComplete != null) {
             // only output the autocomplete attribute if the value
             // is 'off' since its lack of presence will be interpreted
@@ -81,10 +84,7 @@ public class SecretRenderer extends HtmlBasicInputRenderer {
         RenderKitUtils.renderPassThruAttributes(context, writer, component, null, false, ATTRIBUTES, "change", "valueChange");
         RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, component);
 
-        String styleClass;
-        if (null != (styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass"))) {
-            writer.writeAttribute("class", styleClass, "styleClass");
-        }
+        writeStyleClassAttributeIfNecessary(writer, component);
 
         writer.endElement("input");
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/SelectManyCheckboxListRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/SelectManyCheckboxListRenderer.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.Iterator;
 
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.html.HtmlSelectManyCheckbox;
 import jakarta.faces.component.UINamingContainer;
 import jakarta.faces.component.ValueHolder;
 import jakarta.faces.context.FacesContext;
@@ -66,7 +67,9 @@ public class SelectManyCheckboxListRenderer extends MenuRenderer {
         Boolean newTableRow = false;
         int border = 0;
 
-        if (null != (alignStr = (String) component.getAttributes().get("layout"))) {
+        alignStr = component instanceof HtmlSelectManyCheckbox ? ((HtmlSelectManyCheckbox) component).getLayout()
+                : (String) component.getAttributes().get("layout");
+        if (null != alignStr) {
             if (alignStr.equalsIgnoreCase("list")) {
                 newTableRow = null;
             }
@@ -182,14 +185,8 @@ public class SelectManyCheckboxListRenderer extends MenuRenderer {
             if (shouldWriteIdAttribute(component)) {
                 writeIdAttributeIfNecessary(context, writer, component);
             }
-            String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
-            String style = (String) RenderKitUtils.getAttributeIfSet(component, "style");
-            if (styleClass != null) {
-                writer.writeAttribute("class", styleClass, "class");
-            }
-            if (style != null) {
-                writer.writeAttribute("style", style, "style");
-            }
+            writeStyleClassAttributeIfNecessary(writer, component);
+            writeStyleAttributeIfNecessary(writer, component);
         }
         writer.writeText("\n", component, null);
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/SelectManyCheckboxListRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/SelectManyCheckboxListRenderer.java
@@ -182,7 +182,7 @@ public class SelectManyCheckboxListRenderer extends MenuRenderer {
             if (shouldWriteIdAttribute(component)) {
                 writeIdAttributeIfNecessary(context, writer, component);
             }
-            String styleClass = (String) component.getAttributes().get("styleClass");
+            String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
             String style = (String) RenderKitUtils.getAttributeIfSet(component, "style");
             if (styleClass != null) {
                 writer.writeAttribute("class", styleClass, "class");

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/TableRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/TableRenderer.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import com.sun.faces.renderkit.Attribute;
 import com.sun.faces.renderkit.AttributeManager;
+import com.sun.faces.renderkit.RenderKitUtils;
 import com.sun.faces.util.Util;
 
 import jakarta.faces.component.UIColumn;
@@ -329,7 +330,7 @@ public class TableRenderer extends BaseTableRenderer {
             }
 
             final String tableColumnStyleClass = info.getCurrentColumnClass();
-            final String columnStyleClass = (String) column.getAttributes().get("styleClass");
+            final String columnStyleClass = (String) RenderKitUtils.getAttributeIfSet(column, "styleClass");
 
             if (tableColumnStyleClass != null) {
                 if (columnStyleClass != null) {

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/TableRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/TableRenderer.java
@@ -30,6 +30,8 @@ import com.sun.faces.util.Util;
 
 import jakarta.faces.component.UIColumn;
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.html.HtmlDataTable;
+import jakarta.faces.component.html.HtmlColumn;
 import jakarta.faces.component.UIData;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
@@ -214,14 +216,16 @@ public class TableRenderer extends BaseTableRenderer {
         if (footer == null && !info.hasFooterFacets) {
             return;
         }
-        String footerClass = (String) table.getAttributes().get("footerClass");
+        String footerClass = table instanceof HtmlDataTable ? ((HtmlDataTable) table).getFooterClass()
+                : (String) table.getAttributes().get("footerClass");
         writer.startElement("tfoot", table);
         writer.writeText("\n", table, null);
         if (info.hasFooterFacets) {
             writer.startElement("tr", table);
             writer.writeText("\n", table, null);
             for (UIColumn column : info.columns) {
-                String columnFooterClass = (String) column.getAttributes().get("footerClass");
+                String columnFooterClass = column instanceof HtmlColumn ? ((HtmlColumn) column).getFooterClass()
+                        : (String) column.getAttributes().get("footerClass");
                 writer.startElement("td", column);
                 if (columnFooterClass != null) {
                     writer.writeAttribute("class", columnFooterClass, "columnFooterClass");
@@ -265,7 +269,8 @@ public class TableRenderer extends BaseTableRenderer {
         if (header == null && !info.hasHeaderFacets) {
             return;
         }
-        String headerClass = (String) table.getAttributes().get("headerClass");
+        String headerClass = table instanceof HtmlDataTable ? ((HtmlDataTable) table).getHeaderClass()
+                : (String) table.getAttributes().get("headerClass");
         writer.startElement("thead", table);
         writer.writeText("\n", table, null);
         if (header != null) {
@@ -286,7 +291,8 @@ public class TableRenderer extends BaseTableRenderer {
             writer.startElement("tr", table);
             writer.writeText("\n", table, null);
             for (UIColumn column : info.columns) {
-                String columnHeaderClass = (String) column.getAttributes().get("headerClass");
+                String columnHeaderClass = column instanceof HtmlColumn ? ((HtmlColumn) column).getHeaderClass()
+                        : (String) column.getAttributes().get("headerClass");
                 writer.startElement("th", column);
                 if (columnHeaderClass != null) {
                     writer.writeAttribute("class", columnHeaderClass, "columnHeaderClass");
@@ -317,11 +323,8 @@ public class TableRenderer extends BaseTableRenderer {
         for (UIColumn column : info.columns) {
 
             // Render the beginning of this cell
-            boolean isRowHeader = false;
-            Object rowHeaderValue = column.getAttributes().get("rowHeader");
-            if (null != rowHeaderValue) {
-                isRowHeader = Boolean.valueOf(rowHeaderValue.toString());
-            }
+            boolean isRowHeader = column instanceof HtmlColumn ? ((HtmlColumn) column).isRowHeader()
+                    : RenderKitUtils.attributeIsTrue(column, "rowHeader", false);
             if (isRowHeader) {
                 writer.startElement("th", column);
                 writer.writeAttribute("scope", "row", null);

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/TextRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/TextRenderer.java
@@ -91,7 +91,7 @@ public class TextRenderer extends HtmlBasicInputRenderer {
 
         List<String> setAttributes = RenderKitUtils.getAttributesThatAreSet(component);
         String style = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "style");
-        String styleClass = (String) component.getAttributes().get("styleClass");
+        String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
         String dir = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "dir");
         String lang = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "lang");
         String title = (String) RenderKitUtils.getAttributeIfSet(component, setAttributes, "title");

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/TextRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/TextRenderer.java
@@ -31,6 +31,7 @@ import jakarta.faces.component.UIInput;
 import jakarta.faces.component.UIOutput;
 import jakarta.faces.component.html.HtmlInputFile;
 import jakarta.faces.component.html.HtmlInputText;
+import jakarta.faces.component.html.HtmlOutputText;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
 
@@ -129,7 +130,8 @@ public class TextRenderer extends HtmlBasicInputRenderer {
             // only output the autocomplete attribute if the value
             // is 'off' since its lack of presence will be interpreted
             // as 'on' by the browser
-            if ("off".equals(component.getAttributes().get("autocomplete"))) {
+            if (component instanceof HtmlInputText ? "off".equals(((HtmlInputText) component).getAutocomplete())
+                    : "off".equals(component.getAttributes().get("autocomplete"))) {
                 writer.writeAttribute("autocomplete", "off", "autocomplete");
             }
 
@@ -163,8 +165,8 @@ public class TextRenderer extends HtmlBasicInputRenderer {
 
             }
             if (currentValue != null) {
-                Object val = component.getAttributes().get("escape");
-                if (val != null && Boolean.valueOf(val.toString())) {
+                if (component instanceof HtmlOutputText ? ((HtmlOutputText) component).isEscape()
+                        : RenderKitUtils.attributeIsTrue(component, "escape", false)) {
                     writer.writeText(currentValue, component, "value");
                 } else {
                     writer.write(currentValue);

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/TextareaRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/TextareaRenderer.java
@@ -50,7 +50,7 @@ public class TextareaRenderer extends HtmlBasicInputRenderer {
         ResponseWriter writer = context.getResponseWriter();
         assert writer != null;
 
-        String styleClass = (String) component.getAttributes().get("styleClass");
+        String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
 
         writer.startElement("textarea", component);
         writeIdAttributeIfNecessary(context, writer, component);

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/TextareaRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/TextareaRenderer.java
@@ -50,14 +50,10 @@ public class TextareaRenderer extends HtmlBasicInputRenderer {
         ResponseWriter writer = context.getResponseWriter();
         assert writer != null;
 
-        String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
-
         writer.startElement("textarea", component);
         writeIdAttributeIfNecessary(context, writer, component);
         writer.writeAttribute("name", component.getClientId(context), "clientId");
-        if (styleClass != null) {
-            writer.writeAttribute("class", styleClass, "styleClass");
-        }
+        writeStyleClassAttributeIfNecessary(writer, component);
 
         // style is rendered as a passthru attribute
         RenderKitUtils.renderPassThruAttributes(context, writer, component, null, false, ATTRIBUTES, "change", "valueChange");

--- a/impl/src/main/java/com/sun/faces/util/SelectItemUtils.java
+++ b/impl/src/main/java/com/sun/faces/util/SelectItemUtils.java
@@ -68,8 +68,8 @@ public class SelectItemUtils {
         S selectItem = supplier.get();
         selectItem.setValue(itemValue);
         selectItem.setLabel(String.valueOf(itemLabel != null ? itemLabel : selectItem.getValue()));
-        selectItem.setEscape(itemEscaped == null || Boolean.parseBoolean(itemEscaped.toString()));
-        selectItem.setDisabled(itemDisabled != null && Boolean.parseBoolean(itemDisabled.toString()));
+        selectItem.setEscape(Util.toBoolean(itemEscaped, true));
+        selectItem.setDisabled(Util.toBoolean(itemDisabled, false));
         return selectItem;
     }
 

--- a/impl/src/main/java/com/sun/faces/util/Util.java
+++ b/impl/src/main/java/com/sun/faces/util/Util.java
@@ -805,19 +805,27 @@ public class Util {
     }
 
     public static boolean componentIsDisabled(UIComponent component) {
-        return attributeIsTrue(component, "disabled");
+        return toBoolean(component.getAttributes().get("disabled"), false);
     }
 
     public static boolean componentIsDisabledOrReadonly(UIComponent component) {
-        return attributeIsTrue(component, "disabled") || attributeIsTrue(component, "readonly");
+        return componentIsDisabled(component) || toBoolean(component.getAttributes().get("readonly"), false);
     }
 
-    // disabled/readonly are declared boolean properties on the HTML components these helpers run against, so the
-    // attribute value is always a Boolean (the Facelets boolean MetaRule coerces literals/EL before storing; a String
-    // cannot be written through a boolean setter). Read it directly, mirroring UIComponent.isRendered(), rather than
-    // routing through the String.valueOf()/parseBoolean() coercion the absent String case never needs.
-    private static boolean attributeIsTrue(UIComponent component, String name) {
-        return Boolean.TRUE.equals(component.getAttributes().get(name));
+    /**
+     * Coerces a boolean-attribute value to {@code boolean} without the {@code Boolean -> String -> boolean} round-trip
+     * on the common path: an absent value yields {@code defaultValue}, an already-{@code Boolean} value is returned
+     * directly, and only a non-{@code Boolean} (e.g. a literal String set on a non-typed component) is parsed. Prefer
+     * the typed getter via {@code instanceof} where the concrete {@code Html*} type is known; use this for the fallback.
+     */
+    public static boolean toBoolean(Object value, boolean defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        return Boolean.parseBoolean(value.toString());
     }
 
     // W3C XML specification refers to IETF RFC 1766 for language code

--- a/impl/src/main/java/jakarta/faces/component/SelectItemsIterator.java
+++ b/impl/src/main/java/jakarta/faces/component/SelectItemsIterator.java
@@ -448,9 +448,9 @@ final class SelectItemsIterator implements Iterator<SelectItem> {
                     setValue(itemValueResult != null ? itemValueResult : value);
                     setLabel(itemLabelResult != null ? itemLabelResult.toString() : value.toString());
                     setDescription(itemDescriptionResult != null ? itemDescriptionResult.toString() : null);
-                    setEscape(itemEscapedResult != null ? Boolean.valueOf(itemEscapedResult.toString()) : true);
-                    setDisabled(itemDisabledResult != null ? Boolean.valueOf(itemDisabledResult.toString()) : false);
-                    setNoSelectionOption(noSelectionOptionResult != null ? Boolean.valueOf(noSelectionOptionResult.toString()) : false);
+                    setEscape(toBoolean(itemEscapedResult, true));
+                    setDisabled(toBoolean(itemDisabledResult, false));
+                    setNoSelectionOption(toBoolean(noSelectionOptionResult, false));
                 } finally {
                     if (var != null) {
                         if (oldVarValue != null) {
@@ -461,6 +461,18 @@ final class SelectItemsIterator implements Iterator<SelectItem> {
                     }
                 }
 
+            }
+
+            // Coerce a boolean-attribute value without the Boolean -> String -> boolean round-trip on the common path:
+            // absent -> default, already-Boolean -> direct, otherwise parse. (Local copy to avoid a com.sun.faces dependency.)
+            private static boolean toBoolean(Object value, boolean defaultValue) {
+                if (value == null) {
+                    return defaultValue;
+                }
+                if (value instanceof Boolean) {
+                    return (Boolean) value;
+                }
+                return Boolean.parseBoolean(value.toString());
             }
 
             // --------------------------------------- Methods from Serializable

--- a/impl/src/main/java/jakarta/faces/component/UIComponent.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponent.java
@@ -199,9 +199,13 @@ public abstract class UIComponent implements PartialStateHolder, TransientStateH
     private boolean isInView;
     private Map<String, String> resourceBundleMap;
 
-    // It is safe to cache this because components never go from being
-    // composite to non-composite.
-    private transient Boolean isCompositeComponent;
+    // It is safe to cache this because components never go from being composite to non-composite. Event-driven
+    // rather than lazily resolved: the flag is set TRUE when COMPONENT_RESOURCE_KEY is put
+    // (UIComponentBase.AttributesMap) -- the act that makes a component composite -- and re-derived after restore
+    // (full-state via UIComponentBase.restoreMarkersFromState, any restore via processEvent on PostRestoreStateEvent).
+    // So the common non-composite component answers isCompositeComponent() straight from the field, without a
+    // getAttributes().containsKey(COMPONENT_RESOURCE_KEY) probe on every EL push/pop during buildView.
+    private transient boolean isCompositeComponent;
 
     /**
      * Track whether we have been pushed as current in order to handle mismatched pushes and pops of Jakarta Expression
@@ -1585,14 +1589,17 @@ public abstract class UIComponent implements PartialStateHolder, TransientStateH
         if (component == null) {
             throw new NullPointerException();
         }
-        boolean result = false;
-        if (null != component.isCompositeComponent) {
-            result = component.isCompositeComponent.booleanValue();
-        } else {
-            result = component.isCompositeComponent = component.getAttributes().containsKey(Resource.COMPONENT_RESOURCE_KEY);
-        }
-        return result;
+        return component.isCompositeComponent;
 
+    }
+
+    /**
+     * Primes the cached composite-component flag without probing the attributes map. Called by
+     * {@code UIComponentBase.AttributesMap} when {@code COMPONENT_RESOURCE_KEY} is put (which is what makes a
+     * component composite) and by {@code restoreMarkersFromState} on full-state restore. See the field declaration.
+     */
+    void setCompositeComponentFlag(boolean composite) {
+        isCompositeComponent = composite;
     }
 
     /**
@@ -1889,7 +1896,10 @@ public abstract class UIComponent implements PartialStateHolder, TransientStateH
                 valueExpression.setValue(FacesContext.getCurrentInstance().getELContext(), this);
             }
 
-            isCompositeComponent = null;
+            // Re-derive from the (now restored) attributes map; the binding repopulation above and full/partial
+            // state restore can change whether this instance carries COMPONENT_RESOURCE_KEY. Replaces the former
+            // null-reset-then-lazy-recompute now that the flag is a non-nullable primitive.
+            isCompositeComponent = getAttributes().containsKey(Resource.COMPONENT_RESOURCE_KEY);
         }
     }
 

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -25,6 +25,7 @@ import static com.sun.faces.facelets.tag.faces.core.FacetHandler.KEY;
 import static com.sun.faces.util.Util.isAllNull;
 import static com.sun.faces.util.Util.isAnyNull;
 import static com.sun.faces.util.Util.isEmpty;
+import static jakarta.faces.application.Resource.COMPONENT_RESOURCE_KEY;
 import static java.beans.Introspector.getBeanInfo;
 import static java.lang.Boolean.TRUE;
 import static java.lang.Character.isDigit;
@@ -125,6 +126,15 @@ public abstract class UIComponentBase extends UIComponent {
      * can be regenerated) and lets the hot attribute-read path skip re-suppressing and re-caching it per component.
      */
     private Map<String, Method> readMethodMap;
+
+    /**
+     * This class's write methods (keyed by property name), the write-side counterpart of {@link #readMethodMap} kept in
+     * its own application-scoped cache (see {@link #populateDescriptorsMapIfNecessary}). Holds the access-suppressed
+     * setter {@link Method}s strongly so the {@code getAttributes().put} property-write path (Facelets applying a
+     * literal-text {@code ValueExpression} or a non-property literal during buildView) skips the per-put access check
+     * and the soft-reference setter rediscovery.
+     */
+    private Map<String, Method> writeMethodMap;
 
     private Map<Class<? extends SystemEvent>, List<SystemEventListener>> listenersByEventClass;
 
@@ -1634,6 +1644,10 @@ public abstract class UIComponentBase extends UIComponent {
         return readMethodMap;
     }
 
+    Map<String, Method> getWriteMethodMap() {
+        return writeMethodMap;
+    }
+
     // ---- Field-backed Facelets markers (authoritative cache for AttributesMap) ----
     // The marker fields are the single source of truth: AttributesMap.put/remove keep them in sync, and
     // AttributesMap.get/containsKey read them WITHOUT touching the state map -- so the per-component
@@ -1722,6 +1736,7 @@ public abstract class UIComponentBase extends UIComponent {
         dynamicComponent = attrs.get(DYNAMIC_COMPONENT);
         markDeleted = Boolean.TRUE.equals(attrs.get(MARK_DELETED));
         markChildrenModified = Boolean.TRUE.equals(attrs.get(MARK_CHILDREN_MODIFIED));
+        setCompositeComponentFlag(attrs.containsKey(COMPONENT_RESOURCE_KEY));
     }
 
     private void doPostAddProcessing(FacesContext context, UIComponent added) {
@@ -2159,6 +2174,8 @@ public abstract class UIComponentBase extends UIComponent {
         // Per-class, application-scoped cache of access-suppressed read methods (see UIComponentBase.readMethodMap);
         // a hit skips the PropertyDescriptor lookup, the access-check suppression and the reflective getter discovery.
         private transient Map<String, Method> readMap;
+        // Write-side counterpart of readMap (see UIComponentBase.writeMethodMap); used by the property-write path in put.
+        private transient Map<String, Method> writeMap;
         private transient UIComponentBase component;
         private static final long serialVersionUID = -6773035086539772945L;
 
@@ -2169,6 +2186,7 @@ public abstract class UIComponentBase extends UIComponent {
             this.component = (UIComponentBase) component;
             pdMap = this.component.getDescriptorMap();
             readMap = this.component.getReadMethodMap();
+            writeMap = this.component.getWriteMethodMap();
         }
 
         @Override
@@ -2301,12 +2319,25 @@ public abstract class UIComponentBase extends UIComponent {
             PropertyDescriptor pd = marker ? null : getPropertyDescriptor(keyValue);
             if (pd != null) {
                 try {
-                    Object result = null;
-                    Method readMethod = pd.getReadMethod();
-                    if (readMethod != null) {
-                        result = readMethod.invoke(component, EMPTY_OBJECT_ARRAY);
+                    // Prefer the access-suppressed accessors cached per class (writeMap/readMap); fall back to the
+                    // descriptor only when the cache is absent (e.g. no FacesContext at construction), suppressing the
+                    // discovered method so a later put on the same component does not repeat the access check.
+                    Method readMethod = readMap == null ? null : readMap.get(keyValue);
+                    if (readMethod == null) {
+                        readMethod = pd.getReadMethod();
+                        if (readMethod != null) {
+                            suppressAccessCheck(readMethod);
+                        }
                     }
-                    Method writeMethod = pd.getWriteMethod();
+                    Object result = readMethod == null ? null : readMethod.invoke(component, EMPTY_OBJECT_ARRAY);
+
+                    Method writeMethod = writeMap == null ? null : writeMap.get(keyValue);
+                    if (writeMethod == null) {
+                        writeMethod = pd.getWriteMethod();
+                        if (writeMethod != null) {
+                            suppressAccessCheck(writeMethod);
+                        }
+                    }
                     if (writeMethod != null) {
                         writeMethod.invoke(component, value);
                     } else {
@@ -2470,6 +2501,12 @@ public abstract class UIComponentBase extends UIComponent {
         }
 
         private Object putAttribute(String key, Object value) {
+            if (COMPONENT_RESOURCE_KEY.equals(key)) {
+                // Putting the component resource is what makes a component composite; prime the cached flag so
+                // isCompositeComponent() answers from the field instead of probing the attributes map (see the
+                // UIComponent.isCompositeComponent field).
+                component.setCompositeComponentFlag(true);
+            }
             return component.getStateHelper().put(PropertyKeys.attributes, key, value);
         }
 
@@ -2484,19 +2521,20 @@ public abstract class UIComponentBase extends UIComponent {
         }
 
         /**
-         * Suppresses the per-invoke reflective access check on the (public) property getter that gets
-         * cached in {@link #readMap} and then invoked on every property-backed attribute read — hot under
-         * render and {@code UIData}/{@code UIRepeat} iteration (a renderer reads each pass-through attribute
-         * through {@code getAttributes().get}). The check is otherwise re-run per invoke because
-         * {@link PropertyDescriptor#getReadMethod()} hands back the method via a soft {@link
-         * java.lang.ref.Reference} that may be regenerated, yielding a fresh {@link Method} whose access
+         * Suppresses the per-invoke reflective access check on the (public) property accessor (getter cached in
+         * {@link #readMap}, setter in {@link #writeMap}) that is then invoked on every property-backed attribute read
+         * or write — hot under render and {@code UIData}/{@code UIRepeat} iteration (a renderer reads each pass-through
+         * attribute through {@code getAttributes().get}) and under buildView (Facelets writes through
+         * {@code getAttributes().put}). The check is otherwise re-run per invoke because
+         * {@link PropertyDescriptor#getReadMethod()}/{@link PropertyDescriptor#getWriteMethod()} hand back the method via
+         * a soft {@link java.lang.ref.Reference} that may be regenerated, yielding a fresh {@link Method} whose access
          * was never suppressed. Suppressing it on the strongly-held cached instance makes the win durable.
          */
-        private static void suppressAccessCheck(Method readMethod) {
+        private static void suppressAccessCheck(Method accessor) {
             try {
-                // The module system may forbid this for a getter in a non-exported user package;
+                // The module system may forbid this for an accessor in a non-exported user package;
                 // when it does, the normal per-invoke access check simply remains.
-                readMethod.setAccessible(true);
+                accessor.setAccessible(true);
             } catch (RuntimeException accessNotSuppressed) {
             }
         }
@@ -3415,12 +3453,15 @@ public abstract class UIComponentBase extends UIComponent {
 
     private static final String COMPONENT_READ_METHODS_MAP_KEY = "com.sun.faces.component.COMPONENT_READ_METHODS_MAP";
 
+    private static final String COMPONENT_WRITE_METHODS_MAP_KEY = "com.sun.faces.component.COMPONENT_WRITE_METHODS_MAP";
+
     @SuppressWarnings("unchecked")
     private void populateDescriptorsMapIfNecessary() {
         FacesContext facesContext = FacesContext.getCurrentInstance();
         Class<?> clazz = getClass();
         Map<Class<?>, Map<String, PropertyDescriptor>> descriptors = null;
         Map<Class<?>, Map<String, Method>> readMethods = null;
+        Map<Class<?>, Map<String, Method>> writeMethods = null;
 
         /*
          * If we can find a valid FacesContext we are going to use it to get access to the property descriptor map.
@@ -3436,6 +3477,10 @@ public abstract class UIComponentBase extends UIComponent {
             readMethods = (Map<Class<?>, Map<String, Method>>) applicationMap.computeIfAbsent(
                     COMPONENT_READ_METHODS_MAP_KEY, k -> new ConcurrentHashMap<>());
             readMethodMap = readMethods.get(clazz);
+
+            writeMethods = (Map<Class<?>, Map<String, Method>>) applicationMap.computeIfAbsent(
+                    COMPONENT_WRITE_METHODS_MAP_KEY, k -> new ConcurrentHashMap<>());
+            writeMethodMap = writeMethods.get(clazz);
         }
 
         if (propertyDescriptorMap == null) {
@@ -3446,14 +3491,21 @@ public abstract class UIComponentBase extends UIComponent {
             if (propertyDescriptors != null) {
                 propertyDescriptorMap = new HashMap<>(propertyDescriptors.length, 1.0f);
                 readMethodMap = new HashMap<>(propertyDescriptors.length, 1.0f);
+                writeMethodMap = new HashMap<>(propertyDescriptors.length, 1.0f);
                 for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
-                    // Suppress the access check once, here, and strongly cache the read method per class so the
-                    // suppression stays durable (PropertyDescriptor.getReadMethod hands it back via a soft reference
-                    // that can be regenerated) and the hot attribute-read path never re-suppresses or re-caches it.
+                    // Suppress the access check once, here, and strongly cache the accessor per class so the
+                    // suppression stays durable (PropertyDescriptor.getReadMethod/getWriteMethod hand it back via a soft
+                    // reference that can be regenerated) and the hot attribute-read/write paths never re-suppress or
+                    // re-cache it.
                     Method readMethod = propertyDescriptor.getReadMethod();
                     if (readMethod != null) {
                         AttributesMap.suppressAccessCheck(readMethod);
                         readMethodMap.put(propertyDescriptor.getName(), readMethod);
+                    }
+                    Method writeMethod = propertyDescriptor.getWriteMethod();
+                    if (writeMethod != null) {
+                        AttributesMap.suppressAccessCheck(writeMethod);
+                        writeMethodMap.put(propertyDescriptor.getName(), writeMethod);
                     }
                     propertyDescriptorMap.put(propertyDescriptor.getName(), propertyDescriptor);
                 }
@@ -3467,6 +3519,9 @@ public abstract class UIComponentBase extends UIComponent {
                 }
                 if (readMethods != null) {
                     readMethods.putIfAbsent(clazz, readMethodMap);
+                }
+                if (writeMethods != null) {
+                    writeMethods.putIfAbsent(clazz, writeMethodMap);
                 }
             }
         }

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlBody.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlBody.java
@@ -522,6 +522,7 @@ public class HtmlBody extends UIOutput implements ClientBehaviorHolder {
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlColumn.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlColumn.java
@@ -17,6 +17,8 @@
  */
 package jakarta.faces.component.html;
 
+import static jakarta.faces.component.html.HtmlComponentUtils.handleAttribute;
+
 import jakarta.faces.component.UIColumn;
 
 /**
@@ -157,6 +159,7 @@ public class HtmlColumn extends UIColumn {
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
 }

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlCommandButton.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlCommandButton.java
@@ -742,6 +742,7 @@ public class HtmlCommandButton extends UICommand implements ClientBehaviorHolder
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlCommandLink.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlCommandLink.java
@@ -736,6 +736,7 @@ public class HtmlCommandLink extends UICommand implements ClientBehaviorHolder {
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlComponentUtils.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlComponentUtils.java
@@ -12,6 +12,36 @@ class HtmlComponentUtils {
     private static final String ATTRIBUTES_THAT_ARE_SET = "jakarta.faces.component.UIComponentBase.attributesThatAreSet";
     private static final String OPTIMIZED_PACKAGE = "jakarta.faces.component.";
 
+    /**
+     * Records (or clears) that the given pass-through HTML attribute was explicitly set on a standard component, in the
+     * component's {@code attributesThatAreSet} list, so that at render time an unset attribute can be skipped without a
+     * reflective property read.
+     * <p>
+     * The generated concrete {@code Html*} setters call this for the pass-through attributes they expose ({@code style},
+     * {@code styleClass}, {@code dir}, {@code lang}, {@code title}, the {@code on*} handlers, {@code accesskey},
+     * {@code tabindex}, {@code alt}, {@code border}, ...). It is intentionally <em>not</em> called for properties that
+     * are not emitted as HTML attributes by value ({@code escape}, {@code label}, {@code value}, {@code required}, ...),
+     * which drive component logic and are read unconditionally, nor for the boolean attributes rendered through their
+     * own path ({@code disabled}, {@code readonly}); none of those would gain anything from the skip.
+     * <p>
+     * This is the <em>write</em> side of a two-part optimization whose <em>read</em> side is
+     * {@code com.sun.faces.renderkit.AttributeManager} together with {@code RenderKitUtils.renderPassThruAttributes} /
+     * {@code getAttributeIfSet}. {@code AttributeManager} declares <em>which</em> pass-through attributes a renderer
+     * emits; this list records <em>which were actually set</em>; rendering walks the former and consults the latter to
+     * skip the reflective getter for the unset ones. The two sets overlap but are not equal: {@code style}, {@code dir},
+     * {@code lang} and {@code title} appear in both, whereas {@code styleClass} is tracked here yet absent from
+     * {@code AttributeManager}, because it must be emitted as the HTML {@code class} attribute (a name rename the generic
+     * pass-through loop cannot perform) and is therefore rendered inline by each renderer instead.
+     * <p>
+     * Only standard components (those in the {@code jakarta.faces.component} package, i.e. the generated {@code Html*}
+     * classes) maintain the list; for any other component type it is never created and the optimization is simply
+     * skipped. A {@code null} {@code value} clears the tracking unless a {@link ValueExpression} is bound to {@code name},
+     * in which case the attribute stays "set" because its value is supplied dynamically per request.
+     *
+     * @param component the standard component on which the attribute was set or cleared
+     * @param name      the pass-through attribute (property) name
+     * @param value     the new literal value, or {@code null} when the attribute is being cleared
+     */
     static void handleAttribute(UIComponent component, String name, Object value) {
         final Map<String, Object> attributes = component.getAttributes();
 

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlDataTable.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlDataTable.java
@@ -853,6 +853,7 @@ public class HtmlDataTable extends UIData implements ClientBehaviorHolder {
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlForm.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlForm.java
@@ -605,6 +605,7 @@ public class HtmlForm extends UIForm implements ClientBehaviorHolder {
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlGraphicImage.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlGraphicImage.java
@@ -578,6 +578,7 @@ public class HtmlGraphicImage extends UIGraphic implements ClientBehaviorHolder 
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlInputFile.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlInputFile.java
@@ -916,6 +916,7 @@ public class HtmlInputFile extends UIInput implements ClientBehaviorHolder {
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlInputSecret.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlInputSecret.java
@@ -823,6 +823,7 @@ public class HtmlInputSecret extends UIInput implements ClientBehaviorHolder {
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlInputText.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlInputText.java
@@ -787,6 +787,7 @@ public class HtmlInputText extends UIInput implements ClientBehaviorHolder {
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlInputTextarea.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlInputTextarea.java
@@ -734,6 +734,7 @@ public class HtmlInputTextarea extends UIInput implements ClientBehaviorHolder {
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlMessage.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlMessage.java
@@ -356,6 +356,7 @@ public class HtmlMessage extends UIMessage {
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlMessages.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlMessages.java
@@ -381,6 +381,7 @@ public class HtmlMessages extends UIMessages {
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlOutcomeTargetButton.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlOutcomeTargetButton.java
@@ -638,6 +638,7 @@ public class HtmlOutcomeTargetButton extends UIOutcomeTarget implements ClientBe
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlOutcomeTargetLink.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlOutcomeTargetLink.java
@@ -735,6 +735,7 @@ public class HtmlOutcomeTargetLink extends UIOutcomeTarget implements ClientBeha
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlOutputFormat.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlOutputFormat.java
@@ -236,6 +236,7 @@ public class HtmlOutputFormat extends UIOutput {
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlOutputLabel.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlOutputLabel.java
@@ -605,6 +605,7 @@ public class HtmlOutputLabel extends UIOutput implements ClientBehaviorHolder {
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlOutputLink.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlOutputLink.java
@@ -763,6 +763,7 @@ public class HtmlOutputLink extends UIOutput implements ClientBehaviorHolder {
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlOutputText.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlOutputText.java
@@ -238,6 +238,7 @@ public class HtmlOutputText extends UIOutput {
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlPanelGrid.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlPanelGrid.java
@@ -878,6 +878,7 @@ public class HtmlPanelGrid extends UIPanel implements ClientBehaviorHolder {
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlPanelGroup.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlPanelGroup.java
@@ -408,6 +408,7 @@ public class HtmlPanelGroup extends UIPanel implements ClientBehaviorHolder {
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     private static final Collection<String> EVENT_NAMES = Collections.unmodifiableCollection(

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlSelectBooleanCheckbox.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlSelectBooleanCheckbox.java
@@ -683,6 +683,7 @@ public class HtmlSelectBooleanCheckbox extends UISelectBoolean implements Client
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlSelectManyCheckbox.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlSelectManyCheckbox.java
@@ -812,6 +812,7 @@ public class HtmlSelectManyCheckbox extends UISelectMany implements ClientBehavi
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlSelectManyListbox.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlSelectManyListbox.java
@@ -732,6 +732,7 @@ public class HtmlSelectManyListbox extends UISelectMany implements ClientBehavio
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlSelectManyMenu.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlSelectManyMenu.java
@@ -706,6 +706,7 @@ public class HtmlSelectManyMenu extends UISelectMany implements ClientBehaviorHo
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlSelectOneListbox.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlSelectOneListbox.java
@@ -732,6 +732,7 @@ public class HtmlSelectOneListbox extends UISelectOne implements ClientBehaviorH
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlSelectOneMenu.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlSelectOneMenu.java
@@ -707,6 +707,7 @@ public class HtmlSelectOneMenu extends UISelectOne implements ClientBehaviorHold
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlSelectOneRadio.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlSelectOneRadio.java
@@ -820,6 +820,7 @@ public class HtmlSelectOneRadio extends UISelectOne implements ClientBehaviorHol
      */
     public void setStyleClass(java.lang.String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+        handleAttribute(this, "styleClass", styleClass);
     }
 
     /**


### PR DESCRIPTION
#5753 

Backport of #5796 to 4.0. Cuts the per-component reflective and lookup cost the Restore View and Render phases pay for component attribute handling. Behavior-neutral.

- buildView reflective/lookup overhead: `writeMethodMap`, `BeanPropertyTagRule` access-suppression, event-driven `isCompositeComponent` flag.
- Track `styleClass` and skip its reflective read when unset.
- Read renderer attributes via typed `Html*` getters with cheaper boolean coercion.

Adaptations for 4.0:
- The typed-getter reads use classic casts instead of pattern-matching `instanceof`, since 4.0 targets Java 11 (4.1 targets 17).
- The test/perf `numberOfViewsInSession` change is omitted: that benchmark knob does not exist on 4.0's older perf harness.

impl builds and unit tests pass on Java 11.

🤖 Generated with Claude Opus 4.8
