### PR TITLE
Fix CCE in isRendered() on String-valued rendered expression

### DIFF
--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -25,9 +25,9 @@ import static com.sun.faces.facelets.tag.faces.core.FacetHandler.KEY;
 import static com.sun.faces.util.Util.isAllNull;
 import static com.sun.faces.util.Util.isAnyNull;
 import static com.sun.faces.util.Util.isEmpty;
+import static com.sun.faces.util.Util.toBoolean;
 import static jakarta.faces.application.Resource.COMPONENT_RESOURCE_KEY;
 import static java.beans.Introspector.getBeanInfo;
-import static java.lang.Boolean.TRUE;
 import static java.lang.Character.isDigit;
 import static java.lang.Character.isLetter;
 import static java.lang.Thread.currentThread;
@@ -401,7 +401,10 @@ public abstract class UIComponentBase extends UIComponent {
         if (cachedIsRendered != null) {
             return cachedIsRendered;
         }
-        return (Boolean) getStateHelper().eval(PropertyKeys.rendered, TRUE);
+        // Coerce leniently rather than casting: a "rendered" value expression bound with a non-Boolean expected
+        // type (e.g. via a templating layer) can evaluate to a String, which a direct (Boolean) cast rejects.
+        // Tolerating it is not spec-required but is kept for backward compatibility; a Boolean costs nothing here.
+        return toBoolean(getStateHelper().eval(PropertyKeys.rendered), true);
     }
 
     @Override

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -404,6 +404,7 @@ public abstract class UIComponentBase extends UIComponent {
         // Coerce leniently rather than casting: a "rendered" value expression bound with a non-Boolean expected
         // type (e.g. via a templating layer) can evaluate to a String, which a direct (Boolean) cast rejects.
         // Tolerating it is not spec-required but is kept for backward compatibility; a Boolean costs nothing here.
+        // Mojarra 5.0 should log a warning on this and Mojarra 6.0 should remove this leniency.
         return toBoolean(getStateHelper().eval(PropertyKeys.rendered), true);
     }
 

--- a/impl/src/test/java/jakarta/faces/component/UIComponentTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIComponentTestCase.java
@@ -1642,6 +1642,7 @@ public class UIComponentTestCase extends JUnitFacesTestCaseBase {
     // Tests #5801: a "rendered" value expression bound with a non-Boolean expected type (e.g. through a
     // templating layer) can evaluate to a String; isRendered() must coerce it leniently rather than throwing
     // ClassCastException. The Boolean path must stay unchanged.
+    // NOTE: not spec-compliant, so this cannot end up in the TCK.
     @Test
     public void testRenderedCoercesNonBooleanExpression() {
         assertFalse(renderedFromExpression("false"));

--- a/impl/src/test/java/jakarta/faces/component/UIComponentTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIComponentTestCase.java
@@ -17,10 +17,12 @@
 package jakarta.faces.component;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.when;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -36,10 +38,12 @@ import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import com.sun.faces.junit.JUnitFacesTestCaseBase;
 import com.sun.faces.mock.MockRenderKit;
 
+import jakarta.el.ValueExpression;
 import jakarta.faces.FactoryFinder;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.AbortProcessingException;
@@ -1633,6 +1637,27 @@ public class UIComponentTestCase extends JUnitFacesTestCaseBase {
         component.setRendererType("foo");
         assertEquals("foo", component.getRendererType());
 
+    }
+
+    // Tests #5801: a "rendered" value expression bound with a non-Boolean expected type (e.g. through a
+    // templating layer) can evaluate to a String; isRendered() must coerce it leniently rather than throwing
+    // ClassCastException. The Boolean path must stay unchanged.
+    @Test
+    public void testRenderedCoercesNonBooleanExpression() {
+        assertFalse(renderedFromExpression("false"));
+        assertTrue(renderedFromExpression("true"));
+        // Common Boolean path is unaffected.
+        assertFalse(renderedFromExpression(Boolean.FALSE));
+        assertTrue(renderedFromExpression(Boolean.TRUE));
+    }
+
+    // Binds "rendered" to a (non-literal) value expression that evaluates to the given value, then reads isRendered().
+    private boolean renderedFromExpression(Object evaluatedValue) {
+        ValueExpression expression = Mockito.mock(ValueExpression.class);
+        when(expression.isLiteralText()).thenReturn(false);
+        when(expression.getValue(Mockito.any())).thenReturn(evaluatedValue);
+        component.setValueExpression("rendered", expression);
+        return component.isRendered();
     }
 
     // --------------------------------------------------------- Support Methods


### PR DESCRIPTION
## Problem

`UIComponentBase.isRendered()` reads the `rendered` attribute via a strict `(Boolean)` cast on the `StateHelper.eval()` result:

```java
return (Boolean) getStateHelper().eval(PropertyKeys.rendered, TRUE);
```

When the `rendered` value expression is bound with a **non-`Boolean` expected type** — e.g. through a templating layer that creates the `ValueExpression` with `Object.class` rather than the component's `boolean` property type — `eval()` returns the raw evaluated value, which may be a `String`. The cast then throws:

```
java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Boolean
    at jakarta.faces.component.UIComponentBase.isRendered(UIComponentBase.java:312)
```

## Regression source (4.x)

On 4.x this was introduced by PR #5754 (commit aafc13cc76, "Phase A of component-tree perf work"). Before that, `isRendered()` was `Boolean.valueOf(eval(...).toString())` — it called `toString()` on whatever `eval()` returned and parsed that back to a boolean, so a `String` coerced cleanly. #5754 replaced the String round-trip with the direct `(Boolean)` cast to drop the allocation, which silently removed that tolerance.

## Where it surfaced

GlassFish's Admin UI, where `rendered="#{sessionScope.restartRequired}"` resolves to a `String` stored in the session and is bound via jsftemplating with an `Object` expected type — bypassing the EL `String`→`Boolean` coercion that a standard Facelets attribute (created with the `boolean` property type) would apply.

## Actually observed on 5.0.0-M2 — different root cause

It was reported against Mojarra 5.0.0-M2, which **does not contain the #5754 perf work** — its `isRendered()` is still the lenient `Boolean.parseBoolean(eval(rendered, TRUE).toString())`. It nonetheless throws the same CCE, for a different reason: `StateHelper.eval` was generified to `<T> T eval(Serializable key, T defaultValue)` (#2028). Passing the `TRUE` default makes type inference resolve `T = Boolean`, so the **compiler inserts a synthetic `checkcast Boolean`** on the return value *before* `.toString()` even runs. A `String` trips that checkcast — same exception, same line, but produced by the compiler rather than written by hand.

So 5.0 has two independent routes to the identical CCE: (1) the generified-`eval` inference (#2028, present since M2), and (2) the strict `(Boolean)` cast later merged up from 4.x via #5754. Either alone is sufficient.

Implication for the 5.0 fix: dropping the `TRUE` default (single-arg `eval`, which returns `Object`) is **required** to defeat route (1) — assigning the result to an `Object` is not enough, because inference still picks `T = Boolean` from the `TRUE` argument and re-inserts the checkcast. This 4.x fix already drops the default, so it ports cleanly; 5.0 additionally gets the dev-stage warning.

## Note on correctness

Strictly, this is **user error and not spec compliant**: `rendered` is a boolean property, and the application should store a `Boolean` (or bind the VE with a `Boolean` expected type) so EL coerces it. Nothing in the spec requires `isRendered()` to accept a `String`. But the lenient behavior stood for years and apps came to rely on it, so restoring it is the backward-compatible fix and costs nothing on the common path.

## Scope: other boolean properties reviewed

`rendered` is the **only** regression. Every other boolean getter (`disabled`, `readonly`, `required`, `immediate`, `escape`, `ismap`, `multiple`, `redisplay`, and the rest of the generated `Html*` getters) has always used a strict `(Boolean)` cast — long before #5754 — so their behavior is unchanged:

- `isRendered()` was the **sole** getter that historically coerced leniently (`Boolean.valueOf(eval(...).toString())`); #5754 is what flipped it to a strict cast.
- A scan of all `jakarta.faces.component` boolean getters confirms none of the others ever did the `.toString()` round-trip — they read `(Boolean) eval(...)` as far back as they were generated.
- So a `String`-valued, `Object`-typed VE also throws on `disabled`/`readonly`/`immediate`/etc., but it always has, on every prior Faces release. They are not regressions, so they are intentionally left as-is — broadening the leniency there would be a *new* behavior change, not a fix. (On 5.0 these carry the same compiler-inserted checkcast as `rendered`, again with unchanged behavior.)

## Fix

Coerce leniently via `Util.toBoolean()`:

```java
return toBoolean(getStateHelper().eval(PropertyKeys.rendered), true);
```

The common `Boolean` path stays allocation-free (returned directly); only a non-`Boolean` value pays the parse.

In **5.0** this same fallback will additionally log a development-stage warning so the underlying user error gets surfaced and fixed; 4.x stays silent to keep maintenance branches log-output-neutral.

🤖 Generated with Claude Opus 4.8
