### PR TITLE
Cut per-component createComponent overhead in buildView (backport #5800 to 4.0)

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/applicationimpl/InstanceFactory.java
+++ b/impl/src/main/java/com/sun/faces/application/applicationimpl/InstanceFactory.java
@@ -137,6 +137,7 @@ public class InstanceFactory {
     private ViewMemberInstanceFactoryMetadataMap<String, Object> behaviorMap;
     private ViewMemberInstanceFactoryMetadataMap<String, Object> converterIdMap;
     private ViewMemberInstanceFactoryMetadataMap<String, Object> validatorMap;
+    private final Map<Class<?>, Constructor<?>> constructorCache;
 
     private Set<String> defaultValidatorIds;
     private volatile Map<String, String> defaultValidatorInfo;
@@ -152,6 +153,7 @@ public class InstanceFactory {
         validatorMap = new ViewMemberInstanceFactoryMetadataMap<>(new ConcurrentHashMap<>());
         defaultValidatorIds = new LinkedHashSet<>();
         behaviorMap = new ViewMemberInstanceFactoryMetadataMap<>(new ConcurrentHashMap<>());
+        constructorCache = new ConcurrentHashMap<>();
 
         WebConfiguration webConfig = WebConfiguration.getInstance(FacesContext.getCurrentInstance().getExternalContext());
         registerPropertyEditors = webConfig.isOptionEnabled(RegisterConverterPropertyEditors);
@@ -762,7 +764,7 @@ public class InstanceFactory {
         }
 
         try {
-            result = clazz.getDeclaredConstructor().newInstance();
+            result = getCachedConstructor(clazz).newInstance();
         } catch (Throwable t) {
             Throwable previousT;
             do {
@@ -777,6 +779,28 @@ public class InstanceFactory {
         }
 
         return (T) result;
+    }
+
+    /**
+     * Returns the cached no-arg constructor for the given class, resolving and caching it on first use. The access check
+     * is suppressed up front (mirroring the cached read/write accessors in {@code UIComponentBase}) since components have
+     * a public no-arg constructor; a rare suppression failure leaves the per-call check in place. Not cached in dev mode,
+     * where classes may be reloaded, matching {@link #newThing}'s handling of the resolved {@code Class}.
+     */
+    private Constructor<?> getCachedConstructor(Class<?> clazz) throws NoSuchMethodException {
+        Constructor<?> constructor = constructorCache.get(clazz);
+        if (constructor == null) {
+            constructor = clazz.getDeclaredConstructor();
+            try {
+                constructor.setAccessible(true);
+            } catch (RuntimeException accessNotGranted) {
+                // leave the per-call access check in place
+            }
+            if (!associate.isDevModeEnabled()) {
+                constructorCache.put(clazz, constructor);
+            }
+        }
+        return constructor;
     }
 
     /*

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -3484,80 +3484,81 @@ public abstract class UIComponentBase extends UIComponent {
 
     }
 
-    private static final String COMPONENT_DESCRIPTORS_MAP_KEY = "com.sun.faces.component.COMPONENT_DESCRIPTORS_MAP";
+    private static final String COMPONENT_METADATA_MAP_KEY = "com.sun.faces.component.COMPONENT_METADATA_MAP";
 
-    private static final String COMPONENT_READ_METHODS_MAP_KEY = "com.sun.faces.component.COMPONENT_READ_METHODS_MAP";
+    /**
+     * Application-scoped per-class reflective metadata, composed into a single value so the per-construction
+     * {@link #populateDescriptorsMapIfNecessary} does one application-map lookup and one per-class lookup rather than
+     * three of each. The three maps are always produced and cached together, so bundling them is behaviour-equivalent.
+     */
+    private static final class ComponentMetadata {
+        private final Map<String, PropertyDescriptor> propertyDescriptors;
+        private final Map<String, Method> readMethods;
+        private final Map<String, Method> writeMethods;
 
-    private static final String COMPONENT_WRITE_METHODS_MAP_KEY = "com.sun.faces.component.COMPONENT_WRITE_METHODS_MAP";
+        private ComponentMetadata(Map<String, PropertyDescriptor> propertyDescriptors, Map<String, Method> readMethods, Map<String, Method> writeMethods) {
+            this.propertyDescriptors = propertyDescriptors;
+            this.readMethods = readMethods;
+            this.writeMethods = writeMethods;
+        }
+    }
 
     @SuppressWarnings("unchecked")
     private void populateDescriptorsMapIfNecessary() {
         FacesContext facesContext = FacesContext.getCurrentInstance();
         Class<?> clazz = getClass();
-        Map<Class<?>, Map<String, PropertyDescriptor>> descriptors = null;
-        Map<Class<?>, Map<String, Method>> readMethods = null;
-        Map<Class<?>, Map<String, Method>> writeMethods = null;
+        Map<Class<?>, ComponentMetadata> metadataByClass = null;
 
         /*
-         * If we can find a valid FacesContext we are going to use it to get access to the property descriptor map.
+         * If we can find a valid FacesContext we are going to use it to get access to the metadata cache.
          */
         if (facesContext != null && facesContext.getExternalContext() != null && facesContext.getExternalContext().getApplicationMap() != null) {
 
             Map<String, Object> applicationMap = facesContext.getExternalContext().getApplicationMap();
 
-            descriptors = (Map<Class<?>, Map<String, PropertyDescriptor>>) applicationMap.computeIfAbsent(
-                    COMPONENT_DESCRIPTORS_MAP_KEY, k -> new ConcurrentHashMap<>());
-            propertyDescriptorMap = descriptors.get(clazz);
+            metadataByClass = (Map<Class<?>, ComponentMetadata>) applicationMap.computeIfAbsent(
+                    COMPONENT_METADATA_MAP_KEY, k -> new ConcurrentHashMap<>());
 
-            readMethods = (Map<Class<?>, Map<String, Method>>) applicationMap.computeIfAbsent(
-                    COMPONENT_READ_METHODS_MAP_KEY, k -> new ConcurrentHashMap<>());
-            readMethodMap = readMethods.get(clazz);
-
-            writeMethods = (Map<Class<?>, Map<String, Method>>) applicationMap.computeIfAbsent(
-                    COMPONENT_WRITE_METHODS_MAP_KEY, k -> new ConcurrentHashMap<>());
-            writeMethodMap = writeMethods.get(clazz);
+            ComponentMetadata metadata = metadataByClass.get(clazz);
+            if (metadata != null) {
+                propertyDescriptorMap = metadata.propertyDescriptors;
+                readMethodMap = metadata.readMethods;
+                writeMethodMap = metadata.writeMethods;
+                return;
+            }
         }
 
-        if (propertyDescriptorMap == null) {
+        // We did not find the metadata for this class so we are now going to load it.
 
-            // We did not find the property descriptor map so we are now going to load it.
+        PropertyDescriptor propertyDescriptors[] = getPropertyDescriptors();
+        if (propertyDescriptors != null) {
+            propertyDescriptorMap = new HashMap<>(propertyDescriptors.length, 1.0f);
+            readMethodMap = new HashMap<>(propertyDescriptors.length, 1.0f);
+            writeMethodMap = new HashMap<>(propertyDescriptors.length, 1.0f);
+            for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
+                // Suppress the access check once, here, and strongly cache the accessor per class so the
+                // suppression stays durable (PropertyDescriptor.getReadMethod/getWriteMethod hand it back via a soft
+                // reference that can be regenerated) and the hot attribute-read/write paths never re-suppress or
+                // re-cache it.
+                Method readMethod = propertyDescriptor.getReadMethod();
+                if (readMethod != null) {
+                    AttributesMap.suppressAccessCheck(readMethod);
+                    readMethodMap.put(propertyDescriptor.getName(), readMethod);
+                }
+                Method writeMethod = propertyDescriptor.getWriteMethod();
+                if (writeMethod != null) {
+                    AttributesMap.suppressAccessCheck(writeMethod);
+                    writeMethodMap.put(propertyDescriptor.getName(), writeMethod);
+                }
+                propertyDescriptorMap.put(propertyDescriptor.getName(), propertyDescriptor);
+            }
 
-            PropertyDescriptor propertyDescriptors[] = getPropertyDescriptors();
-            if (propertyDescriptors != null) {
-                propertyDescriptorMap = new HashMap<>(propertyDescriptors.length, 1.0f);
-                readMethodMap = new HashMap<>(propertyDescriptors.length, 1.0f);
-                writeMethodMap = new HashMap<>(propertyDescriptors.length, 1.0f);
-                for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
-                    // Suppress the access check once, here, and strongly cache the accessor per class so the
-                    // suppression stays durable (PropertyDescriptor.getReadMethod/getWriteMethod hand it back via a soft
-                    // reference that can be regenerated) and the hot attribute-read/write paths never re-suppress or
-                    // re-cache it.
-                    Method readMethod = propertyDescriptor.getReadMethod();
-                    if (readMethod != null) {
-                        AttributesMap.suppressAccessCheck(readMethod);
-                        readMethodMap.put(propertyDescriptor.getName(), readMethod);
-                    }
-                    Method writeMethod = propertyDescriptor.getWriteMethod();
-                    if (writeMethod != null) {
-                        AttributesMap.suppressAccessCheck(writeMethod);
-                        writeMethodMap.put(propertyDescriptor.getName(), writeMethod);
-                    }
-                    propertyDescriptorMap.put(propertyDescriptor.getName(), propertyDescriptor);
-                }
+            if (LOGGER.isLoggable(FINE)) {
+                LOGGER.log(FINE, "fine.component.populating_descriptor_map", new Object[] { clazz, currentThread().getName() });
+            }
 
-                if (LOGGER.isLoggable(FINE)) {
-                    LOGGER.log(FINE, "fine.component.populating_descriptor_map", new Object[] { clazz, currentThread().getName() });
-                }
-
-                if (descriptors != null) {
-                    descriptors.putIfAbsent(clazz, propertyDescriptorMap);
-                }
-                if (readMethods != null) {
-                    readMethods.putIfAbsent(clazz, readMethodMap);
-                }
-                if (writeMethods != null) {
-                    writeMethods.putIfAbsent(clazz, writeMethodMap);
-                }
+            if (metadataByClass != null) {
+                metadataByClass.putIfAbsent(clazz, new ComponentMetadata(propertyDescriptorMap, readMethodMap, writeMethodMap));
             }
         }
     }


### PR DESCRIPTION
Backport of #5800 to 4.0.

## What

Two reductions on the per-component `createComponent` path, which `buildView` walks once per component on every (re)build — a hot spot on component-heavy views.

- **`InstanceFactory.newThing`** now caches the resolved no-arg `Constructor` per class (access-suppressed) instead of calling `clazz.getDeclaredConstructor()` on every instantiation. Cached only outside Development stage, mirroring the existing `Class` cache, so a dev-time class reload still resolves fresh.
- **`UIComponentBase.populateDescriptorsMapIfNecessary`** (run from the component constructor) looked up three parallel application-scoped maps — descriptors / read methods / write methods, each keyed by `Class` — i.e. three `computeIfAbsent` plus three per-class `get` per construction. The three are always produced and cached together, so they are now bundled behind a single `ComponentMetadata` value: one application-map lookup and one per-class lookup. As a side effect this also closes a torn-read window where the three maps could be observed half-populated.

Behaviour-equivalent; no state-format or API change. Clean cherry-pick apart from `InstanceFactory`'s field block (4.0's maps are not `final`), kept as-is with the new `constructorCache` field added.

1175 impl unit tests green.

Part of #5753.

🤖 Generated with Claude Opus 4.8
