### PR TITLE
Field-back component value expressions to cut Restore View cost (4.0 backport)

### DIFF
--- a/impl/src/main/java/jakarta/faces/component/UIComponent.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponent.java
@@ -320,10 +320,7 @@ public abstract class UIComponent implements PartialStateHolder, TransientStateH
             throw new NullPointerException();
         }
 
-        @SuppressWarnings("unchecked")
-        Map<String, ValueExpression> map = (Map<String, ValueExpression>) getStateHelper().get(UIComponentBase.PropertyKeys.bindings);
-
-        return map != null ? map.get(name) : null;
+        return bindings != null ? bindings.get(name) : null;
     }
 
     /**
@@ -378,7 +375,13 @@ public abstract class UIComponent implements PartialStateHolder, TransientStateH
                     getStateHelper().add(PropertyKeysPrivate.attributesThatAreSet, name);
                 }
 
-                getStateHelper().put(UIComponentBase.PropertyKeys.bindings, name, binding);
+                if (bindings == null) {
+                    bindings = new HashMap<>(5);
+                }
+                bindings.put(name, binding);
+                if (initialStateMarked()) {
+                    bindingsModified = true;
+                }
 
             } else {
                 ELContext context = FacesContext.getCurrentInstance().getELContext();
@@ -390,7 +393,12 @@ public abstract class UIComponent implements PartialStateHolder, TransientStateH
             }
         } else {
             getStateHelper().remove(PropertyKeysPrivate.attributesThatAreSet, name);
-            getStateHelper().remove(UIComponentBase.PropertyKeys.bindings, name);
+            if (bindings != null) {
+                bindings.remove(name);
+                if (initialStateMarked()) {
+                    bindingsModified = true;
+                }
+            }
         }
     }
 
@@ -2401,11 +2409,20 @@ public abstract class UIComponent implements PartialStateHolder, TransientStateH
         return resourceBundle != null ? result : null;
     }
 
-    // The set of ValueExpressions for this component, keyed by property
-    // name This collection is lazily instantiated
-    // The set of ValueExpressions for this component, keyed by property
-    // name This collection is lazily instantiated
+    // The set of ValueExpressions for this component, keyed by property name; lazily instantiated.
+    // Field-backs the component's value expressions (replacing the former PropertyKeys.bindings StateHelper
+    // entry) so getValueExpression/setValueExpression skip a per-call StateHelper lookup -- notably the
+    // getValueExpression("binding") probe fired on every component during Restore View. buildView re-applies
+    // the facelet expressions on each restore, so they ride in the partial-state delta only when changed after
+    // markInitialState (see bindingsModified); full state saving persists the whole map.
     @Deprecated
     protected Map<String, ValueExpression> bindings = null;
+
+    /**
+     * {@code true} once a {@link ValueExpression} is set or removed after {@code markInitialState}, so the change
+     * rides in the partial-state delta. Transient: re-derived per request as {@code buildView} rebuilds the tree.
+     * Gates the field-backed {@link #bindings} map's partial-state save (mirrors {@code rendererTypeSet}).
+     */
+    transient boolean bindingsModified;
 
 }

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -1273,11 +1273,9 @@ public abstract class UIComponentBase extends UIComponent {
             Object savedFacesListeners = listeners != null ? listeners.saveState(context) : null;
             Object savedSysEventListeners = saveSystemEventListeners(context);
             Object savedBehaviors = saveBehaviorsState(context);
-            Object savedBindings = null;
-
-            if (bindings != null) {
-                savedBindings = saveBindingsState(context);
-            }
+            // buildView re-applies facelet value expressions on restore, so only a change made after
+            // markInitialState needs to ride along in the delta (mirrors rendererType/rendererTypeSet).
+            Object savedBindings = bindingsModified ? saveBindingsState(context) : null;
 
             Object savedHelper = null;
             if (stateHelper != null) {
@@ -1368,6 +1366,11 @@ public abstract class UIComponentBase extends UIComponent {
 
         if (values[3] != null) {
             bindings = restoreBindingsState(context, values[3]);
+            if (values.length != 7) {
+                // Partial-state delta: a value expression changed after markInitialState; keep it dirty so
+                // the change stays in the delta across subsequent postbacks (mirrors rendererTypeSet below).
+                bindingsModified = true;
+            }
         }
 
         if (values[4] != null) {


### PR DESCRIPTION
Backport of #5805 to 4.0 — clean cherry-pick (`bdfc97c362`). 4.0 is structurally identical in this area (same deprecated `bindings` field, same `rendererType` field-back state-array layout), so the change applies byte-for-byte.

## What

`getValueExpression`/`setValueExpression` backed the per-component value-expression map through the `StateHelper` (`PropertyKeys.bindings`). Because the `PostRestoreStateEvent` walk calls `getValueExpression("binding")` on **every** component, every Restore View paid a per-component `ComponentStateHelper.get(bindings)` HashMap lookup — the dominant Restore View leaf in JFR profiling, paid even by components that carry no binding.

This field-backs the map with the existing `UIComponentBase.bindings` field; a new transient `bindingsModified` flag gates the partial-state save the same way `rendererTypeSet` does (facelet expressions are rebuilt by `buildView`, so only post-`markInitialState` changes ride in the delta; re-armed on partial-state restore for stickiness). Full state saving persists the whole map as before.

## Perf

Validated on Tomcat against MyFaces 4.1.4 (min-floor metric): Restore View **−2..−4%** on value-bound views, **−8..−20%** on light/readonly/unrolled views.

## Notes

- State-format change (the value-expression map moves from inside the `StateHelper` into `values[3]`). Identical to the TCK-green #5805; 151 component/state unit tests pass on 4.0.
- The `bindings` field is reused as-is and stays `@Deprecated`.

Ref #5753
