### PR TITLE
Render children appended during a parent's own encode

### DIFF
--- a/impl/src/main/java/jakarta/faces/component/UIComponent.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponent.java
@@ -1446,13 +1446,14 @@ public abstract class UIComponent implements PartialStateHolder, TransientStateH
 
         if (getRendersChildren()) {
             encodeChildren(context);
-        } else {
-            int childCount = getChildCount();
-            if (childCount > 0) {
-                List<UIComponent> children = getChildren();
-                for (int i = 0; i < childCount; i++) {
-                    children.get(i).encodeAll(context);
-                }
+        } else if (getChildCount() > 0) {
+            // Re-read size() each iteration rather than freezing the count: a child may be appended to this
+            // component while one of its own children is being encoded (e.g. a component that programmatically
+            // adds a sibling during its render), and it must still be encoded. This matches the live semantics
+            // of the children list iterator, which never throws on concurrent append.
+            List<UIComponent> children = getChildren();
+            for (int i = 0; i < children.size(); i++) {
+                children.get(i).encodeAll(context);
             }
         }
 

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -980,10 +980,11 @@ public abstract class UIComponentBase extends UIComponent {
                     facet.processDecodes(context);
                 }
             }
-            int childCount = getChildCount();
-            if (childCount > 0) {
+            if (getChildCount() > 0) {
+                // Re-read size() each iteration: a child appended while an earlier child is being processed
+                // must still be processed, matching the live children-list iterator semantics.
                 List<UIComponent> children = getChildren();
-                for (int i = 0; i < childCount; i++) {
+                for (int i = 0; i < children.size(); i++) {
                     children.get(i).processDecodes(context);
                 }
             }
@@ -1027,10 +1028,11 @@ public abstract class UIComponentBase extends UIComponent {
                     facet.processValidators(context);
                 }
             }
-            int childCount = getChildCount();
-            if (childCount > 0) {
+            if (getChildCount() > 0) {
+                // Re-read size() each iteration: a child appended while an earlier child is being processed
+                // must still be processed, matching the live children-list iterator semantics.
                 List<UIComponent> children = getChildren();
-                for (int i = 0; i < childCount; i++) {
+                for (int i = 0; i < children.size(); i++) {
                     children.get(i).processValidators(context);
                 }
             }
@@ -1065,10 +1067,11 @@ public abstract class UIComponentBase extends UIComponent {
                     facet.processUpdates(context);
                 }
             }
-            int childCount = getChildCount();
-            if (childCount > 0) {
+            if (getChildCount() > 0) {
+                // Re-read size() each iteration: a child appended while an earlier child is being processed
+                // must still be processed, matching the live children-list iterator semantics.
                 List<UIComponent> children = getChildren();
-                for (int i = 0; i < childCount; i++) {
+                for (int i = 0; i < children.size(); i++) {
                     children.get(i).processUpdates(context);
                 }
             }


### PR DESCRIPTION
## Problem

Commit 407220b1cd ("Use indexed child traversal in process*/encodeAll") replaced the live enhanced-for over `getChildren()` in `UIComponent.encodeAll` and `UIComponentBase.processDecodes/processValidators/processUpdates` with an indexed loop bounded by a child count captured **before** the loop:

```java
int childCount = getChildCount();
for (int i = 0; i < childCount; i++) children.get(i)...;
```

The old enhanced-for iterated via Mojarra's custom `ChildrenListIterator`, whose `hasNext()` re-reads `list.size()` live and whose `next()` performs **no** `modCount` check. As a result, a child appended to a parent *while that parent was iterating its own children* was still visited and rendered/processed. The frozen count silently drops it.

## Impact

A formless OmniFaces `<o:lazyPanel>` appends a hidden `<form>` to `<h:body>` during the body's own child-encode (it needs a Faces form for its `faces.ajax.request`). `BodyRenderer.getRendersChildren()` is `false`, so the body's children are walked by `UIComponent.encodeAll`. With the frozen count the form is never rendered, so there is no Faces form on the page, `getFacesForm()` returns nothing client-side, and the lazy ajax request never fires. OmniFaces `LazyPanelIT#testLazyPanelNoForm` times out (passes on 4.1.9, fails on 4.1.10-SNAPSHOT).

Only containers whose renderer does not render its own children are affected (`<h:body>`); `<h:form>`/`<h:panelGroup>` render children through their renderer and were never broken — which is why only the formless lazy-panel variant regressed.

## Fix

Re-read `children.size()` each iteration in the four loops, keeping the iterator-allocation win of 407220b1cd while restoring the live-append semantics of the original `ChildrenListIterator`. `size()` is an O(1) field read on the backing `ArrayList`. Removal-during-iteration behaviour is unchanged (the old iterator was also index-based: `get(i)`, `i++`, `hasNext = i < size()`).

## Verification

- All five OmniFaces `LazyPanelIT` variants pass against the rebuilt 4.1.10-SNAPSHOT (`-Ptomcat-mojarra`).
- WildFly Mojarra-vs-MyFaces perf bench shows no regression: the change is below the harness noise floor (two identical fixed runs differed as much as fixed-vs-unfixed; the untouched `INVOKE_APPLICATION` phase moved more than the touched `RENDER_RESPONSE`).
- A regression IT reproducing the encode-time sibling append (a component that appends a sibling to its `<h:body>` parent during its own encode) has been added to the Faces TCK `faces23/dynamic-components` suite — red before this change, green after: jakartaee/faces@e6eaf0728.
