### PR TITLE
Backport #5807 to 4.0: Render children appended during a parent's own encode

### DIFF
--- a/impl/src/main/java/jakarta/faces/component/UIComponent.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponent.java
@@ -1445,13 +1445,14 @@ public abstract class UIComponent implements PartialStateHolder, TransientStateH
 
         if (getRendersChildren()) {
             encodeChildren(context);
-        } else {
-            int childCount = getChildCount();
-            if (childCount > 0) {
-                List<UIComponent> children = getChildren();
-                for (int i = 0; i < childCount; i++) {
-                    children.get(i).encodeAll(context);
-                }
+        } else if (getChildCount() > 0) {
+            // Re-read size() each iteration rather than freezing the count: a child may be appended to this
+            // component while one of its own children is being encoded (e.g. a component that programmatically
+            // adds a sibling during its render), and it must still be encoded. This matches the live semantics
+            // of the children list iterator, which never throws on concurrent append.
+            List<UIComponent> children = getChildren();
+            for (int i = 0; i < children.size(); i++) {
+                children.get(i).encodeAll(context);
             }
         }
 

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -979,10 +979,11 @@ public abstract class UIComponentBase extends UIComponent {
                     facet.processDecodes(context);
                 }
             }
-            int childCount = getChildCount();
-            if (childCount > 0) {
+            if (getChildCount() > 0) {
+                // Re-read size() each iteration: a child appended while an earlier child is being processed
+                // must still be processed, matching the live children-list iterator semantics.
                 List<UIComponent> children = getChildren();
-                for (int i = 0; i < childCount; i++) {
+                for (int i = 0; i < children.size(); i++) {
                     children.get(i).processDecodes(context);
                 }
             }
@@ -1026,10 +1027,11 @@ public abstract class UIComponentBase extends UIComponent {
                     facet.processValidators(context);
                 }
             }
-            int childCount = getChildCount();
-            if (childCount > 0) {
+            if (getChildCount() > 0) {
+                // Re-read size() each iteration: a child appended while an earlier child is being processed
+                // must still be processed, matching the live children-list iterator semantics.
                 List<UIComponent> children = getChildren();
-                for (int i = 0; i < childCount; i++) {
+                for (int i = 0; i < children.size(); i++) {
                     children.get(i).processValidators(context);
                 }
             }
@@ -1064,10 +1066,11 @@ public abstract class UIComponentBase extends UIComponent {
                     facet.processUpdates(context);
                 }
             }
-            int childCount = getChildCount();
-            if (childCount > 0) {
+            if (getChildCount() > 0) {
+                // Re-read size() each iteration: a child appended while an earlier child is being processed
+                // must still be processed, matching the live children-list iterator semantics.
                 List<UIComponent> children = getChildren();
-                for (int i = 0; i < childCount; i++) {
+                for (int i = 0; i < children.size(); i++) {
                     children.get(i).processUpdates(context);
                 }
             }


### PR DESCRIPTION
Backport of #5807 into 4.0.

4.0 carries the same frozen child-count loops in `UIComponent.encodeAll` and `UIComponentBase.processDecodes/processValidators/processUpdates` (introduced by the indexed-traversal change), so a child appended to a parent during that parent's own child-encode is dropped. See #5807 for the full analysis and the OmniFaces `LazyPanelIT#testLazyPanelNoForm` reproduction.

Re-reads `children.size()` each iteration, restoring the live-append semantics while keeping the iterator-allocation win. Cherry-picked from the 4.1 fix; compiles on Java 11.
