### PR TITLE
Skip redundant render-time facelet re-apply for static views

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/RIConstants.java
+++ b/impl/src/main/java/org/glassfish/mojarra/RIConstants.java
@@ -40,6 +40,14 @@ public class RIConstants {
 
     public static final String SAVED_STATE = RI_PREFIX + "savedState";
 
+    /**
+     * Request-scoped flag set during a view build when a build-time-dynamic handler (a JSTL conditional/iteration or a
+     * dynamic ui:include/ui:decorate/ui:composition) participates, marking the view as one whose facelet must be
+     * re-applied on every (re)build. Read by {@code FaceletViewHandlingStrategy.buildView} to decide whether the
+     * redundant render-time re-apply may be skipped (see {@code disableRefreshTransientBuild}).
+     */
+    public static final String DYNAMIC_TRANSIENT_BUILD = RI_PREFIX + "dynamicTransientBuild";
+
     /*
      * <p>TLV Resource Bundle Location </p>
      */

--- a/impl/src/main/java/org/glassfish/mojarra/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/view/FaceletViewHandlingStrategy.java
@@ -36,6 +36,7 @@ import static java.util.Collections.emptyList;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINEST;
 import static java.util.logging.Level.WARNING;
+import static org.glassfish.mojarra.RIConstants.DYNAMIC_TRANSIENT_BUILD;
 import static org.glassfish.mojarra.RIConstants.FACELETS_ENCODING_KEY;
 import static org.glassfish.mojarra.RIConstants.FLOW_DEFINITION_ID_SUFFIX;
 import static org.glassfish.mojarra.context.StateContext.getStateContext;
@@ -125,6 +126,7 @@ import jakarta.faces.view.facelets.FaceletContext;
 import jakarta.servlet.http.HttpSession;
 
 import org.glassfish.mojarra.application.ApplicationAssociate;
+import org.glassfish.mojarra.config.WebConfiguration.BooleanWebContextInitParameter;
 import org.glassfish.mojarra.context.FacesContextParam;
 import org.glassfish.mojarra.context.StateContext;
 import org.glassfish.mojarra.facelets.compiler.FaceletDoctype;
@@ -169,6 +171,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
     private final MethodRetargetHandlerManager retargetHandlerManager = new MethodRetargetHandlerManager();
 
     private int responseBufferSize;
+    private boolean disableRefreshTransientBuild;
 
     private Cache<Resource, BeanInfo> metadataCache;
     private Map<String, List<String>> contractMappings;
@@ -299,6 +302,11 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
         StateContext stateCtx = StateContext.getStateContext(ctx);
 
         if (isViewPopulated(ctx, view)) {
+            if (canSkipTransientBuildRefresh(ctx, view, stateCtx)) {
+                // The view was already (re)built this request and holds no build-time-dynamic content, so re-applying
+                // the facelet would reproduce the identical tree. Skip it (see disableRefreshTransientBuild).
+                return;
+            }
             Facelet facelet = faceletFactory.getFacelet(ctx, view.getViewId());
             // Disable events from being intercepted by the StateContext by
             // virute of re-applying the handlers.
@@ -370,6 +378,20 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
         markInitialState(ctx, view);
 
         setViewPopulated(ctx, view);
+    }
+
+    /**
+     * Determines whether the redundant re-apply of the facelet on an already-populated view may be skipped. Opt-in via
+     * {@code disableRefreshTransientBuild}; only safe under partial state saving for a non-transient view whose build
+     * this request involved no build-time-dynamic content ({@link RIConstants#DYNAMIC_TRANSIENT_BUILD}) and no dynamic
+     * component add/remove, since re-applying would then reproduce the identical tree.
+     */
+    private boolean canSkipTransientBuildRefresh(FacesContext ctx, UIViewRoot view, StateContext stateCtx) {
+        return disableRefreshTransientBuild
+                && !view.isTransient()
+                && stateCtx.isPartialStateSaving(ctx, view.getViewId())
+                && isEmpty(stateCtx.getDynamicActions())
+                && !ctx.getAttributes().containsKey(DYNAMIC_TRANSIENT_BUILD);
     }
 
     /**
@@ -832,6 +854,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
         });
 
         responseBufferSize = FacesContextParam.FACELETS_BUFFER_SIZE.getValue(FacesContext.getCurrentInstance());
+        disableRefreshTransientBuild = webConfig.isOptionEnabled(BooleanWebContextInitParameter.DisableRefreshTransientBuild);
 
         LOGGER.fine("Initialization Successful");
 

--- a/impl/src/main/java/org/glassfish/mojarra/config/WebConfiguration.java
+++ b/impl/src/main/java/org/glassfish/mojarra/config/WebConfiguration.java
@@ -705,6 +705,7 @@ public class WebConfiguration {
         RegisterConverterPropertyEditors("org.glassfish.mojarra.registerConverterPropertyEditors", false),
         EnableHttpMethodRestrictionPhaseListener("org.glassfish.mojarra.ENABLE_HTTP_METHOD_RESTRICTION_PHASE_LISTENER", false),
         PartialStateSaving(StateManager.PARTIAL_STATE_SAVING_PARAM_NAME, true),
+        DisableRefreshTransientBuild("org.glassfish.mojarra.disableRefreshTransientBuild", false),
         GenerateUniqueServerStateIds("org.glassfish.mojarra.generateUniqueServerStateIds", true),
         AutoCompleteOffOnViewState("org.glassfish.mojarra.autoCompleteOffOnViewState", false),
         EnableThreading("org.glassfish.mojarra.enableThreading", false),

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/TagHandlerImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/TagHandlerImpl.java
@@ -21,9 +21,12 @@ import java.util.Iterator;
 import java.util.List;
 
 import jakarta.faces.view.facelets.CompositeFaceletHandler;
+import jakarta.faces.view.facelets.FaceletContext;
 import jakarta.faces.view.facelets.FaceletHandler;
 import jakarta.faces.view.facelets.TagConfig;
 import jakarta.faces.view.facelets.TagHandler;
+
+import org.glassfish.mojarra.RIConstants;
 
 /**
  *
@@ -33,6 +36,18 @@ public abstract class TagHandlerImpl extends TagHandler {
 
     public TagHandlerImpl(TagConfig config) {
         super(config);
+    }
+
+    /**
+     * Flag the current view build as containing build-time-dynamic content (a JSTL conditional/iteration or a dynamic
+     * include) so its facelet is re-applied on every (re)build. Build-time-dynamic handlers call this at the top of
+     * their {@code apply}; the absence of the flag lets {@code FaceletViewHandlingStrategy} skip the redundant
+     * render-time re-apply for a purely component-driven view (see {@code disableRefreshTransientBuild}).
+     *
+     * @param ctx the {@link FaceletContext} for the current build
+     */
+    protected static void markDynamicTransientBuild(FaceletContext ctx) {
+        ctx.getFacesContext().getAttributes().put(RIConstants.DYNAMIC_TRANSIENT_BUILD, Boolean.TRUE);
     }
 
     /**

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/CatchHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/CatchHandler.java
@@ -42,6 +42,7 @@ public final class CatchHandler extends TagHandlerImpl {
 
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
+        markDynamicTransientBuild(ctx);
         try {
             nextHandler.apply(ctx, parent);
         } catch (Exception e) {

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/ChooseHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/ChooseHandler.java
@@ -59,6 +59,7 @@ public final class ChooseHandler extends TagHandlerImpl {
 
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
+        markDynamicTransientBuild(ctx);
         for (int i = 0; i < when.length; i++) {
             if (when[i].isTestTrue(ctx)) {
                 when[i].apply(ctx, parent);

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/ForEachHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/ForEachHandler.java
@@ -111,6 +111,7 @@ public final class ForEachHandler extends TagHandlerImpl {
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
 
+        markDynamicTransientBuild(ctx);
         int s = getBegin(ctx);
         int e = getEnd(ctx);
         int m = getStep(ctx);

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/IfHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/IfHandler.java
@@ -47,6 +47,7 @@ public final class IfHandler extends TagHandlerImpl {
 
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException, FacesException, ELException {
+        markDynamicTransientBuild(ctx);
         boolean b = test.getBoolean(ctx);
         if (var != null) {
             ctx.setAttribute(var.getValue(ctx), b);

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/SetHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/SetHandler.java
@@ -59,6 +59,7 @@ public class SetHandler extends TagHandlerImpl {
 
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
+        markDynamicTransientBuild(ctx);
 
         StringBuilder bodyValue = new StringBuilder();
 

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/ui/CompositionHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/ui/CompositionHandler.java
@@ -101,6 +101,10 @@ public final class CompositionHandler extends TagHandlerImpl implements Template
 
         if (template != null) {
 
+            if (!template.isLiteral()) {
+                markDynamicTransientBuild(ctx);
+            }
+
             FacesContext facesContext = ctx.getFacesContext();
             Integer compositionCount = (Integer) facesContext.getAttributes().get("org.glassfish.mojarra.uiCompositionCount");
             if (compositionCount == null) {

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/ui/DecorateHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/ui/DecorateHandler.java
@@ -90,6 +90,9 @@ public final class DecorateHandler extends TagHandlerImpl implements TemplateCli
      */
     @Override
     public void apply(FaceletContext ctxObj, UIComponent parent) throws IOException {
+        if (!template.isLiteral()) {
+            markDynamicTransientBuild(ctxObj);
+        }
         FaceletContextImplBase ctx = (FaceletContextImplBase) ctxObj;
         VariableMapper orig = ctx.getVariableMapper();
         if (params != null) {

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/ui/IncludeHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/ui/IncludeHandler.java
@@ -69,6 +69,9 @@ public final class IncludeHandler extends TagHandlerImpl {
      */
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
+        if (!src.isLiteral()) {
+            markDynamicTransientBuild(ctx);
+        }
         String path = src.getValue(ctx);
         if (path == null || path.length() == 0) {
             return;

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -1372,6 +1372,38 @@
                     <version>1.2.4.Final</version>
                     <scope>test</scope>
                 </dependency>
+                <!-- APIs Tomcat itself ships in lib/ (provided, compile classpath only); mirrors the mojarra tomcat profile. -->
+                <dependency>
+                    <groupId>jakarta.servlet</groupId>
+                    <artifactId>jakarta.servlet-api</artifactId>
+                    <version>6.1.0</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>jakarta.el</groupId>
+                    <artifactId>jakarta.el-api</artifactId>
+                    <version>6.0.1</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>jakarta.annotation</groupId>
+                    <artifactId>jakarta.annotation-api</artifactId>
+                    <version>3.0.0</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>jakarta.websocket</groupId>
+                    <artifactId>jakarta.websocket-api</artifactId>
+                    <version>2.2.0</version>
+                    <scope>provided</scope>
+                </dependency>
+                <!-- Faces API for the compile classpath only; MyFaces bundles its own (myfaces-api) at runtime. -->
+                <dependency>
+                    <groupId>jakarta.faces</groupId>
+                    <artifactId>jakarta.faces-api</artifactId>
+                    <version>${faces-api.version}</version>
+                    <scope>provided</scope>
+                </dependency>
                 <!-- Tomcat is a bare servlet container: bundle MyFaces, CDI (Weld), Bean Validation, JSON-P and JSTL into the WAR. -->
                 <dependency>
                     <groupId>org.apache.myfaces.core</groupId>


### PR DESCRIPTION
#5753 

## Problem

`RenderResponsePhase.execute` calls `vdl.buildView()` unconditionally before rendering. On a postback the view is already built (from Restore View), so `FaceletViewHandlingStrategy.buildView` takes its `isViewPopulated` branch and **re-applies the entire facelet a second time** — re-running every tag handler, re-resolving every tag-attribute EL expression and regenerating ids. For a view with no build-time-dynamic content this reproduces an identical tree: pure waste.

JFR profiling (Tomcat, `form-inputs` scenario, 20000 postbacks, server state saving) attributes **~14.5% of render** to this redundant re-apply — the bulk of the render-phase gap versus MyFaces, which avoids it by defaulting `org.apache.myfaces.REFRESH_TRANSIENT_BUILD_ON_PSS=auto` (gating re-apply behind `isFilledView`). The rest of render — writers, reflective `AttributesMap`, EL, converters, state saving — is already at MyFaces parity.

## Change

Adds an opt-in boolean context param `org.glassfish.mojarra.disableRefreshTransientBuild` (default `false`, so behaviour is unchanged unless enabled). When enabled, the populated branch early-returns instead of re-applying when **all** of the following hold:

- the view is non-transient (excludes stateless views),
- partial state saving is active (excludes client-side state saving),
- there are no dynamic add/remove actions, and
- the view contains no build-time-dynamic content.

The last condition is detected **request-scoped**: the JSTL conditional/iteration handlers (`c:if`, `c:choose`, `c:forEach`, `c:catch`, `c:set`) and dynamic `ui:include`/`ui:decorate`/`ui:composition` (non-literal `src`/`template`) call the new `TagHandlerImpl.markDynamicTransientBuild` at the top of their `apply()`, setting a `FacesContext` attribute. The flag is set during the restore-time build and read during the render-time build of the same request. Runtime-iteration components (`ui:repeat`, `h:dataTable`) are correctly **not** flagged — their per-row children are built at encode time, not via the facelet re-apply.

## Results

| | render avg | JFR re-apply share |
|---|---|---|
| param **off** (current behaviour) | 720 µs | 14.5% |
| param **on** | **631 µs** | **0.4%** |
| MyFaces 4.1 | 630 µs | 2.6% |

Render reaches MyFaces parity. Verified behaviour-neutral with the param off (full impl unit suite green) and the full Faces TCK passes with the param enabled.

## Notes

- Second commit is an unrelated test-harness fix: the `tomcat-myfaces` perf profile was missing the `provided` compile-time `jakarta.*` APIs that the `tomcat` profile declares, so the perf WAR could not compile under it. Needed to run the cross-implementation comparison that motivated this change.
- A follow-up (not in this PR) can make the *unavoidable* `c:forEach` re-apply cheaper for unrolled views (MyFaces-style `IterationState`/id-base reuse), the complementary lever for the `*-unrolled` scenarios.

🤖 Generated with Claude Opus 4.8
