### PR TITLE
Backport #5811 to 4.0: Skip redundant render-time facelet re-apply for static views

### DIFF
--- a/impl/src/main/java/com/sun/faces/RIConstants.java
+++ b/impl/src/main/java/com/sun/faces/RIConstants.java
@@ -40,6 +40,14 @@ public class RIConstants {
 
     public static final String SAVED_STATE = FACES_PREFIX + "savedState";
 
+    /**
+     * Request-scoped flag set during a view build when a build-time-dynamic handler (a JSTL conditional/iteration or a
+     * dynamic ui:include/ui:decorate/ui:composition) participates, marking the view as one whose facelet must be
+     * re-applied on every (re)build. Read by {@code FaceletViewHandlingStrategy.buildView} to decide whether the
+     * redundant render-time re-apply may be skipped (see {@code disableRefreshTransientBuild}).
+     */
+    public static final String DYNAMIC_TRANSIENT_BUILD = FACES_PREFIX + "dynamicTransientBuild";
+
     /*
      * <p>TLV Resource Bundle Location </p>
      */

--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -17,6 +17,7 @@
 package com.sun.faces.application.view;
 
 import static com.sun.faces.RIConstants.DYNAMIC_COMPONENT;
+import static com.sun.faces.RIConstants.DYNAMIC_TRANSIENT_BUILD;
 import static com.sun.faces.RIConstants.FACELETS_ENCODING_KEY;
 import static com.sun.faces.RIConstants.FLOW_DEFINITION_ID_SUFFIX;
 import static com.sun.faces.config.WebConfiguration.WebContextInitParameter.FaceletsBufferSize;
@@ -131,6 +132,7 @@ import jakarta.servlet.http.HttpSession;
 import com.sun.faces.application.ApplicationAssociate;
 import com.sun.faces.application.resource.ResourceHandlerImpl;
 import com.sun.faces.config.WebConfiguration;
+import com.sun.faces.config.WebConfiguration.BooleanWebContextInitParameter;
 import com.sun.faces.context.StateContext;
 import com.sun.faces.facelets.compiler.FaceletDoctype;
 import com.sun.faces.facelets.el.ContextualCompositeMethodExpression;
@@ -174,6 +176,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
     private MethodRetargetHandlerManager retargetHandlerManager = new MethodRetargetHandlerManager();
 
     private int responseBufferSize;
+    private boolean disableRefreshTransientBuild;
 
     private Cache<Resource, BeanInfo> metadataCache;
     private Map<String, List<String>> contractMappings;
@@ -304,6 +307,11 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
         StateContext stateCtx = StateContext.getStateContext(ctx);
 
         if (isViewPopulated(ctx, view)) {
+            if (canSkipTransientBuildRefresh(ctx, view, stateCtx)) {
+                // The view was already (re)built this request and holds no build-time-dynamic content, so re-applying
+                // the facelet would reproduce the identical tree. Skip it (see disableRefreshTransientBuild).
+                return;
+            }
             Facelet facelet = faceletFactory.getFacelet(ctx, view.getViewId());
             // Disable events from being intercepted by the StateContext by
             // virute of re-applying the handlers.
@@ -375,6 +383,20 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
         markInitialState(ctx, view);
 
         setViewPopulated(ctx, view);
+    }
+
+    /**
+     * Determines whether the redundant re-apply of the facelet on an already-populated view may be skipped. Opt-in via
+     * {@code disableRefreshTransientBuild}; only safe under partial state saving for a non-transient view whose build
+     * this request involved no build-time-dynamic content ({@link RIConstants#DYNAMIC_TRANSIENT_BUILD}) and no dynamic
+     * component add/remove, since re-applying would then reproduce the identical tree.
+     */
+    private boolean canSkipTransientBuildRefresh(FacesContext ctx, UIViewRoot view, StateContext stateCtx) {
+        return disableRefreshTransientBuild
+                && !view.isTransient()
+                && stateCtx.isPartialStateSaving(ctx, view.getViewId())
+                && isEmpty(stateCtx.getDynamicActions())
+                && !ctx.getAttributes().containsKey(DYNAMIC_TRANSIENT_BUILD);
     }
 
     /**
@@ -844,6 +866,8 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
         } catch (NumberFormatException nfe) {
             responseBufferSize = Integer.parseInt(FaceletsBufferSize.getDefaultValue());
         }
+
+        disableRefreshTransientBuild = webConfig.isOptionEnabled(BooleanWebContextInitParameter.DisableRefreshTransientBuild);
 
         LOGGER.fine("Initialization Successful");
 

--- a/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
+++ b/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
@@ -873,6 +873,7 @@ public class WebConfiguration {
         EnableHttpMethodRestrictionPhaseListener("com.sun.faces.ENABLE_HTTP_METHOD_RESTRICTION_PHASE_LISTENER", false),
         FaceletsSkipComments(ViewHandler.FACELETS_SKIP_COMMENTS_PARAM_NAME, false),
         PartialStateSaving(StateManager.PARTIAL_STATE_SAVING_PARAM_NAME, true),
+        DisableRefreshTransientBuild("com.sun.faces.disableRefreshTransientBuild", false),
         GenerateUniqueServerStateIds("com.sun.faces.generateUniqueServerStateIds", true),
         InterpretEmptyStringSubmittedValuesAsNull(UIInput.EMPTY_STRING_AS_NULL_PARAM_NAME, false),
         AutoCompleteOffOnViewState("com.sun.faces.autoCompleteOffOnViewState", true),

--- a/impl/src/main/java/com/sun/faces/facelets/tag/TagHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/TagHandlerImpl.java
@@ -21,9 +21,12 @@ import java.util.Iterator;
 import java.util.List;
 
 import jakarta.faces.view.facelets.CompositeFaceletHandler;
+import jakarta.faces.view.facelets.FaceletContext;
 import jakarta.faces.view.facelets.FaceletHandler;
 import jakarta.faces.view.facelets.TagConfig;
 import jakarta.faces.view.facelets.TagHandler;
+
+import com.sun.faces.RIConstants;
 
 /**
  *
@@ -33,6 +36,18 @@ public abstract class TagHandlerImpl extends TagHandler {
 
     public TagHandlerImpl(TagConfig config) {
         super(config);
+    }
+
+    /**
+     * Flag the current view build as containing build-time-dynamic content (a JSTL conditional/iteration or a dynamic
+     * include) so its facelet is re-applied on every (re)build. Build-time-dynamic handlers call this at the top of
+     * their {@code apply}; the absence of the flag lets {@code FaceletViewHandlingStrategy} skip the redundant
+     * render-time re-apply for a purely component-driven view (see {@code disableRefreshTransientBuild}).
+     *
+     * @param ctx the {@link FaceletContext} for the current build
+     */
+    protected static void markDynamicTransientBuild(FaceletContext ctx) {
+        ctx.getFacesContext().getAttributes().put(RIConstants.DYNAMIC_TRANSIENT_BUILD, Boolean.TRUE);
     }
 
     /**

--- a/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/CatchHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/CatchHandler.java
@@ -42,6 +42,7 @@ public final class CatchHandler extends TagHandlerImpl {
 
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
+        markDynamicTransientBuild(ctx);
         try {
             nextHandler.apply(ctx, parent);
         } catch (Exception e) {

--- a/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/ChooseHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/ChooseHandler.java
@@ -59,6 +59,7 @@ public final class ChooseHandler extends TagHandlerImpl {
 
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
+        markDynamicTransientBuild(ctx);
         for (int i = 0; i < when.length; i++) {
             if (when[i].isTestTrue(ctx)) {
                 when[i].apply(ctx, parent);

--- a/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/ForEachHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/ForEachHandler.java
@@ -111,6 +111,7 @@ public final class ForEachHandler extends TagHandlerImpl {
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
 
+        markDynamicTransientBuild(ctx);
         int s = getBegin(ctx);
         int e = getEnd(ctx);
         int m = getStep(ctx);

--- a/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/IfHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/IfHandler.java
@@ -47,6 +47,7 @@ public final class IfHandler extends TagHandlerImpl {
 
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException, FacesException, ELException {
+        markDynamicTransientBuild(ctx);
         boolean b = test.getBoolean(ctx);
         if (var != null) {
             ctx.setAttribute(var.getValue(ctx), b);

--- a/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/SetHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/SetHandler.java
@@ -60,6 +60,8 @@ public class SetHandler extends TagHandlerImpl {
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
 
+        markDynamicTransientBuild(ctx);
+
         StringBuilder bodyValue = new StringBuilder();
 
         Iterator iter = TagHandlerImpl.findNextByType(nextHandler, TextHandler.class);

--- a/impl/src/main/java/com/sun/faces/facelets/tag/ui/CompositionHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/ui/CompositionHandler.java
@@ -101,6 +101,10 @@ public final class CompositionHandler extends TagHandlerImpl implements Template
 
         if (template != null) {
 
+            if (!template.isLiteral()) {
+                markDynamicTransientBuild(ctx);
+            }
+
             FacesContext facesContext = ctx.getFacesContext();
             Integer compositionCount = (Integer) facesContext.getAttributes().get("com.sun.faces.uiCompositionCount");
             if (compositionCount == null) {

--- a/impl/src/main/java/com/sun/faces/facelets/tag/ui/DecorateHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/ui/DecorateHandler.java
@@ -90,6 +90,9 @@ public final class DecorateHandler extends TagHandlerImpl implements TemplateCli
      */
     @Override
     public void apply(FaceletContext ctxObj, UIComponent parent) throws IOException {
+        if (!template.isLiteral()) {
+            markDynamicTransientBuild(ctxObj);
+        }
         FaceletContextImplBase ctx = (FaceletContextImplBase) ctxObj;
         VariableMapper orig = ctx.getVariableMapper();
         if (params != null) {

--- a/impl/src/main/java/com/sun/faces/facelets/tag/ui/IncludeHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/ui/IncludeHandler.java
@@ -67,6 +67,9 @@ public final class IncludeHandler extends TagHandlerImpl {
      */
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
+        if (!src.isLiteral()) {
+            markDynamicTransientBuild(ctx);
+        }
         String path = src.getValue(ctx);
         if (path == null || path.length() == 0) {
             return;


### PR DESCRIPTION
Backport of #5811 to 4.0 for #5753.

## Problem

`RenderResponsePhase.execute` calls `vdl.buildView()` unconditionally before rendering. On a postback the view is already built (from Restore View), so `FaceletViewHandlingStrategy.buildView` takes its `isViewPopulated` branch and **re-applies the entire facelet a second time** — re-running every tag handler, re-resolving every tag-attribute EL expression and regenerating ids. For a view with no build-time-dynamic content this reproduces an identical tree: pure waste.

JFR profiling (Tomcat, `form-inputs` scenario, 20000 postbacks, server state saving) attributes **~14.5% of render** to this redundant re-apply — the bulk of the render-phase gap versus MyFaces, which avoids it by defaulting `org.apache.myfaces.REFRESH_TRANSIENT_BUILD_ON_PSS=auto`.

## Change

Adds an opt-in boolean context param `com.sun.faces.disableRefreshTransientBuild` (default `false`, so behaviour is unchanged unless enabled). When enabled, the populated branch early-returns instead of re-applying when **all** of the following hold:

- the view is non-transient (excludes stateless views),
- partial state saving is active (excludes client-side state saving),
- there are no dynamic add/remove actions, and
- the view contains no build-time-dynamic content.

The last condition is detected **request-scoped**: the JSTL conditional/iteration handlers (`c:if`, `c:choose`, `c:forEach`, `c:catch`, `c:set`) and dynamic `ui:include`/`ui:decorate`/`ui:composition` (non-literal `src`/`template`) call the new `TagHandlerImpl.markDynamicTransientBuild` at the top of their `apply()`, setting a `FacesContext` attribute. The flag is set during the restore-time build and read during the render-time build of the same request. Runtime-iteration components (`ui:repeat`, `h:dataTable`) are correctly **not** flagged — their per-row children are built at encode time.

## Notes

- Faithful port of the master feature commit, adapted only for the `com.sun.faces` package layout and the `com.sun.faces.*` param-name convention.
- The original PR's second commit (a `tomcat-myfaces` perf-profile `pom.xml` fix) is **not** ported — that perf profile does not exist on 4.0.

🤖 Generated with Claude Opus 4.8
