### PR TITLE
Guard CDI system-event dispatch against teardown (WELD-001325)

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/application/applicationimpl/Events.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/applicationimpl/Events.java
@@ -74,6 +74,12 @@ public class Events {
     // in-scope (jakartaee/faces#1501) application/view events into CDI at all.
     private final Map<Class<? extends SystemEvent>, Boolean> cdiObserverPresenceCache = new ConcurrentHashMap<>();
 
+    // The system-event types observed by some CDI observer, collected by CdiExtension during CDI bootstrap and
+    // immutable thereafter. Captured once and reused so the shutdown path does not call
+    // BeanManager.getExtension(CdiExtension.class), which throws IllegalArgumentException (WELD-001325) once the
+    // container has deregistered the extension during contextDestroyed.
+    private volatile Set<Class<?>> cdiObservedSystemEventTypes;
+
     /*
      * This class encapsulates the behavior to prevent infinite loops when the publishing of one event leads to the queueing
      * of another event of the same type. Special provision is made to allow the case where this guaring mechanims happens
@@ -431,14 +437,39 @@ public class Events {
      * {@link CdiExtension#getObservedSystemEventTypes()}.
      */
     private boolean hasCdiObserverFor(ELAwareBeanManager beanManager, Class<? extends SystemEvent> systemEventClass) {
+        Set<Class<?>> observedTypes = cdiObservedSystemEventTypes(beanManager);
+        if (observedTypes == null) {
+            // CdiExtension is not (or no longer) registered -- the deployment is shutting down. No CDI observers
+            // to dispatch to; the caller publishes the event without CDI.
+            return false;
+        }
         return cdiObserverPresenceCache.computeIfAbsent(systemEventClass, eventClass -> {
-            for (Class<?> observedType : beanManager.getExtension(CdiExtension.class).getObservedSystemEventTypes()) {
+            for (Class<?> observedType : observedTypes) {
                 if (observedType.isAssignableFrom(eventClass)) {
                     return true;
                 }
             }
             return false;
         });
+    }
+
+    /**
+     * @return the system-event types observed by some CDI observer (immutable after CDI bootstrap, so captured
+     * once and reused), or {@code null} when {@link CdiExtension} is not registered -- notably during
+     * {@code contextDestroyed}, where {@code BeanManager.getExtension(CdiExtension.class)} throws
+     * {@code IllegalArgumentException} (WELD-001325) because the container has already deregistered it.
+     */
+    private Set<Class<?>> cdiObservedSystemEventTypes(ELAwareBeanManager beanManager) {
+        Set<Class<?>> observedTypes = cdiObservedSystemEventTypes;
+        if (observedTypes == null) {
+            try {
+                observedTypes = beanManager.getExtension(CdiExtension.class).getObservedSystemEventTypes();
+                cdiObservedSystemEventTypes = observedTypes;
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        }
+        return observedTypes;
     }
 
 }


### PR DESCRIPTION
## Problem

`Events.hasCdiObserverFor` (the CDI-system-event dispatch guard added in #5803) decides whether to fire a Faces system event into CDI by calling `beanManager.getExtension(CdiExtension.class)` once per event class. During `contextDestroyed` the container has already deregistered the extension, so when `ConfigureListener` publishes `PreDestroyApplicationEvent` that call throws:

```
WELD-001325: No instance of an extension class org.glassfish.mojarra.cdi.CdiExtension registered with the deployment
  at org.glassfish.mojarra.application.applicationimpl.Events.lambda$hasCdiObserverFor$0(Events.java:435)
  at org.glassfish.mojarra.application.applicationimpl.Events.hasCdiObserverFor(Events.java:434)
  at org.glassfish.mojarra.application.applicationimpl.Events.fireCdiSystemEvent(Events.java:404)
  ...
  at org.glassfish.mojarra.config.ConfigureListener.contextDestroyed(ConfigureListener.java:320)
```

logged as *"Unexpected exception when attempting to tear down the Mojarra runtime"*. It's a teardown-only log (the runtime still tears down), surfaced by running the OmniFaces IT against Mojarra 5.

## Fix

The `CdiExtension`'s observed-system-event-type set is collected during CDI bootstrap (`ProcessObserverMethod`) and is immutable afterwards. Capture it **once** into a `volatile` field and reuse it, so the shutdown path no longer calls `getExtension`. If the extension is already gone before it was ever captured (an app that fires no CDI-scoped system event before shutdown), catch the `IllegalArgumentException` and treat it as **no observers** — skip the CDI dispatch and publish the event normally.

## Notes

- Behaviour-neutral in normal operation: the same set `getExtension` returned, now cached; only the teardown lookup is eliminated.
- **5.0-only** — the `hasCdiObserverFor` guard does not exist on 4.x (zero occurrences).
- impl builds, 1061 tests green. End-to-end teardown validation comes from the OmniFaces-on-Mojarra5 run.

Regression from #5803 (jakartaee/faces#1501).

🤖 Generated with Claude Opus 4.8
