### PR TITLE
Default the render-time facelet re-apply skip; rename its param

### DIFF
--- a/impl/src/main/java/com/sun/faces/RIConstants.java
+++ b/impl/src/main/java/com/sun/faces/RIConstants.java
@@ -44,7 +44,7 @@ public class RIConstants {
      * Request-scoped flag set during a view build when a build-time-dynamic handler (a JSTL conditional/iteration or a
      * dynamic ui:include/ui:decorate/ui:composition) participates, marking the view as one whose facelet must be
      * re-applied on every (re)build. Read by {@code FaceletViewHandlingStrategy.buildView} to decide whether the
-     * redundant render-time re-apply may be skipped (see {@code disableRefreshTransientBuild}).
+     * redundant render-time re-apply may be skipped (see {@code refreshTransientBuildOnPSS}).
      */
     public static final String DYNAMIC_TRANSIENT_BUILD = FACES_PREFIX + "dynamicTransientBuild";
 

--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -176,7 +176,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
     private MethodRetargetHandlerManager retargetHandlerManager = new MethodRetargetHandlerManager();
 
     private int responseBufferSize;
-    private boolean disableRefreshTransientBuild;
+    private boolean refreshTransientBuildOnPSS;
 
     private Cache<Resource, BeanInfo> metadataCache;
     private Map<String, List<String>> contractMappings;
@@ -309,7 +309,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
         if (isViewPopulated(ctx, view)) {
             if (canSkipTransientBuildRefresh(ctx, view, stateCtx)) {
                 // The view was already (re)built this request and holds no build-time-dynamic content, so re-applying
-                // the facelet would reproduce the identical tree. Skip it (see disableRefreshTransientBuild).
+                // the facelet would reproduce the identical tree. Skip it (see refreshTransientBuildOnPSS).
                 return;
             }
             Facelet facelet = faceletFactory.getFacelet(ctx, view.getViewId());
@@ -386,13 +386,15 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
     }
 
     /**
-     * Determines whether the redundant re-apply of the facelet on an already-populated view may be skipped. Opt-in via
-     * {@code disableRefreshTransientBuild}; only safe under partial state saving for a non-transient view whose build
-     * this request involved no build-time-dynamic content ({@link RIConstants#DYNAMIC_TRANSIENT_BUILD}) and no dynamic
-     * component add/remove, since re-applying would then reproduce the identical tree.
+     * Determines whether the redundant re-apply of the facelet on an already-populated view may be skipped. Enabled by
+     * default (MyFaces {@code REFRESH_TRANSIENT_BUILD_ON_PSS=auto} parity); set {@code refreshTransientBuildOnPSS} to
+     * {@code true} to restore the legacy unconditional re-apply. The skip is only safe under partial state saving for a
+     * non-transient view whose build this request involved no build-time-dynamic content
+     * ({@link RIConstants#DYNAMIC_TRANSIENT_BUILD}) and no dynamic component add/remove, since re-applying would then
+     * reproduce the identical tree.
      */
     private boolean canSkipTransientBuildRefresh(FacesContext ctx, UIViewRoot view, StateContext stateCtx) {
-        return disableRefreshTransientBuild
+        return !refreshTransientBuildOnPSS
                 && !view.isTransient()
                 && stateCtx.isPartialStateSaving(ctx, view.getViewId())
                 && isEmpty(stateCtx.getDynamicActions())
@@ -867,7 +869,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
             responseBufferSize = Integer.parseInt(FaceletsBufferSize.getDefaultValue());
         }
 
-        disableRefreshTransientBuild = webConfig.isOptionEnabled(BooleanWebContextInitParameter.DisableRefreshTransientBuild);
+        refreshTransientBuildOnPSS = webConfig.isOptionEnabled(BooleanWebContextInitParameter.RefreshTransientBuildOnPSS);
 
         LOGGER.fine("Initialization Successful");
 

--- a/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
+++ b/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
@@ -873,7 +873,7 @@ public class WebConfiguration {
         EnableHttpMethodRestrictionPhaseListener("com.sun.faces.ENABLE_HTTP_METHOD_RESTRICTION_PHASE_LISTENER", false),
         FaceletsSkipComments(ViewHandler.FACELETS_SKIP_COMMENTS_PARAM_NAME, false),
         PartialStateSaving(StateManager.PARTIAL_STATE_SAVING_PARAM_NAME, true),
-        DisableRefreshTransientBuild("com.sun.faces.disableRefreshTransientBuild", false),
+        RefreshTransientBuildOnPSS("com.sun.faces.refreshTransientBuildOnPSS", false),
         GenerateUniqueServerStateIds("com.sun.faces.generateUniqueServerStateIds", true),
         InterpretEmptyStringSubmittedValuesAsNull(UIInput.EMPTY_STRING_AS_NULL_PARAM_NAME, false),
         AutoCompleteOffOnViewState("com.sun.faces.autoCompleteOffOnViewState", true),

--- a/impl/src/main/java/com/sun/faces/facelets/tag/TagHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/TagHandlerImpl.java
@@ -42,7 +42,7 @@ public abstract class TagHandlerImpl extends TagHandler {
      * Flag the current view build as containing build-time-dynamic content (a JSTL conditional/iteration or a dynamic
      * include) so its facelet is re-applied on every (re)build. Build-time-dynamic handlers call this at the top of
      * their {@code apply}; the absence of the flag lets {@code FaceletViewHandlingStrategy} skip the redundant
-     * render-time re-apply for a purely component-driven view (see {@code disableRefreshTransientBuild}).
+     * render-time re-apply for a purely component-driven view (see {@code refreshTransientBuildOnPSS}).
      *
      * @param ctx the {@link FaceletContext} for the current build
      */


### PR DESCRIPTION
## Problem

PR #5811 added a behaviour-neutral skip of the redundant render/restore-time facelet re-apply for static views, but gated it behind an **opt-in** context param `com.sun.faces.disableRefreshTransientBuild` (default `false`). So out of the box Mojarra still pays the full re-apply tax that JFR attributes to ~14.5% of render — the bulk of the render-phase gap versus MyFaces, which skips it by **default** via `org.apache.myfaces.REFRESH_TRANSIENT_BUILD_ON_PSS=auto`.

## Change

Make the skip the **default**, matching MyFaces `auto`, and rename the param to a positive opt-out:

- `com.sun.faces.refreshTransientBuildOnPSS`, default `false` → skip the redundant re-apply when safe.
- set it to `true` → restore the legacy unconditional re-apply.

The per-view safety conditions are unchanged from #5811: the skip only applies under partial state saving, to a non-transient view, with no dynamic add/remove actions and no build-time-dynamic content (`c:if`/`c:forEach`/`c:choose`/`c:catch`/`c:set` and non-literal `ui:include`/`ui:decorate`/`ui:composition`, tracked request-scoped via `DYNAMIC_TRANSIENT_BUILD`). Those views are still re-applied on every (re)build, so JSTL/dynamic structures keep re-evaluating correctly — exactly the MyFaces `auto` semantics.

## Verification

- Full impl unit suite green (1179, 0 failures) with the new default.
- #5811 already proved the full Faces TCK passes with the skip enabled, which is now the default.

Ref #5753, follow-up to #5811.

🤖 Generated with Claude Opus 4.8
