### PR TITLE
Re-apply views with dynamic f:view / f:loadBundle inputs

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -387,11 +387,10 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
 
     /**
      * Determines whether the redundant re-apply of the facelet on an already-populated view may be skipped. Enabled by
-     * default (MyFaces {@code REFRESH_TRANSIENT_BUILD_ON_PSS=auto} parity); set {@code refreshTransientBuildOnPSS} to
-     * {@code true} to restore the legacy unconditional re-apply. The skip is only safe under partial state saving for a
-     * non-transient view whose build this request involved no build-time-dynamic content
-     * ({@link RIConstants#DYNAMIC_TRANSIENT_BUILD}) and no dynamic component add/remove, since re-applying would then
-     * reproduce the identical tree.
+     * default; set {@code refreshTransientBuildOnPSS} to {@code true} to restore the legacy unconditional re-apply.
+     * The skip is only safe under partial state saving for a non-transient view whose build this request involved no
+     * build-time-dynamic content ({@link RIConstants#DYNAMIC_TRANSIENT_BUILD}) and no dynamic component add/remove,
+     * since re-applying would then reproduce the identical tree.
      */
     private boolean canSkipTransientBuildRefresh(FacesContext ctx, UIViewRoot view, StateContext stateCtx) {
         return !refreshTransientBuildOnPSS

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/core/LoadBundleHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/core/LoadBundleHandler.java
@@ -198,6 +198,11 @@ public final class LoadBundleHandler extends TagHandlerImpl {
      */
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
+        if (!basename.isLiteral()) {
+            // A non-literal basename is re-evaluated per request, so the view must be re-applied on every (re)build
+            // instead of skipped (see refreshTransientBuildOnPSS) to re-resolve the bundle under var.
+            markDynamicTransientBuild(ctx);
+        }
         UIViewRoot root = ComponentSupport.getViewRoot(ctx, parent);
         ResourceBundle bundle = null;
         try {

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/core/ViewHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/core/ViewHandler.java
@@ -94,6 +94,12 @@ public final class ViewHandler extends TagHandlerImpl {
      */
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
+        if (hasDynamicAttribute()) {
+            // A non-literal f:view attribute (e.g. locale, contentType) is re-evaluated per request and applied to
+            // the UIViewRoot during this build, so the view must be re-applied on every (re)build instead of skipped
+            // (see refreshTransientBuildOnPSS), otherwise a value changed by a postback would not take effect.
+            markDynamicTransientBuild(ctx);
+        }
         UIViewRoot root = ComponentSupport.getViewRoot(ctx, parent);
         if (root != null) {
             if (renderKitId != null) {
@@ -170,6 +176,21 @@ public final class ViewHandler extends TagHandlerImpl {
         }
 
         nextHandler.apply(ctx, parent);
+    }
+
+    /**
+     * Whether any of the view attributes applied to the {@link UIViewRoot} during the build is non-literal, i.e.
+     * re-evaluated per request. Such a view must be re-applied on every (re)build so a value changed by a postback
+     * is reflected; the {@code beforePhase}/{@code afterPhase} listener expressions are excluded as they are fixed
+     * per facelet and restored from state.
+     */
+    private boolean hasDynamicAttribute() {
+        return isDynamic(locale) || isDynamic(renderKitId) || isDynamic(contentType) || isDynamic(encoding)
+                || isDynamic(contracts) || isDynamic(transientFlag);
+    }
+
+    private static boolean isDynamic(TagAttribute attribute) {
+        return attribute != null && !attribute.isLiteral();
     }
 
 }


### PR DESCRIPTION
## Problem

PR #5811 made the render-time facelet re-apply skip the default (`refreshTransientBuildOnPSS`, opt-out). The skip is safe for static, component-driven views, but it also suppressed the re-apply of a few core tag handlers that apply **per-request** state to the view during the build and have no "only when new" guard, so a value changed by a postback no longer took effect:

- **`f:view`** — `locale`, `contentType`, `renderKitId`, `encoding`, `contracts`, `transient` stayed frozen at their initial-build values. E.g. switching `f:view locale` via a postback failed to re-resolve localized resources / bundles (caught by the resurrected `Issue4086IT` in the faces TCK).
- **`f:loadBundle`** — a non-literal `basename` kept serving the initially-resolved bundle.

## Change

Mark the view build-time-dynamic (via `TagHandlerImpl.markDynamicTransientBuild`, same mechanism `c:if`/`c:forEach`/dynamic `ui:include` already use) when:

- any `f:view` attribute applied to `UIViewRoot` is non-literal, or
- an `f:loadBundle` `basename` is non-literal.

Such a view is then re-applied on every (re)build, so the per-request value is reflected. Views without these dynamic inputs are unaffected and still benefit from the skip.

## Scope / non-goals

Attached-object handlers (`f:convertX`, `f:validateX`) configure their target only when the component is new (`getParent() == null`), so their EL-bound attributes were never re-resolved on a postback — independent of this skip, and unchanged here (jakartaee/faces#1499). Verified: with the skip disabled (legacy always-re-apply) the converter case is still stale, so it is not a regression introduced by #5811.

## Verification

- impl unit suite green.
- New faces TCK `LoadBundleIT` (locale-switch + non-literal-basename-switch) passes with this fix and fails without it; `Issue4086IT` passes with the `f:view` fix and fails without it. (jakartaee/faces#2193)

Follow-up to #5811. Ref #5753.

🤖 Generated with Claude Opus 4.8
