### PR TITLE
Skip CDI PhaseEvent dispatch when no observer is registered

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/cdi/CdiExtension.java
+++ b/impl/src/main/java/org/glassfish/mojarra/cdi/CdiExtension.java
@@ -52,6 +52,7 @@ import jakarta.faces.component.FacesComponent;
 import jakarta.faces.component.behavior.FacesBehavior;
 import jakarta.faces.convert.FacesConverter;
 import jakarta.faces.event.NamedEvent;
+import jakarta.faces.event.PhaseEvent;
 import jakarta.faces.event.SystemEvent;
 import jakarta.faces.model.DataModel;
 import jakarta.faces.model.FacesDataModel;
@@ -103,6 +104,13 @@ public class CdiExtension implements Extension {
      * given system event (the common case — see {@link #processSystemEventObserver(ProcessObserverMethod)}).
      */
     private final Set<Class<?>> observedSystemEventTypes = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Whether any CDI observer observes a Faces {@link PhaseEvent}. Lets {@code Phase} skip the four CDI phase
+     * event dispatches (and their qualifier allocations) it would otherwise fire before and after every phase
+     * when no observer can receive them (the common case — see {@link #processPhaseEventObserver(ProcessObserverMethod)}).
+     */
+    private volatile boolean phaseEventObserved;
 
     /**
      * Stores the logger.
@@ -238,6 +246,24 @@ public class CdiExtension implements Extension {
         } else if (observedType instanceof ParameterizedType parameterizedType && parameterizedType.getRawType() instanceof Class<?> rawClass) {
             observedSystemEventTypes.add(rawClass);
         }
+    }
+
+    /**
+     * ProcessObserverMethod:
+     * <ul>
+     * <li>record whether any observer observes a Faces {@link PhaseEvent}
+     * </ul>
+     * <p>
+     * Faces dispatches a CDI {@link PhaseEvent} (qualified with {@link jakarta.faces.event.BeforePhase} and
+     * {@link jakarta.faces.event.AfterPhase}) before and after every lifecycle phase. Recording their presence
+     * here lets {@code Phase} skip that dispatch entirely when no observer listens for them. Observers must
+     * observe a {@code PhaseEvent} (or subtype) to receive Faces phase events as CDI events, which is the
+     * contract of the feature.
+     *
+     * @param event the process observer method event
+     */
+    public void processPhaseEventObserver(@Observes ProcessObserverMethod<PhaseEvent, ?> event) {
+        phaseEventObserved = true;
     }
 
     /**
@@ -381,5 +407,12 @@ public class CdiExtension implements Extension {
      */
     public Set<Class<?>> getObservedSystemEventTypes() {
         return observedSystemEventTypes;
+    }
+
+    /**
+     * @return whether the application defines any CDI observer of a Faces {@link PhaseEvent}.
+     */
+    public boolean isPhaseEventObserved() {
+        return phaseEventObserved;
     }
 }

--- a/impl/src/main/java/org/glassfish/mojarra/lifecycle/Phase.java
+++ b/impl/src/main/java/org/glassfish/mojarra/lifecycle/Phase.java
@@ -35,6 +35,7 @@ import jakarta.faces.event.PhaseId;
 import jakarta.faces.event.PhaseListener;
 import jakarta.faces.lifecycle.Lifecycle;
 
+import org.glassfish.mojarra.cdi.CdiExtension;
 import org.glassfish.mojarra.util.FacesLogger;
 import org.glassfish.mojarra.util.Timer;
 
@@ -156,10 +157,12 @@ public abstract class Phase {
             }
         }
 
-        fireCdiPhaseEvent(context, event, AfterPhase.Literal.of(event.getPhaseId()));
+        if (hasCdiPhaseObserver(context)) {
+            fireCdiPhaseEvent(context, event, AfterPhase.Literal.of(event.getPhaseId()));
 
-        if (event.getPhaseId() != PhaseId.ANY_PHASE) {
-            fireCdiPhaseEvent(context, event, AfterPhase.Literal.INSTANCE);
+            if (event.getPhaseId() != PhaseId.ANY_PHASE) {
+                fireCdiPhaseEvent(context, event, AfterPhase.Literal.INSTANCE);
+            }
         }
     }
 
@@ -181,11 +184,13 @@ public abstract class Phase {
             }
         }
 
-        if (event.getPhaseId() != PhaseId.ANY_PHASE) {
-            fireCdiPhaseEvent(context, event, BeforePhase.Literal.INSTANCE);
-        }
+        if (hasCdiPhaseObserver(context)) {
+            if (event.getPhaseId() != PhaseId.ANY_PHASE) {
+                fireCdiPhaseEvent(context, event, BeforePhase.Literal.INSTANCE);
+            }
 
-        fireCdiPhaseEvent(context, event, BeforePhase.Literal.of(event.getPhaseId()));
+            fireCdiPhaseEvent(context, event, BeforePhase.Literal.of(event.getPhaseId()));
+        }
 
         while (listenersIterator.hasNext()) {
             PhaseListener listener = listenersIterator.next();
@@ -207,6 +212,20 @@ public abstract class Phase {
     
     private static void fireCdiPhaseEvent(FacesContext context, PhaseEvent event, Annotation qualifier) {
         getCdiBeanManager(context).getEvent().select(PhaseEvent.class, qualifier).fire(event);
+    }
+
+    /**
+     * @return whether the application defines any CDI observer of a {@link PhaseEvent}, so the before/after
+     * phase dispatch can be skipped entirely in the common case where it does not. Decided once at CDI bootstrap
+     * (see {@link CdiExtension#isPhaseEventObserved()}); returns {@code false} when the extension is no longer
+     * registered (deployment shutting down, WELD-001325), where there are no observers to dispatch to.
+     */
+    private static boolean hasCdiPhaseObserver(FacesContext context) {
+        try {
+            return getCdiBeanManager(context).getExtension(CdiExtension.class).isPhaseEventObserved();
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
     // --------------------------------------------------------- Private Methods


### PR DESCRIPTION
## Problem

Faces dispatches a CDI `PhaseEvent` (qualified with `@BeforePhase` and `@AfterPhase`) before and after **every** lifecycle phase. `Phase` fires up to four `beanManager.getEvent().select(PhaseEvent.class, qualifier).fire(event)` calls per phase — each allocating a fresh `EventImpl` and running Weld observer resolution — even when the application defines **no** `@Observes PhaseEvent` observer, which is the common case.

A cross-impl Tomcat JFR profile (RESTORE_VIEW, unrolled scenarios, Mojarra 5.0 vs MyFaces 5.0.0-SNAPSHOT) surfaced this: `Phase.fireCdiPhaseEvent` was **6.1% of the whole request** — a flat per-phase tax vs MyFaces's equivalent at ~4%.

## Fix

Mirror the existing system-event no-observer guard (`Events#fireCdiSystemEvent` / `CdiExtension#getObservedSystemEventTypes`):

- `CdiExtension.processPhaseEventObserver(@Observes ProcessObserverMethod<PhaseEvent, ?>)` records at CDI bootstrap whether any `PhaseEvent` observer exists (`volatile boolean phaseEventObserved`).
- `Phase.hasCdiPhaseObserver(context)` gates both fire blocks in `handleBeforePhase`/`handleAfterPhase`, so with no observer nothing is fired — and the `BeforePhase/AfterPhase.Literal.of(...)` qualifier allocations are skipped too.

`getExtension` is intentionally **not** cached on the `Phase` instance: a lifecycle/phase can be shared across webapps with different `BeanManager`s, so an instance-level cache of the boolean would be cross-app-incorrect. The `getExtension` map lookup (≤12×/request) is cheap next to the 24 CDI fires it removes.

Behavior is unchanged for apps that **do** observe `PhaseEvent`: the guard returns `true` and every qualified event fires as before.

## Verification

- Tomcat JFR (patched): `fireCdiPhaseEvent` **6.1% → 0.0%** of the request.
- RESTORE_VIEW wall: **−3.0% / −3.1% / −3.8%** (composite-unrolled / view-unrolled / view-unrolled-ajax); the win applies to all six phases.
- 0 render errors; 1175 impl unit tests green; full Jakarta Faces TCK green.

Refs #1443, #5753

Mojarra 5.0 only, no backport needed.

🤖 Generated with Claude Opus 4.8
