### PR TITLE
Backport Restore View allocation reductions (#5818, faces#2194) to 4.0

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentSupport.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentSupport.java
@@ -124,10 +124,9 @@ public final class ComponentSupport {
             }
         }
 
-        Map<String, UIComponent> facets = c.getFacets();
-        // remove any facets marked as deleted
-        if (facets.size() > 0) {
-            Set<Entry<String, UIComponent>> col = facets.entrySet();
+        // remove any facets marked as deleted (getFacetCount avoids allocating an empty FacetsMap when there are none)
+        if (c.getFacetCount() > 0) {
+            Set<Entry<String, UIComponent>> col = c.getFacets().entrySet();
             UIComponent fc;
             Entry<String, UIComponent> curEntry;
             for (Iterator<Entry<String, UIComponent>> itr = col.iterator(); itr.hasNext();) {
@@ -397,8 +396,8 @@ public final class ComponentSupport {
             }
         }
 
-        // mark all facets to be deleted
-        if (c.getFacets().size() > 0) {
+        // mark all facets to be deleted (getFacetCount avoids allocating an empty FacetsMap when there are none)
+        if (c.getFacetCount() > 0) {
             Set col = c.getFacets().entrySet();
             UIComponent fc;
             for (Iterator itr = col.iterator(); itr.hasNext();) {
@@ -454,7 +453,7 @@ public final class ComponentSupport {
         if (c.getChildCount() > 0) {
             for (Iterator itr = c.getChildren().iterator(); itr.hasNext();) {
                 d = (UIComponent) itr.next();
-                if (d.getFacets().size() > 0) {
+                if (d.getFacetCount() > 0) {
                     for (Iterator jtr = d.getFacets().values().iterator(); jtr.hasNext();) {
                         e = (UIComponent) jtr.next();
                         if (e.isTransient()) {

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ValueHolderRule.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ValueHolderRule.java
@@ -61,6 +61,20 @@ final class ValueHolderRule extends MetaRule {
         }
     }
 
+    final static class LiteralValueMetadata extends Metadata {
+
+        private final String value;
+
+        public LiteralValueMetadata(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public void applyMetadata(FaceletContext ctx, Object instance) {
+            ((ValueHolder) instance).setValue(value);
+        }
+    }
+
     final static class DynamicValueExpressionMetadata extends Metadata {
 
         private final TagAttribute attr;
@@ -93,6 +107,10 @@ final class ValueHolderRule extends MetaRule {
         }
 
         if ("value".equals(name)) {
+            if (attribute.isLiteral()) {
+                return new LiteralValueMetadata(attribute.getValue());
+            }
+
             return new DynamicValueExpressionMetadata(attribute);
         }
 

--- a/impl/src/main/java/jakarta/faces/component/ComponentStateHelper.java
+++ b/impl/src/main/java/jakarta/faces/component/ComponentStateHelper.java
@@ -80,7 +80,7 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
      */
     private Map<Serializable, Object> defaultMap() {
         if (defaultMap == null) {
-            defaultMap = new HashMap<>();
+            defaultMap = new HashMap<>(8);
         }
         return defaultMap;
     }

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -1326,6 +1326,13 @@ public abstract class UIComponentBase extends UIComponent {
                 values[3] = saveBindingsState(context);
             }
 
+            // MARK_CREATED is field-backed and no longer mirrored into the attributes map per component (see
+            // AttributesMap.put). Full state runs no buildView reconstruction on restore, so re-attach it here for
+            // restoreMarkersFromState to recover. Partial state omits it -- buildView re-establishes it each postback.
+            if (markCreated != null) {
+                getStateHelper().put(PropertyKeys.attributes, MARK_CREATED, markCreated);
+            }
+
             if (stateHelper != null) {
                 values[4] = stateHelper.saveState(context);
             }
@@ -2344,7 +2351,11 @@ public abstract class UIComponentBase extends UIComponent {
             // each refresh) that is never present when state is saved, so it stays field-only to avoid per-component
             // StateHelper traffic.
             boolean marker = component.markerPut(keyValue, value);
-            if (marker && MARK_DELETED.equals(keyValue)) {
+            if (marker && (MARK_DELETED.equals(keyValue) || MARK_CREATED.equals(keyValue))) {
+                // MARK_DELETED is a transient build-time flag; MARK_CREATED is field-backed (markCreated) and set on
+                // every component during buildView. Neither needs the per-component StateHelper mirror on the hot
+                // c:forEach re-apply path: MARK_DELETED is never saved, and MARK_CREATED is re-attached to the
+                // attributes map once at full-state save (saveState) -- partial state rebuilds it via buildView.
                 return null;
             }
 


### PR DESCRIPTION
Backports the Restore View allocation reductions from #5818 (impl) and jakartaee/faces#2194 (API) to 4.0. Part of the Restore View performance effort tracked in #5753.

On the 4.x line the API sources live inside the impl module (`impl/src/main/java/jakarta/faces/...`), so both PRs' changes land here as four commits:

- **Avoid allocating an empty FacetsMap during Restore View re-apply** — `ComponentSupport`'s `markForDeletion`/`finalizeForDeletion`/`removeTransient` guarded facet loops with `getFacets().size() > 0`, materialising an empty `FacetsMap` per facet-less component; switched to `getFacetCount()`.
- **Set literal ValueHolder values directly instead of via a ValueExpression** — `ValueHolderRule` built a `ValueExpression` for every `value` attribute, including literals; literals now apply via `ValueHolder.setValue`, mirroring the existing literal-converter path.
- **Size ComponentStateHelper's default map to avoid an oversized array** — `defaultMap()` used the no-arg `HashMap` constructor (`Node[16]`); constructed with capacity 8.
- **Stop mirroring MARK_CREATED into per-component saved state** — the field-backed (`markCreated`) tag id was still mirrored into the `StateHelper`; the mirror is skipped in `AttributesMap.put` and re-attached once in the full-state `saveState` branch. Serialized state format unchanged.

The MARK_CREATED change is safe on 4.0: `AttributesMap.containsKey`/`get` already consult `markerGet` first, so `containsKey(MARK_CREATED)` still resolves via the field once the mirror is gone, and `restoreMarkersFromState` recovers it under full state saving.

`impl` module builds and its unit tests pass. Full TCK pending.

🤖 Generated with Claude Opus 4.8
