### PR TITLE
Treat a declared default as satisfying a required composite attribute

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/tag/composite/InterfaceHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/composite/InterfaceHandler.java
@@ -120,6 +120,11 @@ public class InterfaceHandler extends TagHandlerImpl {
                         found = null != cc.getValueExpression(key);
                     }
                 }
+                // A declared default value satisfies a required attribute the page author omitted: cc.attrs.<name>
+                // resolves to that default, so it is not a missing-value error (matches the non-Development render).
+                if (!found) {
+                    found = null != cur.getValue("default");
+                }
                 if (!found) {
                     if (null == buf) {
                         buf = new StringBuffer();


### PR DESCRIPTION
In **Development** stage, `InterfaceHandler.validateComponent` throws a `TagException` for a `required="true"` composite attribute that the page author omits — even when the `cc:attribute` declares a `default`. It tests only `cc.getAttributes().containsKey(name)` and `cc.getValueExpression(name)`, neither of which sees the declared default (that lives in the BeanInfo `PropertyDescriptor` and is resolved separately through `cc.attrs`). So the page fails to render. Production skips this validation entirely, so the default resolves and renders fine — the behavior diverges by project stage.

Example that fails only under Development:

```xhtml
<cc:attribute name="ProdDescription" required="true" default="No Description"/>
...
<h:inputText value="#{cc.attrs.ProdDescription}"/>
```

## Fix

Treat a declared `default` as satisfying the requirement — `cc.attrs.<name>` resolves to that default, so an omitted-but-defaulted attribute is not a missing-value error. This aligns the Development render with the non-Development one. A truly missing required attribute (no default) is still reported.

## Context

Exposed by the resurrected `Issue2039IT` (jakartaee/faces#2181), which brings back coverage for eclipse-ee4j/mojarra#2039. The same latent bug is present on 4.0, 4.1 and 5.0/master (identical `validateComponent`); this PR fixes 4.0. The equivalent fix on 5.0/master was verified with the **full TCK green under `-Dwebapp.projectStage=Development`**.

🤖 Generated with Claude Opus 4.8
