### PR TITLE
Reduce redundant per-request view-lifecycle work (three perf levers)

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/RIConstants.java
+++ b/impl/src/main/java/org/glassfish/mojarra/RIConstants.java
@@ -48,6 +48,16 @@ public class RIConstants {
      */
     public static final String DYNAMIC_TRANSIENT_BUILD = RI_PREFIX + "dynamicTransientBuild";
 
+    /**
+     * Request-scoped flag recording whether the render-time {@code buildView} re-applied the facelet ({@code TRUE}) or
+     * skipped the re-apply for an already-populated static view ({@code FALSE}, see {@code refreshTransientBuildOnPSS}).
+     * Since {@code buildView} runs immediately before {@code renderView}, this reflects whether the tree the state
+     * manager is about to save was (re)built from the facelet this request. {@code saveView} reads it to skip the
+     * redundant whole-tree duplicate-id walk when the tree was not rebuilt (its ids were already validated when it was
+     * first built). Absence is treated as rebuilt, so the check runs by default.
+     */
+    public static final String VIEW_REBUILT_AT_RENDER = RI_PREFIX + "viewRebuiltAtRender";
+
     /*
      * <p>TLV Resource Bundle Location </p>
      */

--- a/impl/src/main/java/org/glassfish/mojarra/application/view/FaceletPartialStateManagementStrategy.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/view/FaceletPartialStateManagementStrategy.java
@@ -20,6 +20,7 @@ import static jakarta.faces.component.visit.VisitHint.SKIP_ITERATION;
 import static jakarta.faces.component.visit.VisitResult.ACCEPT;
 import static java.util.logging.Level.FINEST;
 import static org.glassfish.mojarra.RIConstants.DYNAMIC_ACTIONS;
+import static org.glassfish.mojarra.RIConstants.VIEW_REBUILT_AT_RENDER;
 import static org.glassfish.mojarra.facelets.tag.faces.ComponentSupport.DYNAMIC_COMPONENT;
 import static org.glassfish.mojarra.util.ComponentStruct.ADD;
 import static org.glassfish.mojarra.util.ComponentStruct.REMOVE;
@@ -453,7 +454,12 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
             return null;
         }
 
-        Util.checkIdUniqueness(context, viewRoot, new HashSet<>(64));
+        // Skip the whole-tree duplicate-id walk when the render-time build skipped the facelet re-apply: the tree is
+        // then identical to the one already validated when it was first built (see VIEW_REBUILT_AT_RENDER). A rebuilt
+        // or freshly-built (GET / navigation / JSTL) tree, or an unset flag, still runs the check.
+        if (!Boolean.FALSE.equals(context.getAttributes().get(VIEW_REBUILT_AT_RENDER))) {
+            Util.checkIdUniqueness(context, viewRoot, new HashSet<>(64));
+        }
 
         final Map<String, Object> stateMap = new HashMap<>();
         final StateContext stateContext = StateContext.getStateContext(context);

--- a/impl/src/main/java/org/glassfish/mojarra/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/view/FaceletViewHandlingStrategy.java
@@ -37,6 +37,7 @@ import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINEST;
 import static java.util.logging.Level.WARNING;
 import static org.glassfish.mojarra.RIConstants.DYNAMIC_TRANSIENT_BUILD;
+import static org.glassfish.mojarra.RIConstants.VIEW_REBUILT_AT_RENDER;
 import static org.glassfish.mojarra.RIConstants.FACELETS_ENCODING_KEY;
 import static org.glassfish.mojarra.RIConstants.FLOW_DEFINITION_ID_SUFFIX;
 import static org.glassfish.mojarra.context.StateContext.getStateContext;
@@ -300,11 +301,14 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
     @Override
     public void buildView(FacesContext ctx, UIViewRoot view) throws IOException {
         StateContext stateCtx = StateContext.getStateContext(ctx);
+        // Every path below rebuilds the tree from the facelet except the skip branch, which flips this to FALSE.
+        ctx.getAttributes().put(VIEW_REBUILT_AT_RENDER, Boolean.TRUE);
 
         if (isViewPopulated(ctx, view)) {
             if (canSkipTransientBuildRefresh(ctx, view, stateCtx)) {
                 // The view was already (re)built this request and holds no build-time-dynamic content, so re-applying
                 // the facelet would reproduce the identical tree. Skip it (see refreshTransientBuildOnPSS).
+                ctx.getAttributes().put(VIEW_REBUILT_AT_RENDER, Boolean.FALSE);
                 return;
             }
             Facelet facelet = faceletFactory.getFacelet(ctx, view.getViewId());

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/TagAttributeImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/TagAttributeImpl.java
@@ -54,6 +54,8 @@ public class TagAttributeImpl extends TagAttribute {
 
     private final boolean compositeComponentExpr;
 
+    private final boolean compositeComponentLookupWithArgs;
+
     private final String localName;
 
     private final Location location;
@@ -71,6 +73,7 @@ public class TagAttributeImpl extends TagAttribute {
     public TagAttributeImpl() {
         literal = false;
         compositeComponentExpr = false;
+        compositeComponentLookupWithArgs = false;
         localName = null;
         location = null;
         namespace = null;
@@ -94,6 +97,7 @@ public class TagAttributeImpl extends TagAttribute {
         // Classify once here, since this attribute's value never changes; getValueExpression/getMethodExpression
         // would otherwise re-run the regex on every view build.
         compositeComponentExpr = ELUtils.isCompositeComponentExpr(this.value);
+        compositeComponentLookupWithArgs = ELUtils.isCompositeComponentLookupWithArgs(this.value);
     }
 
     /**
@@ -176,7 +180,7 @@ public class TagAttributeImpl extends TagAttribute {
 
         try {
             ExpressionFactory f = ctx.getExpressionFactory();
-            if (ELUtils.isCompositeComponentLookupWithArgs(value)) {
+            if (compositeComponentLookupWithArgs) {
                 String message = MessageUtils.getExceptionMessageString(ARGUMENTS_NOT_LEGAL_CC_ATTRS_EXPR);
                 throw new TagAttributeException(this, message);
             }
@@ -347,7 +351,7 @@ public class TagAttributeImpl extends TagAttribute {
             // Reuse the value classified in the constructor when called for this attribute's own value (the common
             // path via getValueExpression(ctx, type)); only a foreign expr needs the on-the-fly check.
             if (expr == value ? compositeComponentExpr : ELUtils.isCompositeComponentExpr(expr)) {
-                if (ELUtils.isCompositeComponentLookupWithArgs(expr)) {
+                if (expr == value ? compositeComponentLookupWithArgs : ELUtils.isCompositeComponentLookupWithArgs(expr)) {
                     String message = MessageUtils.getExceptionMessageString(ARGUMENTS_NOT_LEGAL_CC_ATTRS_EXPR);
                     throw new TagAttributeException(this, message);
                 }

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/RenderKitUtils.java
@@ -373,7 +373,6 @@ public class RenderKitUtils {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private static void renderPassThruAttributesInternal(FacesContext context, ResponseWriter writer, UIComponent component,
             Attribute[] attributes, Map<String, List<ClientBehavior>> behaviors) throws IOException {
 
@@ -386,7 +385,9 @@ public class RenderKitUtils {
 
         List<String> setAttributes = getAttributesThatAreSet(component);
 
-        if (setAttributes != null && canBeOptimized(component, behaviors)) {
+        if (canBeOptimized(component, behaviors)) {
+            // Iterates only the attributes actually set (none => renders nothing but the optional single behavior),
+            // instead of the unoptimized path's reflective read of every known attribute.
             renderPassThruAttributesOptimized(context, writer, component, attributes, setAttributes, behaviors);
         } else {
             // this block should only be hit by custom components leveraging
@@ -398,12 +399,13 @@ public class RenderKitUtils {
 
     /**
      * Returns the names of the attributes that have been explicitly set on the given component, either as a literal value
-     * or as a value expression, or {@code null} when none have been set. This is the same list that
+     * or as a value expression, or an empty list when none have been set. This is the same list that
      * {@link #renderPassThruAttributes} consults to skip reflective reads of attributes that were never set.
      */
     @SuppressWarnings("unchecked")
     public static List<String> getAttributesThatAreSet(UIComponent component) {
-        return (List<String>) component.getAttributes().get(ATTRIBUTES_THAT_ARE_SET_KEY);
+        List<String> setAttributes = (List<String>) component.getAttributes().get(ATTRIBUTES_THAT_ARE_SET_KEY);
+        return setAttributes != null ? setAttributes : Collections.emptyList();
     }
 
     /**


### PR DESCRIPTION
Three independent, behaviour-neutral perf levers that eliminate redundant per-request work in the Facelets view-build / render path. Each is a separate commit; all measured on Tomcat 11 + Weld, 5.0, warmup=100 runs=2000–3000, back-to-back on a quiesced host.

## Lever 1 — skip the reflective pass-through attribute sweep when none are set
`renderPassThruAttributesInternal` fell through to the unoptimized path whenever `getAttributesThatAreSet` returned null, reflectively probing every known attribute (~15 per renderer × N components, nearly all unset) — the common `<h:outputText value="…"/>` case. Returning an empty list instead of null routes that case to the optimized path (renders nothing) instead of the reflective sweep.

**view-unrolled RENDER_RESPONSE −9%.**

## Lever 2 — skip the id-uniqueness check on postbacks that reuse the restored tree
`Util.checkIdUniqueness` walks the whole component tree into a HashSet on every `saveView`. For a static same-view postback, `buildView` skips the transient-build refresh (#5811), so the tree is unchanged since restore and was already validated. `buildView` now records whether it rebuilt the tree via a request flag; `saveView` runs the check unless the tree was reused. First GET, navigation targets, JSTL and dynamic-action views still validate; an absent flag defaults to checking.

**form-inputs RENDER_RESPONSE −15% (with Lever 1).**

## Lever 3 — classify composite-lookup-with-args once instead of per view build
`ELUtils.isCompositeComponentLookupWithArgs` runs a regex over the attribute's constant value, but `TagAttributeImpl` re-ran it on every `getValueExpression`/`getMethodExpression` call — i.e. every buildView metadata re-apply. Lifted to a final field classified once in the constructor, mirroring the existing `compositeComponentExpr` field. The foreign-expression path still evaluates on the fly.

**composite-unrolled RESTORE_VIEW −11% (min floor −12%).**

## Overall
Full 20-scenario Mojarra-5 vs MyFaces-5 bench on Tomcat: all-phases at parity, RENDER_RESPONSE 0.95× (Mojarra ahead). Full TCK green.

Part of the ongoing performance work tracked in #5753.

🤖 Generated with Claude Opus 4.8
