### PR TITLE
Backport #5821 to 4.0: three view-lifecycle perf levers

### DIFF
--- a/impl/src/main/java/com/sun/faces/RIConstants.java
+++ b/impl/src/main/java/com/sun/faces/RIConstants.java
@@ -48,6 +48,16 @@ public class RIConstants {
      */
     public static final String DYNAMIC_TRANSIENT_BUILD = FACES_PREFIX + "dynamicTransientBuild";
 
+    /**
+     * Request-scoped flag recording whether the render-time {@code buildView} re-applied the facelet ({@code TRUE}) or
+     * skipped the re-apply for an already-populated static view ({@code FALSE}, see {@code refreshTransientBuildOnPSS}).
+     * Since {@code buildView} runs immediately before {@code renderView}, this reflects whether the tree the state
+     * manager is about to save was (re)built from the facelet this request. {@code saveView} reads it to skip the
+     * redundant whole-tree duplicate-id walk when the tree was not rebuilt (its ids were already validated when it was
+     * first built). Absence is treated as rebuilt, so the check runs by default.
+     */
+    public static final String VIEW_REBUILT_AT_RENDER = FACES_PREFIX + "viewRebuiltAtRender";
+
     /*
      * <p>TLV Resource Bundle Location </p>
      */

--- a/impl/src/main/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategy.java
@@ -18,6 +18,7 @@ package com.sun.faces.application.view;
 
 import static com.sun.faces.RIConstants.DYNAMIC_ACTIONS;
 import static com.sun.faces.RIConstants.DYNAMIC_COMPONENT;
+import static com.sun.faces.RIConstants.VIEW_REBUILT_AT_RENDER;
 import static com.sun.faces.util.ComponentStruct.ADD;
 import static com.sun.faces.util.ComponentStruct.REMOVE;
 import static com.sun.faces.util.Util.isEmpty;
@@ -453,7 +454,12 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
             return null;
         }
 
-        Util.checkIdUniqueness(context, viewRoot, new HashSet<>(64));
+        // Skip the whole-tree duplicate-id walk when the render-time build skipped the facelet re-apply: the tree is
+        // then identical to the one already validated when it was first built (see VIEW_REBUILT_AT_RENDER). A rebuilt
+        // or freshly-built (GET / navigation / JSTL) tree, or an unset flag, still runs the check.
+        if (!Boolean.FALSE.equals(context.getAttributes().get(VIEW_REBUILT_AT_RENDER))) {
+            Util.checkIdUniqueness(context, viewRoot, new HashSet<>(64));
+        }
 
         final Map<String, Object> stateMap = new HashMap<>();
         final StateContext stateContext = StateContext.getStateContext(context);

--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -18,6 +18,7 @@ package com.sun.faces.application.view;
 
 import static com.sun.faces.RIConstants.DYNAMIC_COMPONENT;
 import static com.sun.faces.RIConstants.DYNAMIC_TRANSIENT_BUILD;
+import static com.sun.faces.RIConstants.VIEW_REBUILT_AT_RENDER;
 import static com.sun.faces.RIConstants.FACELETS_ENCODING_KEY;
 import static com.sun.faces.RIConstants.FLOW_DEFINITION_ID_SUFFIX;
 import static com.sun.faces.config.WebConfiguration.WebContextInitParameter.FaceletsBufferSize;
@@ -305,11 +306,14 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
     @Override
     public void buildView(FacesContext ctx, UIViewRoot view) throws IOException {
         StateContext stateCtx = StateContext.getStateContext(ctx);
+        // Every path below rebuilds the tree from the facelet except the skip branch, which flips this to FALSE.
+        ctx.getAttributes().put(VIEW_REBUILT_AT_RENDER, Boolean.TRUE);
 
         if (isViewPopulated(ctx, view)) {
             if (canSkipTransientBuildRefresh(ctx, view, stateCtx)) {
                 // The view was already (re)built this request and holds no build-time-dynamic content, so re-applying
                 // the facelet would reproduce the identical tree. Skip it (see refreshTransientBuildOnPSS).
+                ctx.getAttributes().put(VIEW_REBUILT_AT_RENDER, Boolean.FALSE);
                 return;
             }
             Facelet facelet = faceletFactory.getFacelet(ctx, view.getViewId());

--- a/impl/src/main/java/com/sun/faces/facelets/tag/TagAttributeImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/TagAttributeImpl.java
@@ -54,6 +54,8 @@ public class TagAttributeImpl extends TagAttribute {
 
     private final boolean compositeComponentExpr;
 
+    private final boolean compositeComponentLookupWithArgs;
+
     private final String localName;
 
     private final Location location;
@@ -71,6 +73,7 @@ public class TagAttributeImpl extends TagAttribute {
     public TagAttributeImpl() {
         literal = false;
         compositeComponentExpr = false;
+        compositeComponentLookupWithArgs = false;
         localName = null;
         location = null;
         namespace = null;
@@ -94,6 +97,7 @@ public class TagAttributeImpl extends TagAttribute {
         // Classify once here, since this attribute's value never changes; getValueExpression/getMethodExpression
         // would otherwise re-run the regex on every view build.
         compositeComponentExpr = ELUtils.isCompositeComponentExpr(this.value);
+        compositeComponentLookupWithArgs = ELUtils.isCompositeComponentLookupWithArgs(this.value);
     }
 
     /**
@@ -176,7 +180,7 @@ public class TagAttributeImpl extends TagAttribute {
 
         try {
             ExpressionFactory f = ctx.getExpressionFactory();
-            if (ELUtils.isCompositeComponentLookupWithArgs(value)) {
+            if (compositeComponentLookupWithArgs) {
                 String message = MessageUtils.getExceptionMessageString(ARGUMENTS_NOT_LEGAL_CC_ATTRS_EXPR);
                 throw new TagAttributeException(this, message);
             }
@@ -347,7 +351,7 @@ public class TagAttributeImpl extends TagAttribute {
             // Reuse the value classified in the constructor when called for this attribute's own value (the common
             // path via getValueExpression(ctx, type)); only a foreign expr needs the on-the-fly check.
             if (expr == value ? compositeComponentExpr : ELUtils.isCompositeComponentExpr(expr)) {
-                if (ELUtils.isCompositeComponentLookupWithArgs(expr)) {
+                if (expr == value ? compositeComponentLookupWithArgs : ELUtils.isCompositeComponentLookupWithArgs(expr)) {
                     String message = MessageUtils.getExceptionMessageString(ARGUMENTS_NOT_LEGAL_CC_ATTRS_EXPR);
                     throw new TagAttributeException(this, message);
                 }

--- a/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
@@ -378,7 +378,6 @@ public class RenderKitUtils {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private static void renderPassThruAttributesInternal(FacesContext context, ResponseWriter writer, UIComponent component,
             Attribute[] attributes, Map<String, List<ClientBehavior>> behaviors) throws IOException {
 
@@ -391,7 +390,9 @@ public class RenderKitUtils {
 
         List<String> setAttributes = getAttributesThatAreSet(component);
 
-        if (setAttributes != null && canBeOptimized(component, behaviors)) {
+        if (canBeOptimized(component, behaviors)) {
+            // Iterates only the attributes actually set (none => renders nothing but the optional single behavior),
+            // instead of the unoptimized path's reflective read of every known attribute.
             renderPassThruAttributesOptimized(context, writer, component, attributes, setAttributes, behaviors);
         } else {
             // this block should only be hit by custom components leveraging
@@ -403,12 +404,13 @@ public class RenderKitUtils {
 
     /**
      * Returns the names of the attributes that have been explicitly set on the given component, either as a literal value
-     * or as a value expression, or {@code null} when none have been set. This is the same list that
+     * or as a value expression, or an empty list when none have been set. This is the same list that
      * {@link #renderPassThruAttributes} consults to skip reflective reads of attributes that were never set.
      */
     @SuppressWarnings("unchecked")
     public static List<String> getAttributesThatAreSet(UIComponent component) {
-        return (List<String>) component.getAttributes().get(ATTRIBUTES_THAT_ARE_SET_KEY);
+        List<String> setAttributes = (List<String>) component.getAttributes().get(ATTRIBUTES_THAT_ARE_SET_KEY);
+        return setAttributes != null ? setAttributes : Collections.emptyList();
     }
 
     /**


### PR DESCRIPTION
Backport of #5821 to 4.0 — three behaviour-neutral view-lifecycle perf levers, adapted to the `com.sun.faces` packages. Identical mechanism to the merged 5.0 change; see #5821 for the full rationale, JFR analysis and cross-impl bench numbers.

- **Skip the reflective pass-through attribute sweep when none are set** (`RenderKitUtils`) — `getAttributesThatAreSet` returns an empty list instead of `null`, routing the common no-set-attrs component (e.g. `<h:outputText value="…"/>`) to the optimized path instead of the reflective read of every known attribute. All callers (the render path, `getAttributeIfSet`, and the message/output/text renderers) treat empty exactly as they treated `null`.
- **Skip the id-uniqueness check on postbacks that reuse the restored tree** (`RIConstants.VIEW_REBUILT_AT_RENDER` + `FaceletViewHandlingStrategy` + `FaceletPartialStateManagementStrategy`) — `buildView` records whether it re-applied the facelet or skipped it for an already-populated static view (#5811); `saveView` skips the whole-tree duplicate-id walk when the tree was not rebuilt. First GET, navigation, JSTL and dynamic-action views (and an unset flag) still validate.
- **Classify composite-lookup-with-args once** (`TagAttributeImpl`) — lifted the per-`getValueExpression`/`getMethodExpression` regex to a final field classified in the constructor, mirroring the existing `compositeComponentExpr` field.

Impl build + unit tests green. Same change as the TCK-green #5821, so TCK-covered.

Part of the ongoing performance work tracked in #5753.

🤖 Generated with Claude Opus 4.8
