### PR TITLE
Rework test/perf scenarios: realism, coverage, ~2-3ms sizing

### DIFF
--- a/test/perf/README.md
+++ b/test/perf/README.md
@@ -182,30 +182,37 @@ mvn clean verify -Dperf=true \
 
 ## Scenarios
 
-Row data for the table/repeat/composite scenarios comes from one shared `DataBean`. The counts are
-calibrated so each scenario costs roughly ~5 ms per postback on tomcat-myfaces, keeping per-scenario times
-comparable: `readonlyRows` (200) and `inputRows` (50) for the cheap table/repeat rows, `compositeRows` (100)
-for the heavier per-row composites, `ajaxRows` (200) for the restore-dominated ajax-inputs scenarios (kept
-under the container's default `maxParameterCount`), and `groups` (5×10) for the nested scenarios. The
-`*-unrolled` scenarios size their `c:forEach` directly for the same ~5 ms target.
+Row data for the table/repeat/composite/unrolled scenarios comes from one shared `DataBean`, sized by four
+constants — one per tier — so a whole tier is tuned by editing a single number: `READONLY_ROWS` (200),
+`INPUT_ROWS` (35), `UNROLLED_ROWS` (100) and nested `GROUPS`×`GROUP_ROWS` (5×10). The counts are calibrated so
+every scenario costs roughly ~2–3 ms per request on tomcat-mojarra, keeping per-scenario times comparable —
+with the caveat that a single per-tier count can't fully equalise the three structures (a composite costs
+~1.5× a plain row, a nested ui:repeat ~0.4×), so composites read a little hot and `repeat-nested` a little
+cold. The rows themselves are realistic `Row` records (typed fields, a non-ASCII/HTML-metachar description
+exercising the slow escaping path), and the `*-unrolled` scenarios iterate the same rows via `c:forEach items`.
+The two `dynamic-*` scenarios are sized by the `FIELD_COUNT` constant of their backing bean, and the flat forms
+by the shared `/WEB-INF/includes/form-fields.xhtml` field body. `index` and `viewparam-get` are intentionally
+left small.
 
-- `index` — landing page (smallest baseline)
-- `form-inputs` — single h:form with text/textarea/select/checkbox/radio, managed converters+validators, BV
-- `table-readonly` — h:dataTable, 200 rows, outputs only
-- `table-inputs` — h:dataTable, 50 rows, per-row inputs + converters/validators
-- `table-nested` — h:dataTable ∋ h:dataTable with a per-row input composite (5×10); UIData twin of `composite-nested`, isolating UIData's per-row child-state save/restore against ui:repeat's
-- `repeat-readonly` — ui:repeat, 200 rows, outputs only
-- `repeat-inputs` — ui:repeat, 50 rows, per-row inputs
-- `repeat-nested` — ui:repeat ∋ ui:repeat (5×10 rows, per-row inputs)
-- `composite-readonly` — readonly composite component, 100 instances
-- `composite-inputs` — input composite component, 50 instances
-- `composite-nested` — composite component nested inside ui:repeat (5×10)
-- `composite-unrolled` — *static* tree of composite components built by `c:forEach` (~100 composites, all NamingContainers — the issue #4811 pattern); a postback rebuilds and re-renders the whole composite tree at scale (its restore is delta-free, so the state-restore walk is skipped)
-- `view-unrolled` — flat *static* tree built by `c:forEach` (~200 panelGroups, no inputs); delta-free full postback exercising `restoreViewRootOnly` + the descendant mark-id cache + full render at scale
-- `form-inputs-ajax`, `table-inputs-ajax`, `repeat-inputs-ajax` — same as their non-ajax twins but submit via `<f:ajax execute="@form" render="@form messages">`; driver sends a partial-ajax POST and refreshes `ViewState` from the XML response.
+- `index` — landing page (smallest baseline); also relocates a stylesheet + script via `h:outputStylesheet`/`h:outputScript`
+- `form-inputs` — flat multi-section form (product/contact/address/company/payment/preferences) sharing `/WEB-INF/includes/form-fields.xhtml`: text/textarea/select/checkbox/radio inputs over managed converters+validators and Bean Validation; `country` uses a `Map`-valued `f:selectItems` (label→code). The hero `name`/`quantity`/`price` fields stay flat; the bulk sit in nested typed section view-models on `FormBean` (two-level `BeanELResolver` path)
+- `form-invalid` — same shared field body as `form-inputs`, but the driver posts values that fail conversion/validation (`name=forbidden` trips the CDI prohibited-words validator; non-numeric quantity/price trip `convertNumber`) so every run exercises `FacesMessage` creation, `UIInput` invalid-marking, the **skipped** Update Model/Invoke phases, redisplay of the rejected values and `h:messages` rendering with content
+- `table-readonly` — h:dataTable, outputs only
+- `table-inputs` — h:dataTable, per-row inputs + converters/validators
+- `table-nested` — h:dataTable ∋ h:dataTable with a per-row input composite; UIData twin of `composite-nested`, isolating UIData's per-row child-state save/restore against ui:repeat's
+- `repeat-readonly` — ui:repeat, outputs only
+- `repeat-inputs` — ui:repeat, per-row inputs
+- `repeat-nested` — ui:repeat ∋ ui:repeat, per-row inputs
+- `composite-readonly` — readonly composite component instances
+- `composite-inputs` — input composite component instances
+- `composite-nested` — composite component nested inside ui:repeat
+- `composite-unrolled` — *static* tree of composite components built by `c:forEach items` (all NamingContainers — the issue #4811 pattern); a postback rebuilds and re-renders the whole composite tree at scale (its restore is delta-free, so the state-restore walk is skipped)
+- `view-unrolled` — flat *static* tree built by `c:forEach items` (output blocks, no inputs); delta-free full postback exercising `restoreViewRootOnly` + the descendant mark-id cache + full render at scale
+- `form-inputs-ajax` — ajax twin of `form-inputs` (same shared field body): submits via `<f:ajax execute="@form" render="@form messages">`; additionally the `name` field carries **two** `f:ajax` on distinct events (keyup+blur), which flips the client-behavior chain and Mojarra's *unoptimized* pass-through-attribute renderer path (enabled via the fragment's `ajax` param)
+- `table-inputs-ajax`, `repeat-inputs-ajax` — same as their non-ajax twins but submit via `<f:ajax execute="@form" render="@form messages">`; driver sends a partial-ajax POST and refreshes `ViewState` from the XML response
 - `view-unrolled-ajax` — ajax twin of `view-unrolled`: same flat static tree, `@form` ajax postback (`restoreViewRootOnly` + partial-response render at scale)
-- `dynamic-form-ajax` — the idiomatic **dynamic components** pattern: a request-scoped bean holds the container via `binding`, and an `f:event type="postAddToView"` listener (`DynamicFormBean#build`) **programmatically** builds a large set of labelled inputs each time the view is (re)built, rather than declaring them in the facelet. The tree structure is identical every request, so the ajax postback runs the full lifecycle (decode/validate/update + partial render) over the dynamically-built inputs exactly like `form-inputs-ajax`. Unlike `dynamic-toggle-ajax` it does **not** touch the dynamic add/remove machinery (the components are built during the normal view (re)build, not after it) — it isolates the cost of `binding` resolution plus programmatic component construction, and is portable across implementations.
-- `dynamic-toggle-ajax` — each ajax toggle adds or removes a large input subtree under the in-view `container` via `getChildren().add()/clear()` in the action. Because the mutation happens **after** `markInitialState`, this is the scenario that drives Mojarra's dynamic add/remove path — `StateContext` dynamic-action tracking, the `DYNAMIC_COMPONENT` marker, and full-state-save/restore of the dynamic subtree — which no structurally-static scenario reaches. It is the one for benchmarking that path. On Mojarra the dynamic subtree is replayed on restore, so toggles alternate add↔remove; MyFaces re-adds it each request rather than persisting it across the postback.
+- `dynamic-form-ajax` — the idiomatic **dynamic components** pattern: a request-scoped bean holds the container via `binding`, and an `f:event type="postAddToView"` listener (`DynamicFormBean#build`) **programmatically** builds `FIELD_COUNT` labelled inputs each time the view is (re)built, rather than declaring them in the facelet. The tree structure is identical every request, so the ajax postback runs the full lifecycle (decode/validate/update + partial render) over the dynamically-built inputs exactly like `form-inputs-ajax`. Unlike `dynamic-toggle-ajax` it does **not** touch the dynamic add/remove machinery (the components are built during the normal view (re)build, not after it) — it isolates the cost of `binding` resolution plus programmatic component construction, and is portable across implementations.
+- `dynamic-toggle-ajax` — each ajax toggle adds or removes a `FIELD_COUNT`-input subtree under the in-view `container` via `getChildren().add()/clear()` in the action. Because the mutation happens **after** `markInitialState`, this is the scenario that drives Mojarra's dynamic add/remove path — `StateContext` dynamic-action tracking, the `DYNAMIC_COMPONENT` marker, and full-state-save/restore of the dynamic subtree — which no structurally-static scenario reaches. It is the one for benchmarking that path. On Mojarra the dynamic subtree is replayed on restore, so toggles alternate add↔remove; MyFaces re-adds it each request rather than persisting it across the postback.
 - `viewparam-get` — GET with `<f:metadata><f:viewParam><f:viewAction></f:metadata>` so the GET runs the **entire** lifecycle (Apply Request Values → Render Response), not just Restore View + Render Response.
 
 GET-only scenarios fire RESTORE_VIEW + RENDER_RESPONSE; the `viewparam-get`

--- a/test/perf/src/main/java/org/eclipse/mojarra/test/perf/beans/AppConfig.java
+++ b/test/perf/src/main/java/org/eclipse/mojarra/test/perf/beans/AppConfig.java
@@ -15,7 +15,9 @@
  */
 package org.eclipse.mojarra.test.perf.beans;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Named;
@@ -28,15 +30,42 @@ import jakarta.inject.Named;
 @ApplicationScoped
 public class AppConfig {
 
-    private static final List<String> COUNTRIES = List.of("NL", "BE", "DE", "FR", "GB", "US", "JP");
+    // Map-valued select items (label -> value) exercise SelectItemsIterator's Map path, distinct from the
+    // List<String> path that CATEGORIES takes. A code/name country map is the idiomatic real-world case.
+    private static final Map<String, String> COUNTRIES = new LinkedHashMap<>();
+    static {
+        COUNTRIES.put("Netherlands", "NL");
+        COUNTRIES.put("Belgium", "BE");
+        COUNTRIES.put("Germany", "DE");
+        COUNTRIES.put("France", "FR");
+        COUNTRIES.put("United Kingdom", "GB");
+        COUNTRIES.put("United States", "US");
+        COUNTRIES.put("Japan", "JP");
+    }
     private static final List<String> CATEGORIES = List.of("Books", "Music", "Movies", "Games", "Other");
+    private static final List<String> LANGUAGES = List.of("NL", "EN", "DE", "FR", "JP");
+    private static final List<String> TIMEZONES =
+            List.of("Europe/Amsterdam", "Europe/London", "America/New_York", "Asia/Tokyo");
+    private static final List<String> THEMES = List.of("Light", "Dark", "System");
 
-    public List<String> getCountries() {
+    public Map<String, String> getCountries() {
         return COUNTRIES;
     }
 
     public List<String> getCategories() {
         return CATEGORIES;
+    }
+
+    public List<String> getLanguages() {
+        return LANGUAGES;
+    }
+
+    public List<String> getTimezones() {
+        return TIMEZONES;
+    }
+
+    public List<String> getThemes() {
+        return THEMES;
     }
 
     public String getAppName() {

--- a/test/perf/src/main/java/org/eclipse/mojarra/test/perf/beans/DataBean.java
+++ b/test/perf/src/main/java/org/eclipse/mojarra/test/perf/beans/DataBean.java
@@ -19,15 +19,16 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import jakarta.annotation.PostConstruct;
 import jakarta.faces.view.ViewScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
 /**
- * Shared row data for the table ({@code h:dataTable}), repeat ({@code ui:repeat}) and composite scenarios.
- * Composites are far heavier per row, so they iterate {@link #getCompositeRows()} (a smaller list) while the
- * plain table/repeat scenarios iterate the larger {@link #getReadonlyRows()} / {@link #getInputRows()}.
+ * Row data for the table ({@code h:dataTable}), repeat ({@code ui:repeat}), composite and unrolled
+ * ({@code c:forEach items}) scenarios. Scenarios group into four size tiers, each a single tunable constant below:
+ * {@link #getReadonlyRows() readonly} rows, {@link #getInputRows() input} rows (also the tier the flat forms match),
+ * {@link #getUnrolledRows() unrolled} rows, and nested {@link #getGroups() groups}. Each getter builds its list lazily
+ * so a view generates only the rows it renders.
  */
 @Named
 @ViewScoped
@@ -35,44 +36,53 @@ public class DataBean implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    private static final int READONLY_ROWS = 200;
+    private static final int INPUT_ROWS = 35;
+    private static final int UNROLLED_ROWS = 100;
+    private static final int GROUPS = 5;
+    private static final int GROUP_ROWS = 10;
+
     @Inject
     private RowFactory rowFactory;
 
     private List<Row> readonlyRows;
     private List<Row> inputRows;
-    private List<Row> compositeRows;
-    private List<Row> ajaxRows;
+    private List<Row> unrolledRows;
     private List<Group> groups;
 
-    @PostConstruct
-    public void init() {
-        readonlyRows = rowFactory.generate(140);
-        inputRows = rowFactory.generate(25);
-        compositeRows = rowFactory.generate(100);
-        ajaxRows = rowFactory.generate(25);
-        groups = new ArrayList<>();
-        for (int g = 0; g < 5; g++) {
-            groups.add(new Group("Group " + g, rowFactory.generate(7)));
-        }
-    }
-
+    /** Readonly (outputs-only) table/repeat/composite rows, e.g. {@code #{dataBean.readonlyRows}}. */
     public List<Row> getReadonlyRows() {
+        if (readonlyRows == null) {
+            readonlyRows = rowFactory.generate(READONLY_ROWS);
+        }
         return readonlyRows;
     }
 
+    /** Per-row-input table/repeat/composite rows (plain and ajax), e.g. {@code #{dataBean.inputRows}}. */
     public List<Row> getInputRows() {
+        if (inputRows == null) {
+            inputRows = rowFactory.generate(INPUT_ROWS);
+        }
         return inputRows;
     }
 
-    public List<Row> getCompositeRows() {
-        return compositeRows;
+    /** Rows the {@code *-unrolled} {@code c:forEach} iterates, e.g. {@code #{dataBean.unrolledRows}}. */
+    public List<Row> getUnrolledRows() {
+        if (unrolledRows == null) {
+            unrolledRows = rowFactory.generate(UNROLLED_ROWS);
+        }
+        return unrolledRows;
     }
 
-    public List<Row> getAjaxRows() {
-        return ajaxRows;
-    }
-
+    /** Nested scenarios: {@value #GROUPS} groups of {@value #GROUP_ROWS} rows, e.g. {@code #{dataBean.groups}}. */
     public List<Group> getGroups() {
+        if (groups == null) {
+            List<Group> list = new ArrayList<>(GROUPS);
+            for (int g = 0; g < GROUPS; g++) {
+                list.add(new Group("Group " + g, rowFactory.generate(GROUP_ROWS)));
+            }
+            groups = list;
+        }
         return groups;
     }
 

--- a/test/perf/src/main/java/org/eclipse/mojarra/test/perf/beans/DynamicFormBean.java
+++ b/test/perf/src/main/java/org/eclipse/mojarra/test/perf/beans/DynamicFormBean.java
@@ -39,7 +39,7 @@ import jakarta.inject.Named;
 @RequestScoped
 public class DynamicFormBean {
 
-    private static final int FIELD_COUNT = 80;
+    private static final int FIELD_COUNT = 100;
 
     private UIComponent container;
     private final Map<String, String> values = new HashMap<>();

--- a/test/perf/src/main/java/org/eclipse/mojarra/test/perf/beans/DynamicToggleBean.java
+++ b/test/perf/src/main/java/org/eclipse/mojarra/test/perf/beans/DynamicToggleBean.java
@@ -43,7 +43,7 @@ public class DynamicToggleBean implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static final int FIELD_COUNT = 820;
+    private static final int FIELD_COUNT = 500;
 
     public String toggle() {
         FacesContext context = FacesContext.getCurrentInstance();

--- a/test/perf/src/main/java/org/eclipse/mojarra/test/perf/beans/FormBean.java
+++ b/test/perf/src/main/java/org/eclipse/mojarra/test/perf/beans/FormBean.java
@@ -23,6 +23,14 @@ import jakarta.faces.view.ViewScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
+/**
+ * Backs the flat multi-section forms ({@code form-inputs}, {@code form-inputs-ajax}, {@code form-invalid}), which
+ * share a single field body via {@code /WEB-INF/includes/form-fields.xhtml}. The "hero" fields ({@code name}, {@code quantity},
+ * {@code price}, …) are kept as direct typed properties — the {@code form-invalid} run keys its rejected values on
+ * their ids. The remaining fields live in nested section view-models ({@link Address}, {@link Company}, …), exercising
+ * the two-level {@code BeanELResolver} property path that real DTO-backed forms take, across a realistic
+ * multi-section component count.
+ */
 @Named
 @ViewScoped
 public class FormBean implements Serializable {
@@ -44,11 +52,20 @@ public class FormBean implements Serializable {
     private String country = "NL";
     private String category = "Books";
 
+    private final Address address = new Address();
+    private final Company company = new Company();
+    private final Contact contact = new Contact();
+    private final Payment payment = new Payment();
+    private final Preferences preferences = new Preferences();
+    private final Shipping shipping = new Shipping();
+
     public String submit() {
         session.getHits();
         appConfig.getAppName();
         return null;
     }
+
+    // --- Hero fields (invalid-path keys on name/quantity/price) ---
 
     public String getName() {
         return name;
@@ -112,5 +129,187 @@ public class FormBean implements Serializable {
 
     public void setCategory(String category) {
         this.category = category;
+    }
+
+    // --- Nested section view-models ---
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public Company getCompany() {
+        return company;
+    }
+
+    public Contact getContact() {
+        return contact;
+    }
+
+    public Payment getPayment() {
+        return payment;
+    }
+
+    public Preferences getPreferences() {
+        return preferences;
+    }
+
+    public Shipping getShipping() {
+        return shipping;
+    }
+
+    public static class Address implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private String street = "Main Street";
+        private String houseNumber = "42";
+        private String addition = "B";
+        private String postalCode = "1000 AA";
+        private String city = "Amsterdam";
+        private String state = "Noord-Holland";
+        private String region = "West";
+
+        public String getStreet() { return street; }
+        public void setStreet(String street) { this.street = street; }
+        public String getHouseNumber() { return houseNumber; }
+        public void setHouseNumber(String houseNumber) { this.houseNumber = houseNumber; }
+        public String getAddition() { return addition; }
+        public void setAddition(String addition) { this.addition = addition; }
+        public String getPostalCode() { return postalCode; }
+        public void setPostalCode(String postalCode) { this.postalCode = postalCode; }
+        public String getCity() { return city; }
+        public void setCity(String city) { this.city = city; }
+        public String getState() { return state; }
+        public void setState(String state) { this.state = state; }
+        public String getRegion() { return region; }
+        public void setRegion(String region) { this.region = region; }
+    }
+
+    public static class Company implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private String companyName = "Acme Corp";
+        private String department = "Engineering";
+        private String jobTitle = "Developer";
+        private String vatNumber = "NL123456789B01";
+        private Integer employees = 100;
+        private String website = "https://acme.example";
+        private String industry = "Books";
+
+        public String getCompanyName() { return companyName; }
+        public void setCompanyName(String companyName) { this.companyName = companyName; }
+        public String getDepartment() { return department; }
+        public void setDepartment(String department) { this.department = department; }
+        public String getJobTitle() { return jobTitle; }
+        public void setJobTitle(String jobTitle) { this.jobTitle = jobTitle; }
+        public String getVatNumber() { return vatNumber; }
+        public void setVatNumber(String vatNumber) { this.vatNumber = vatNumber; }
+        public Integer getEmployees() { return employees; }
+        public void setEmployees(Integer employees) { this.employees = employees; }
+        public String getWebsite() { return website; }
+        public void setWebsite(String website) { this.website = website; }
+        public String getIndustry() { return industry; }
+        public void setIndustry(String industry) { this.industry = industry; }
+    }
+
+    public static class Contact implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private String email = "info@acme.example";
+        private String phone = "+31 20 1234567";
+        private String mobile = "+31 6 12345678";
+        private String fax = "+31 20 7654321";
+        private String skype = "acme.support";
+
+        public String getEmail() { return email; }
+        public void setEmail(String email) { this.email = email; }
+        public String getPhone() { return phone; }
+        public void setPhone(String phone) { this.phone = phone; }
+        public String getMobile() { return mobile; }
+        public void setMobile(String mobile) { this.mobile = mobile; }
+        public String getFax() { return fax; }
+        public void setFax(String fax) { this.fax = fax; }
+        public String getSkype() { return skype; }
+        public void setSkype(String skype) { this.skype = skype; }
+    }
+
+    public static class Payment implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private String cardName = "A. Acme";
+        private String cardNumber = "4111111111111111";
+        private String expiryMonth = "12";
+        private String expiryYear = "2030";
+        private String cvc = "123";
+        private String iban = "NL91ABNA0417164300";
+        private String currency = "EUR";
+
+        public String getCardName() { return cardName; }
+        public void setCardName(String cardName) { this.cardName = cardName; }
+        public String getCardNumber() { return cardNumber; }
+        public void setCardNumber(String cardNumber) { this.cardNumber = cardNumber; }
+        public String getExpiryMonth() { return expiryMonth; }
+        public void setExpiryMonth(String expiryMonth) { this.expiryMonth = expiryMonth; }
+        public String getExpiryYear() { return expiryYear; }
+        public void setExpiryYear(String expiryYear) { this.expiryYear = expiryYear; }
+        public String getCvc() { return cvc; }
+        public void setCvc(String cvc) { this.cvc = cvc; }
+        public String getIban() { return iban; }
+        public void setIban(String iban) { this.iban = iban; }
+        public String getCurrency() { return currency; }
+        public void setCurrency(String currency) { this.currency = currency; }
+    }
+
+    public static class Preferences implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private boolean newsletter = true;
+        private String language = "NL";
+        private String timezone = "Europe/Amsterdam";
+        private String theme = "Light";
+        private String referral = "search";
+        private String comments = "No comments";
+        private boolean acceptTerms = true;
+
+        public boolean isNewsletter() { return newsletter; }
+        public void setNewsletter(boolean newsletter) { this.newsletter = newsletter; }
+        public String getLanguage() { return language; }
+        public void setLanguage(String language) { this.language = language; }
+        public String getTimezone() { return timezone; }
+        public void setTimezone(String timezone) { this.timezone = timezone; }
+        public String getTheme() { return theme; }
+        public void setTheme(String theme) { this.theme = theme; }
+        public String getReferral() { return referral; }
+        public void setReferral(String referral) { this.referral = referral; }
+        public String getComments() { return comments; }
+        public void setComments(String comments) { this.comments = comments; }
+        public boolean isAcceptTerms() { return acceptTerms; }
+        public void setAcceptTerms(boolean acceptTerms) { this.acceptTerms = acceptTerms; }
+    }
+
+    public static class Shipping implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private String street = "Depot Road";
+        private String houseNumber = "7";
+        private String postalCode = "2000 BB";
+        private String city = "Rotterdam";
+        private String country = "NL";
+        private String method = "Standard";
+        private String instructions = "Leave at reception";
+        private boolean giftWrap = false;
+        private String deliveryDate = "2026-02-01";
+
+        public String getStreet() { return street; }
+        public void setStreet(String street) { this.street = street; }
+        public String getHouseNumber() { return houseNumber; }
+        public void setHouseNumber(String houseNumber) { this.houseNumber = houseNumber; }
+        public String getPostalCode() { return postalCode; }
+        public void setPostalCode(String postalCode) { this.postalCode = postalCode; }
+        public String getCity() { return city; }
+        public void setCity(String city) { this.city = city; }
+        public String getCountry() { return country; }
+        public void setCountry(String country) { this.country = country; }
+        public String getMethod() { return method; }
+        public void setMethod(String method) { this.method = method; }
+        public String getInstructions() { return instructions; }
+        public void setInstructions(String instructions) { this.instructions = instructions; }
+        public boolean isGiftWrap() { return giftWrap; }
+        public void setGiftWrap(boolean giftWrap) { this.giftWrap = giftWrap; }
+        public String getDeliveryDate() { return deliveryDate; }
+        public void setDeliveryDate(String deliveryDate) { this.deliveryDate = deliveryDate; }
     }
 }

--- a/test/perf/src/main/java/org/eclipse/mojarra/test/perf/beans/RowFactory.java
+++ b/test/perf/src/main/java/org/eclipse/mojarra/test/perf/beans/RowFactory.java
@@ -31,7 +31,9 @@ public class RowFactory {
             rows.add(new Row(
                     i,
                     "Item " + i,
-                    "Description for item " + i + " with some filler text",
+                    // Non-ASCII + HTML metacharacters exercise the slow char-by-char escaping path in
+                    // HtmlUtils.writeText; description is render-only (never a posted input) so it round-trips safely.
+                    "Ünïcode ‹" + i + "› — <b>café</b> & \"quoted\" 日本語 filler",
                     i * 3 + 1,
                     new BigDecimal("9.99").add(BigDecimal.valueOf(i)),
                     LocalDate.of(2026, 1, 1).plusDays(i % 365),

--- a/test/perf/src/main/webapp/WEB-INF/includes/form-fields.xhtml
+++ b/test/perf/src/main/webapp/WEB-INF/includes/form-fields.xhtml
@@ -1,0 +1,250 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!--
+    Shared field body for form-inputs, form-inputs-ajax and form-invalid: one realistic multi-section form
+    (product, contact, address, company, payment, preferences) over a mix of input types, converters, validators
+    and select items. The optional #{ajax} param enables the live-validation client-behavior chain on the "name"
+    field (two f:ajax on distinct events) — the unoptimized pass-through-attribute renderer path in Mojarra — for
+    the ajax variant only; the plain variants leave those behaviors disabled so their character stays a pure POST.
+-->
+<ui:composition
+    xmlns:h="jakarta.faces.html"
+    xmlns:f="jakarta.faces.core"
+    xmlns:ui="jakarta.faces.facelets"
+>
+    <h:panelGroup id="product" layout="block">
+        <h:outputText value="Product"/>
+        <h:panelGrid columns="2">
+            <h:outputLabel for="name" value="Name"/>
+            <h:inputText id="name" value="#{formBean.name}" required="true">
+                <f:converter converterId="trimConverter"/>
+                <f:validator validatorId="lengthRangeValidator"/>
+                <f:validator validatorId="prohibitedWordsValidator"/>
+                <f:ajax event="keyup" render="messages" disabled="#{empty ajax or !ajax}"/>
+                <f:ajax event="blur" execute="@this" render="messages" disabled="#{empty ajax or !ajax}"/>
+            </h:inputText>
+
+            <h:outputLabel for="description" value="Description"/>
+            <h:inputTextarea id="description" value="#{formBean.description}">
+                <f:validator validatorId="lengthRangeValidator"/>
+            </h:inputTextarea>
+
+            <h:outputLabel for="quantity" value="Quantity"/>
+            <h:inputText id="quantity" value="#{formBean.quantity}">
+                <f:convertNumber integerOnly="true"/>
+                <f:validateLongRange minimum="0" maximum="10000"/>
+            </h:inputText>
+
+            <h:outputLabel for="price" value="Price"/>
+            <h:inputText id="price" value="#{formBean.price}">
+                <f:convertNumber type="currency" currencyCode="EUR"/>
+            </h:inputText>
+
+            <h:outputLabel for="date" value="Date (yyyy-MM-dd)"/>
+            <h:inputText id="date" value="#{formBean.date}"/>
+
+            <h:outputLabel for="active" value="Active"/>
+            <h:selectBooleanCheckbox id="active" value="#{formBean.active}"/>
+
+            <h:outputLabel for="country" value="Country"/>
+            <h:selectOneMenu id="country" value="#{formBean.country}">
+                <f:converter converterId="upperCaseConverter"/>
+                <f:selectItems value="#{appConfig.countries}"/>
+            </h:selectOneMenu>
+
+            <h:outputLabel for="category" value="Category"/>
+            <h:selectOneRadio id="category" value="#{formBean.category}">
+                <f:selectItems value="#{appConfig.categories}"/>
+            </h:selectOneRadio>
+        </h:panelGrid>
+    </h:panelGroup>
+
+    <h:panelGroup id="contact" layout="block">
+        <h:outputText value="Contact"/>
+        <h:panelGrid columns="2">
+            <h:outputLabel for="email" value="Email"/>
+            <h:inputText id="email" value="#{formBean.contact.email}">
+                <f:validateRegex pattern="[^@\s]+@[^@\s]+\.[^@\s]+"/>
+            </h:inputText>
+
+            <h:outputLabel for="phone" value="Phone"/>
+            <h:inputText id="phone" value="#{formBean.contact.phone}"/>
+
+            <h:outputLabel for="mobile" value="Mobile"/>
+            <h:inputText id="mobile" value="#{formBean.contact.mobile}"/>
+
+            <h:outputLabel for="fax" value="Fax"/>
+            <h:inputText id="fax" value="#{formBean.contact.fax}"/>
+
+            <h:outputLabel for="skype" value="Skype"/>
+            <h:inputText id="skype" value="#{formBean.contact.skype}"/>
+        </h:panelGrid>
+    </h:panelGroup>
+
+    <h:panelGroup id="address" layout="block">
+        <h:outputText value="Address"/>
+        <h:panelGrid columns="2">
+            <h:outputLabel for="street" value="Street"/>
+            <h:inputText id="street" value="#{formBean.address.street}"/>
+
+            <h:outputLabel for="houseNumber" value="House number"/>
+            <h:inputText id="houseNumber" value="#{formBean.address.houseNumber}"/>
+
+            <h:outputLabel for="addition" value="Addition"/>
+            <h:inputText id="addition" value="#{formBean.address.addition}"/>
+
+            <h:outputLabel for="postalCode" value="Postal code"/>
+            <h:inputText id="postalCode" value="#{formBean.address.postalCode}"/>
+
+            <h:outputLabel for="city" value="City"/>
+            <h:inputText id="city" value="#{formBean.address.city}"/>
+
+            <h:outputLabel for="state" value="State"/>
+            <h:inputText id="state" value="#{formBean.address.state}"/>
+
+            <h:outputLabel for="region" value="Region"/>
+            <h:inputText id="region" value="#{formBean.address.region}"/>
+        </h:panelGrid>
+    </h:panelGroup>
+
+    <h:panelGroup id="company" layout="block">
+        <h:outputText value="Company"/>
+        <h:panelGrid columns="2">
+            <h:outputLabel for="companyName" value="Company name"/>
+            <h:inputText id="companyName" value="#{formBean.company.companyName}"/>
+
+            <h:outputLabel for="department" value="Department"/>
+            <h:inputText id="department" value="#{formBean.company.department}"/>
+
+            <h:outputLabel for="jobTitle" value="Job title"/>
+            <h:inputText id="jobTitle" value="#{formBean.company.jobTitle}"/>
+
+            <h:outputLabel for="vatNumber" value="VAT number"/>
+            <h:inputText id="vatNumber" value="#{formBean.company.vatNumber}">
+                <f:validateLength minimum="4" maximum="20"/>
+            </h:inputText>
+
+            <h:outputLabel for="employees" value="Employees"/>
+            <h:inputText id="employees" value="#{formBean.company.employees}">
+                <f:convertNumber integerOnly="true"/>
+            </h:inputText>
+
+            <h:outputLabel for="website" value="Website"/>
+            <h:inputText id="website" value="#{formBean.company.website}"/>
+
+            <h:outputLabel for="industry" value="Industry"/>
+            <h:selectOneMenu id="industry" value="#{formBean.company.industry}">
+                <f:selectItems value="#{appConfig.categories}"/>
+            </h:selectOneMenu>
+        </h:panelGrid>
+    </h:panelGroup>
+
+    <h:panelGroup id="payment" layout="block">
+        <h:outputText value="Payment"/>
+        <h:panelGrid columns="2">
+            <h:outputLabel for="cardName" value="Cardholder"/>
+            <h:inputText id="cardName" value="#{formBean.payment.cardName}"/>
+
+            <h:outputLabel for="cardNumber" value="Card number"/>
+            <h:inputText id="cardNumber" value="#{formBean.payment.cardNumber}">
+                <f:validateLength minimum="12" maximum="19"/>
+            </h:inputText>
+
+            <h:outputLabel for="expiryMonth" value="Expiry month"/>
+            <h:inputText id="expiryMonth" value="#{formBean.payment.expiryMonth}"/>
+
+            <h:outputLabel for="expiryYear" value="Expiry year"/>
+            <h:inputText id="expiryYear" value="#{formBean.payment.expiryYear}"/>
+
+            <h:outputLabel for="cvc" value="CVC"/>
+            <h:inputSecret id="cvc" value="#{formBean.payment.cvc}" redisplay="true"/>
+
+            <h:outputLabel for="iban" value="IBAN"/>
+            <h:inputText id="iban" value="#{formBean.payment.iban}"/>
+
+            <h:outputLabel for="currency" value="Currency"/>
+            <h:inputText id="currency" value="#{formBean.payment.currency}"/>
+        </h:panelGrid>
+    </h:panelGroup>
+
+    <h:panelGroup id="preferences" layout="block">
+        <h:outputText value="Preferences"/>
+        <h:panelGrid columns="2">
+            <h:outputLabel for="newsletter" value="Newsletter"/>
+            <h:selectBooleanCheckbox id="newsletter" value="#{formBean.preferences.newsletter}"/>
+
+            <h:outputLabel for="language" value="Language"/>
+            <h:selectOneMenu id="language" value="#{formBean.preferences.language}">
+                <f:selectItems value="#{appConfig.languages}"/>
+            </h:selectOneMenu>
+
+            <h:outputLabel for="timezone" value="Timezone"/>
+            <h:selectOneMenu id="timezone" value="#{formBean.preferences.timezone}">
+                <f:selectItems value="#{appConfig.timezones}"/>
+            </h:selectOneMenu>
+
+            <h:outputLabel for="theme" value="Theme"/>
+            <h:selectOneRadio id="theme" value="#{formBean.preferences.theme}">
+                <f:selectItems value="#{appConfig.themes}"/>
+            </h:selectOneRadio>
+
+            <h:outputLabel for="referral" value="Referral"/>
+            <h:inputText id="referral" value="#{formBean.preferences.referral}"/>
+
+            <h:outputLabel for="comments" value="Comments"/>
+            <h:inputTextarea id="comments" value="#{formBean.preferences.comments}"/>
+
+            <h:outputLabel for="acceptTerms" value="Accept terms"/>
+            <h:selectBooleanCheckbox id="acceptTerms" value="#{formBean.preferences.acceptTerms}"/>
+        </h:panelGrid>
+    </h:panelGroup>
+
+    <h:panelGroup id="shipping" layout="block">
+        <h:outputText value="Shipping"/>
+        <h:panelGrid columns="2">
+            <h:outputLabel for="shipStreet" value="Street"/>
+            <h:inputText id="shipStreet" value="#{formBean.shipping.street}"/>
+
+            <h:outputLabel for="shipHouseNumber" value="House number"/>
+            <h:inputText id="shipHouseNumber" value="#{formBean.shipping.houseNumber}"/>
+
+            <h:outputLabel for="shipPostalCode" value="Postal code"/>
+            <h:inputText id="shipPostalCode" value="#{formBean.shipping.postalCode}"/>
+
+            <h:outputLabel for="shipCity" value="City"/>
+            <h:inputText id="shipCity" value="#{formBean.shipping.city}"/>
+
+            <h:outputLabel for="shipCountry" value="Country"/>
+            <h:selectOneMenu id="shipCountry" value="#{formBean.shipping.country}">
+                <f:selectItems value="#{appConfig.countries}"/>
+            </h:selectOneMenu>
+
+            <h:outputLabel for="shipMethod" value="Method"/>
+            <h:inputText id="shipMethod" value="#{formBean.shipping.method}"/>
+
+            <h:outputLabel for="shipInstructions" value="Instructions"/>
+            <h:inputTextarea id="shipInstructions" value="#{formBean.shipping.instructions}"/>
+
+            <h:outputLabel for="shipGiftWrap" value="Gift wrap"/>
+            <h:selectBooleanCheckbox id="shipGiftWrap" value="#{formBean.shipping.giftWrap}"/>
+
+            <h:outputLabel for="shipDeliveryDate" value="Delivery date"/>
+            <h:inputText id="shipDeliveryDate" value="#{formBean.shipping.deliveryDate}"/>
+        </h:panelGrid>
+    </h:panelGroup>
+</ui:composition>

--- a/test/perf/src/main/webapp/WEB-INF/web.xml
+++ b/test/perf/src/main/webapp/WEB-INF/web.xml
@@ -52,11 +52,11 @@
     <!-- Must match amount of stateful pages in this perf bench WAR. -->
     <context-param>
         <param-name>com.sun.faces.numberOfLogicalViews</param-name>
-        <param-value>15</param-value>
+        <param-value>16</param-value>
     </context-param>
     <context-param>
         <param-name>org.apache.myfaces.NUMBER_OF_VIEWS_IN_SESSION</param-name>
-        <param-value>15</param-value>
+        <param-value>16</param-value>
     </context-param>
 
     <!-- Escape hatch for any other context-param; pass raw <context-param> XML via -Dwebapp.additionalContextParams=... -->

--- a/test/perf/src/main/webapp/composite-readonly.xhtml
+++ b/test/perf/src/main/webapp/composite-readonly.xhtml
@@ -25,7 +25,7 @@
         <title>composite-readonly</title>
     </h:head>
     <h:body>
-        <ui:repeat value="#{dataBean.compositeRows}" var="row">
+        <ui:repeat value="#{dataBean.readonlyRows}" var="row">
             <cc:readonly row="#{row}"/>
         </ui:repeat>
     </h:body>

--- a/test/perf/src/main/webapp/form-inputs-ajax.xhtml
+++ b/test/perf/src/main/webapp/form-inputs-ajax.xhtml
@@ -19,40 +19,16 @@
 <html lang="#{facesContext.viewRoot.locale.language}"
     xmlns:h="jakarta.faces.html"
     xmlns:f="jakarta.faces.core"
+    xmlns:ui="jakarta.faces.facelets"
 >
     <h:head>
         <title>form-inputs-ajax</title>
     </h:head>
     <h:body>
         <h:form id="form">
-            <h:panelGrid columns="2">
-                <h:outputLabel for="name" value="Name"/>
-                <h:inputText id="name" value="#{formBean.name}" required="true">
-                    <f:converter converterId="trimConverter"/>
-                    <f:validator validatorId="lengthRangeValidator"/>
-                    <f:validator validatorId="prohibitedWordsValidator"/>
-                </h:inputText>
-
-                <h:outputLabel for="quantity" value="Quantity"/>
-                <h:inputText id="quantity" value="#{formBean.quantity}">
-                    <f:convertNumber integerOnly="true"/>
-                    <f:validateLongRange minimum="0" maximum="10000"/>
-                </h:inputText>
-
-                <h:outputLabel for="price" value="Price"/>
-                <h:inputText id="price" value="#{formBean.price}">
-                    <f:convertNumber type="currency" currencyCode="EUR"/>
-                </h:inputText>
-
-                <h:outputLabel for="date" value="Date"/>
-                <h:inputText id="date" value="#{formBean.date}"/>
-
-                <h:outputLabel for="country" value="Country"/>
-                <h:selectOneMenu id="country" value="#{formBean.country}">
-                    <f:converter converterId="upperCaseConverter"/>
-                    <f:selectItems value="#{appConfig.countries}"/>
-                </h:selectOneMenu>
-            </h:panelGrid>
+            <ui:include src="/WEB-INF/includes/form-fields.xhtml">
+                <ui:param name="ajax" value="#{true}"/>
+            </ui:include>
 
             <h:commandButton id="submit" value="Submit" action="#{formBean.submit}">
                 <f:ajax execute="@form" render="@form messages"/>

--- a/test/perf/src/main/webapp/form-inputs.xhtml
+++ b/test/perf/src/main/webapp/form-inputs.xhtml
@@ -18,54 +18,14 @@
 -->
 <html lang="#{facesContext.viewRoot.locale.language}"
     xmlns:h="jakarta.faces.html"
-    xmlns:f="jakarta.faces.core"
+    xmlns:ui="jakarta.faces.facelets"
 >
     <h:head>
         <title>form-inputs</title>
     </h:head>
     <h:body>
         <h:form id="form">
-            <h:panelGrid columns="2">
-                <h:outputLabel for="name" value="Name"/>
-                <h:inputText id="name" value="#{formBean.name}" required="true">
-                    <f:converter converterId="trimConverter"/>
-                    <f:validator validatorId="lengthRangeValidator"/>
-                    <f:validator validatorId="prohibitedWordsValidator"/>
-                </h:inputText>
-
-                <h:outputLabel for="description" value="Description"/>
-                <h:inputTextarea id="description" value="#{formBean.description}">
-                    <f:validator validatorId="lengthRangeValidator"/>
-                </h:inputTextarea>
-
-                <h:outputLabel for="quantity" value="Quantity"/>
-                <h:inputText id="quantity" value="#{formBean.quantity}">
-                    <f:convertNumber integerOnly="true"/>
-                    <f:validateLongRange minimum="0" maximum="10000"/>
-                </h:inputText>
-
-                <h:outputLabel for="price" value="Price"/>
-                <h:inputText id="price" value="#{formBean.price}">
-                    <f:convertNumber type="currency" currencyCode="EUR"/>
-                </h:inputText>
-
-                <h:outputLabel for="date" value="Date (yyyy-MM-dd)"/>
-                <h:inputText id="date" value="#{formBean.date}"/>
-
-                <h:outputLabel for="active" value="Active"/>
-                <h:selectBooleanCheckbox id="active" value="#{formBean.active}"/>
-
-                <h:outputLabel for="country" value="Country"/>
-                <h:selectOneMenu id="country" value="#{formBean.country}">
-                    <f:converter converterId="upperCaseConverter"/>
-                    <f:selectItems value="#{appConfig.countries}"/>
-                </h:selectOneMenu>
-
-                <h:outputLabel for="category" value="Category"/>
-                <h:selectOneRadio id="category" value="#{formBean.category}">
-                    <f:selectItems value="#{appConfig.categories}"/>
-                </h:selectOneRadio>
-            </h:panelGrid>
+            <ui:include src="/WEB-INF/includes/form-fields.xhtml"/>
 
             <h:commandButton id="submit" value="Submit" action="#{formBean.submit}"/>
             <h:messages id="messages" globalOnly="false"/>

--- a/test/perf/src/main/webapp/form-invalid.xhtml
+++ b/test/perf/src/main/webapp/form-invalid.xhtml
@@ -18,18 +18,17 @@
 -->
 <html lang="#{facesContext.viewRoot.locale.language}"
     xmlns:h="jakarta.faces.html"
-    xmlns:c="jakarta.tags.core"
-    xmlns:cc="jakarta.faces.composite/cc"
+    xmlns:ui="jakarta.faces.facelets"
 >
     <h:head>
-        <title>composite-unrolled</title>
+        <title>form-invalid</title>
     </h:head>
     <h:body>
         <h:form id="form">
-            <c:forEach items="#{dataBean.unrolledRows}" var="row">
-                <cc:cell value="#{row.id}"/>
-            </c:forEach>
-            <h:commandButton id="submit" value="Submit" />
+            <ui:include src="/WEB-INF/includes/form-fields.xhtml"/>
+
+            <h:commandButton id="submit" value="Submit" action="#{formBean.submit}"/>
+            <h:messages id="messages" globalOnly="false"/>
         </h:form>
     </h:body>
 </html>

--- a/test/perf/src/main/webapp/index.xhtml
+++ b/test/perf/src/main/webapp/index.xhtml
@@ -23,9 +23,14 @@
         <title>Mojarra perf bench</title>
     </h:head>
     <h:body>
+        <!-- Resource components: outputStylesheet always relocates to head; outputScript target=head relocates
+             via the PostAddToView head-facet machinery, exercising the resource-relocation renderer path. -->
+        <h:outputStylesheet name="app.css"/>
+        <h:outputScript name="app.js" target="head"/>
         <h1>#{appConfig.appName}</h1>
         <ul>
             <li><h:link outcome="form-inputs"         value="form-inputs"/></li>
+			<li><h:link outcome="form-invalid"        value="form-invalid"/></li>
             <li><h:link outcome="table-readonly"      value="table-readonly"/></li>
             <li><h:link outcome="table-inputs"        value="table-inputs"/></li>
             <li><h:link outcome="repeat-readonly"     value="repeat-readonly"/></li>

--- a/test/perf/src/main/webapp/repeat-inputs-ajax.xhtml
+++ b/test/perf/src/main/webapp/repeat-inputs-ajax.xhtml
@@ -27,7 +27,7 @@
     <h:body>
         <h:form id="form">
             <h:panelGroup id="rows" layout="block">
-                <ui:repeat value="#{dataBean.ajaxRows}" var="row">
+                <ui:repeat value="#{dataBean.inputRows}" var="row">
                     <h:panelGroup id="row" ayout="block">
                         <h:outputText value="#{row.id}"/>
                         <h:inputText value="#{row.name}">

--- a/test/perf/src/main/webapp/resources/app.css
+++ b/test/perf/src/main/webapp/resources/app.css
@@ -1,0 +1,3 @@
+/* perf-bench stylesheet resource (exercises resource relocation) */
+body { font-family: sans-serif; margin: 1rem; }
+.perf { color: #333; }

--- a/test/perf/src/main/webapp/resources/app.js
+++ b/test/perf/src/main/webapp/resources/app.js
@@ -1,0 +1,2 @@
+/* perf-bench script resource (exercises resource relocation) */
+window.perfBench = { ready: true };

--- a/test/perf/src/main/webapp/table-inputs-ajax.xhtml
+++ b/test/perf/src/main/webapp/table-inputs-ajax.xhtml
@@ -25,7 +25,7 @@
     </h:head>
     <h:body>
         <h:form id="form">
-            <h:dataTable id="table" value="#{dataBean.ajaxRows}" var="row">
+            <h:dataTable id="table" value="#{dataBean.inputRows}" var="row">
                 <h:column>
                     <f:facet name="header">#</f:facet>
                     <h:outputText value="#{row.id}"/>

--- a/test/perf/src/main/webapp/view-unrolled-ajax.xhtml
+++ b/test/perf/src/main/webapp/view-unrolled-ajax.xhtml
@@ -26,12 +26,12 @@
     </h:head>
     <h:body>
         <h:form id="form">
-            <c:forEach var="i" begin="1" end="165">
-                <h:panelGroup id="block#{i}" layout="block">
-                    <h:outputText value="alpha"/>
-                    <h:outputText value="beta"/>
-                    <h:outputText value="gamma"/>
-                    <h:outputText value="delta"/>
+            <c:forEach items="#{dataBean.unrolledRows}" var="row" varStatus="loop">
+                <h:panelGroup id="row_#{loop.index + 1}" layout="block">
+                    <h:outputText value="#{row.name}"/>
+                    <h:outputText value="#{row.description}"/>
+                    <h:outputText value="#{row.quantity}"/>
+                    <h:outputText value="#{row.active}"/>
                 </h:panelGroup>
             </c:forEach>
             <h:commandButton id="submit" value="Submit">

--- a/test/perf/src/main/webapp/view-unrolled.xhtml
+++ b/test/perf/src/main/webapp/view-unrolled.xhtml
@@ -25,12 +25,12 @@
     </h:head>
     <h:body>
         <h:form id="form">
-            <c:forEach var="i" begin="1" end="155">
-                <h:panelGroup id="block#{i}" layout="block">
-                    <h:outputText value="alpha"/>
-                    <h:outputText value="beta"/>
-                    <h:outputText value="gamma"/>
-                    <h:outputText value="delta"/>
+            <c:forEach items="#{dataBean.unrolledRows}" var="row" varStatus="loop">
+                <h:panelGroup id="row_#{loop.index + 1}" layout="block">
+                    <h:outputText value="#{row.name}"/>
+                    <h:outputText value="#{row.description}"/>
+                    <h:outputText value="#{row.quantity}"/>
+                    <h:outputText value="#{row.active}"/>
                 </h:panelGroup>
             </c:forEach>
             <h:commandButton id="submit" value="Submit"/>

--- a/test/perf/src/test/java/org/eclipse/mojarra/test/perf/PerfBenchIT.java
+++ b/test/perf/src/test/java/org/eclipse/mojarra/test/perf/PerfBenchIT.java
@@ -130,6 +130,7 @@ class PerfBenchIT extends BaseIT {
     /** Full (non-ajax) form postbacks. */
     private static final List<String> POSTBACK = only(List.of(
             "form-inputs",
+            "form-invalid",
             "table-inputs",
             "repeat-inputs",
             "composite-inputs",
@@ -193,6 +194,19 @@ class PerfBenchIT extends BaseIT {
         for (String scenario : POSTBACK_AJAX) {
             String html = get(client, scenario + ".xhtml");
             ajaxForms.put(scenario, parseForm(html, scenario + ".xhtml", true));
+        }
+
+        // The "unhappy path": post values that fail conversion/validation so every run exercises FacesMessage
+        // creation, UIInput invalid-marking, the skipped UPDATE_MODEL/INVOKE phases, redisplay of the submitted
+        // (rejected) value and h:messages rendering with content. "forbidden" trips the CDI prohibited-words
+        // validator; the non-numeric quantity/price trip convertNumber. Injected once; reposted verbatim each run.
+        FormSpec invalidForm = forms.get("form-invalid");
+        if (invalidForm != null) {
+            invalidForm.fields.replaceAll((name, value) ->
+                      name.endsWith(":name")     ? "forbidden"
+                    : name.endsWith(":quantity") ? "not-a-number"
+                    : name.endsWith(":price")    ? "xyz"
+                    : value);
         }
 
         get(client, "perf-stats?reset=1");


### PR DESCRIPTION
#5753 

The `test/perf` bench WAR mostly drove happy paths over a few structures at ad-hoc sizes. This broadens it to more representative views and evens out per-scenario cost so no single scenario dominates the suite.

## Changes

- **Unrolled views** (`view-unrolled[-ajax]`, `composite-unrolled`): replace the synthetic `c:forEach begin/end` over static text with `c:forEach items` over real `DataBean` rows, with correct per-row ids (the old `id="block#{i}"` duplicated once the loop var changed).
- **Flat forms**: factor the field body into a shared multi-section fragment `WEB-INF/includes/form-fields.xhtml` (50 typed fields backed by nested section view-models on `FormBean`), included by `form-inputs`, `form-inputs-ajax` and a new `form-invalid`. `form-invalid` reposts values that fail conversion/validation, exercising the unhappy path (FacesMessage, invalid-marking, skipped Update Model/Invoke, redisplay, `h:messages`). `form-inputs-ajax` gains two `f:ajax` on one field (client-behavior chain + unoptimized pass-through renderer). `AppConfig` gains language/timezone/theme select lists.
- **DataBean**: collapse the five ad-hoc lists (readonly/input/composite/ajax/groups, inline magic numbers, eager init) into four named-constant tiers (`READONLY_ROWS` 200, `INPUT_ROWS` 35, `UNROLLED_ROWS` 100, `GROUPS` 5 × `GROUP_ROWS` 10), built lazily so a view generates only what it renders. Composite and ajax scenarios fold into the shared readonly/input tiers.
- **Extra coverage**: relocate a stylesheet+script on `index`; seed a non-ASCII/HTML-metachar row description (slow escaping path); Map-valued select items on the country field.
- **Recalibrate** every scenario to ~2–3 ms/request on tomcat-mojarra (dynamic `FIELD_COUNT` 100/500). A single per-tier count can't fully equalise the three structures (composite ~1.5×/row, nested `ui:repeat` ~0.4×/row), so composites read a little hot and `repeat-nested` a little cold.
- `web.xml`: bump `numberOfLogicalViews` / `NUMBER_OF_VIEWS_IN_SESSION` 15→16 for the added stateful page. `PerfBenchIT` drives `form-invalid` and injects the rejected values. README scenarios/tuning sections updated.

## Verification

Two-pass run on Tomcat against Mojarra 4.1.10-SNAPSHOT and MyFaces 4.1.4 (`warmup=50 runs=1000`), passes agreeing within 0.2%:

- **Clean server logs on both impls** — no exceptions, no stack traces, no duplicate-id errors.
- Every tunable scenario lands ~2–3 ms except the inherent-structure outliers noted above.
- Suite total within **+2.3%** of MyFaces (Mojarra 47.5 ms vs MyFaces 46.4 ms per full cycle). The residual gap is concentrated in the `*-unrolled` trio (the render-time `c:forEach` re-apply); readonly `h:dataTable`/`ui:repeat` render faster than MyFaces.

Targets `4.1` (the module layout differs on `master`).

🤖 Generated with Claude Opus 4.8
