### PR TITLE
Restructure perf bench into a component-family x variant matrix

### DIFF
--- a/test/perf/README.md
+++ b/test/perf/README.md
@@ -182,35 +182,41 @@ mvn clean verify -Dperf=true \
 
 ## Scenarios
 
-Row data for the table/repeat/composite/unrolled scenarios comes from one shared `DataBean`, sized by four
+Row data for the table/repeat/composite/foreach scenarios comes from one shared `DataBean`, sized by four
 constants — one per tier — so a whole tier is tuned by editing a single number: `READONLY_ROWS` (200),
-`INPUT_ROWS` (35), `UNROLLED_ROWS` (100) and nested `GROUPS`×`GROUP_ROWS` (5×10). The counts are calibrated so
-every scenario costs roughly ~2–3 ms per request on tomcat-mojarra, keeping per-scenario times comparable —
-with the caveat that a single per-tier count can't fully equalise the three structures (a composite costs
-~1.5× a plain row, a nested ui:repeat ~0.4×), so composites read a little hot and `repeat-nested` a little
-cold. The rows themselves are realistic `Row` records (typed fields, a non-ASCII/HTML-metachar description
-exercising the slow escaping path), and the `*-unrolled` scenarios iterate the same rows via `c:forEach items`.
+`INPUT_ROWS` (35), `FOREACH_ROWS` (100) and nested `GROUPS`×`GROUP_ROWS` (5×10). The rows themselves are
+realistic `Row` records (typed fields, a non-ASCII/HTML-metachar description exercising the slow escaping path).
 The two `dynamic-*` scenarios are sized by the `FIELD_COUNT` constant of their backing bean, and the flat forms
 by the shared `/WEB-INF/includes/form-fields.xhtml` field body. `index` and `viewparam-get` are intentionally
 left small.
 
+### Component-family matrix
+
+Four component families each span up to six variants. The family fixes the *structure*; the variant fixes the
+*request shape* and whether inputs are present:
+
+| family | iterator | readonly (GET) | inputs | nested | build | inputs-ajax | nested-ajax |
+|---|---|:-:|:-:|:-:|:-:|:-:|:-:|
+| **table** | `h:dataTable` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **repeat** | `ui:repeat` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **composite** | composite components | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **foreach** | `c:forEach items` (build-time unrolled) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+- **readonly** — GET render, outputs only, no form: isolates fresh `buildView` + encode (no state restore). Sized by `READONLY_ROWS` (200); `foreach-readonly` by `FOREACH_ROWS` (100).
+- **inputs** — full postback, per-row inputs + managed converters/validators (`INPUT_ROWS`, 35): full lifecycle over a flat iteration.
+- **nested** — full postback, the iterator inside itself two levels deep with per-row inputs (`GROUPS`×`GROUP_ROWS`, 5×10): isolates per-row child-state save/restore.
+- **build** — full postback of a **readonly** (no-input) tree: empty ARV/PV/UMV, so it isolates the state-**restore** path + encode from any input processing — the representative postback cost for readonly content. `table-build`/`repeat-build` re-post the standard readonly tree (`READONLY_ROWS`); `composite-build` (the #4811 all-NamingContainer case) and `foreach-build` (flat unrolled outputs) are the `c:forEach`-built trees (`FOREACH_ROWS`, delta-free restore).
+- **inputs-ajax** / **nested-ajax** — ajax twins of `inputs`/`nested`, submitting `<f:ajax execute="@form" render="…">`; the driver sends a partial-ajax POST and refreshes `ViewState` from the XML response.
+
+The GET `readonly` and postback `build` variants of the same family render the same tree, giving a clean
+`buildView` (GET) vs `restore` (postback) A/B. Everything else is a full postback (all six phases on POST).
+
+Scenarios outside the matrix:
+
 - `index` — landing page (smallest baseline); also relocates a stylesheet + script via `h:outputStylesheet`/`h:outputScript`
 - `form-inputs` — flat multi-section form (product/contact/address/company/payment/preferences) sharing `/WEB-INF/includes/form-fields.xhtml`: text/textarea/select/checkbox/radio inputs over managed converters+validators and Bean Validation; `country` uses a `Map`-valued `f:selectItems` (label→code). The hero `name`/`quantity`/`price` fields stay flat; the bulk sit in nested typed section view-models on `FormBean` (two-level `BeanELResolver` path)
 - `form-invalid` — same shared field body as `form-inputs`, but the driver posts values that fail conversion/validation (`name=forbidden` trips the CDI prohibited-words validator; non-numeric quantity/price trip `convertNumber`) so every run exercises `FacesMessage` creation, `UIInput` invalid-marking, the **skipped** Update Model/Invoke phases, redisplay of the rejected values and `h:messages` rendering with content
-- `table-readonly` — h:dataTable, outputs only
-- `table-inputs` — h:dataTable, per-row inputs + converters/validators
-- `table-nested` — h:dataTable ∋ h:dataTable with a per-row input composite; UIData twin of `composite-nested`, isolating UIData's per-row child-state save/restore against ui:repeat's
-- `repeat-readonly` — ui:repeat, outputs only
-- `repeat-inputs` — ui:repeat, per-row inputs
-- `repeat-nested` — ui:repeat ∋ ui:repeat, per-row inputs
-- `composite-readonly` — readonly composite component instances
-- `composite-inputs` — input composite component instances
-- `composite-nested` — composite component nested inside ui:repeat
-- `composite-unrolled` — *static* tree of composite components built by `c:forEach items` (all NamingContainers — the issue #4811 pattern); a postback rebuilds and re-renders the whole composite tree at scale (its restore is delta-free, so the state-restore walk is skipped)
-- `view-unrolled` — flat *static* tree built by `c:forEach items` (output blocks, no inputs); delta-free full postback exercising `restoreViewRootOnly` + the descendant mark-id cache + full render at scale
 - `form-inputs-ajax` — ajax twin of `form-inputs` (same shared field body): submits via `<f:ajax execute="@form" render="@form messages">`; additionally the `name` field carries **two** `f:ajax` on distinct events (keyup+blur), which flips the client-behavior chain and Mojarra's *unoptimized* pass-through-attribute renderer path (enabled via the fragment's `ajax` param)
-- `table-inputs-ajax`, `repeat-inputs-ajax` — same as their non-ajax twins but submit via `<f:ajax execute="@form" render="@form messages">`; driver sends a partial-ajax POST and refreshes `ViewState` from the XML response
-- `view-unrolled-ajax` — ajax twin of `view-unrolled`: same flat static tree, `@form` ajax postback (`restoreViewRootOnly` + partial-response render at scale)
 - `dynamic-form-ajax` — the idiomatic **dynamic components** pattern: a request-scoped bean holds the container via `binding`, and an `f:event type="postAddToView"` listener (`DynamicFormBean#build`) **programmatically** builds `FIELD_COUNT` labelled inputs each time the view is (re)built, rather than declaring them in the facelet. The tree structure is identical every request, so the ajax postback runs the full lifecycle (decode/validate/update + partial render) over the dynamically-built inputs exactly like `form-inputs-ajax`. Unlike `dynamic-toggle-ajax` it does **not** touch the dynamic add/remove machinery (the components are built during the normal view (re)build, not after it) — it isolates the cost of `binding` resolution plus programmatic component construction, and is portable across implementations.
 - `dynamic-toggle-ajax` — each ajax toggle adds or removes a `FIELD_COUNT`-input subtree under the in-view `container` via `getChildren().add()/clear()` in the action. Because the mutation happens **after** `markInitialState`, this is the scenario that drives Mojarra's dynamic add/remove path — `StateContext` dynamic-action tracking, the `DYNAMIC_COMPONENT` marker, and full-state-save/restore of the dynamic subtree — which no structurally-static scenario reaches. It is the one for benchmarking that path. On Mojarra the dynamic subtree is replayed on restore, so toggles alternate add↔remove; MyFaces re-adds it each request rather than persisting it across the postback.
 - `viewparam-get` — GET with `<f:metadata><f:viewParam><f:viewAction></f:metadata>` so the GET runs the **entire** lifecycle (Apply Request Values → Render Response), not just Restore View + Render Response.

--- a/test/perf/src/main/java/org/eclipse/mojarra/test/perf/BuildViewBenchServlet.java
+++ b/test/perf/src/main/java/org/eclipse/mojarra/test/perf/BuildViewBenchServlet.java
@@ -38,7 +38,7 @@ import jakarta.servlet.http.HttpServletResponse;
  * state save. Uses only standard {@code jakarta.faces} API, so the same endpoint runs on Eclipse
  * Mojarra and Apache MyFaces, giving an apples-to-apples buildView comparison.
  *
- * <p>{@code GET /buildview-bench?scenario=composite-unrolled&warmup=50&runs=2000} creates a fresh
+ * <p>{@code GET /buildview-bench?scenario=composite-build&warmup=50&runs=2000} creates a fresh
  * {@link UIViewRoot} and calls {@link ViewDeclarationLanguage#buildView} that many times (the
  * compiled Facelet is cached after warmup, so each measured run rebuilds the component tree without
  * recompiling), then reports ns per build and the component count of the last tree.
@@ -52,7 +52,7 @@ public class BuildViewBenchServlet extends HttpServlet {
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         String scenario = request.getParameter("scenario");
         if (scenario == null || scenario.isBlank()) {
-            scenario = "composite-unrolled";
+            scenario = "composite-build";
         }
         int warmup = intParam(request, "warmup", 50);
         int runs = intParam(request, "runs", 2000);

--- a/test/perf/src/main/java/org/eclipse/mojarra/test/perf/EncodeAllBenchServlet.java
+++ b/test/perf/src/main/java/org/eclipse/mojarra/test/perf/EncodeAllBenchServlet.java
@@ -38,7 +38,7 @@ import jakarta.servlet.http.HttpServletResponse;
  * counting writer; uses only standard {@code jakarta.faces} API, so the same endpoint runs on Mojarra
  * and MyFaces for an apples-to-apples render comparison.
  *
- * <p>{@code GET /encodeall-bench?scenario=composite-unrolled&warmup=50&runs=2000} reports ns per
+ * <p>{@code GET /encodeall-bench?scenario=composite-build&warmup=50&runs=2000} reports ns per
  * render and the output character count.
  */
 @WebServlet("/encodeall-bench")
@@ -50,7 +50,7 @@ public class EncodeAllBenchServlet extends HttpServlet {
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         String scenario = request.getParameter("scenario");
         if (scenario == null || scenario.isBlank()) {
-            scenario = "composite-unrolled";
+            scenario = "composite-build";
         }
         int warmup = intParam(request, "warmup", 50);
         int runs = intParam(request, "runs", 2000);

--- a/test/perf/src/main/java/org/eclipse/mojarra/test/perf/beans/DataBean.java
+++ b/test/perf/src/main/java/org/eclipse/mojarra/test/perf/beans/DataBean.java
@@ -24,10 +24,10 @@ import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
 /**
- * Row data for the table ({@code h:dataTable}), repeat ({@code ui:repeat}), composite and unrolled
+ * Row data for the table ({@code h:dataTable}), repeat ({@code ui:repeat}), composite and foreach
  * ({@code c:forEach items}) scenarios. Scenarios group into four size tiers, each a single tunable constant below:
  * {@link #getReadonlyRows() readonly} rows, {@link #getInputRows() input} rows (also the tier the flat forms match),
- * {@link #getUnrolledRows() unrolled} rows, and nested {@link #getGroups() groups}. Each getter builds its list lazily
+ * {@link #getForeachRows() foreach} rows, and nested {@link #getGroups() groups}. Each getter builds its list lazily
  * so a view generates only the rows it renders.
  */
 @Named
@@ -38,7 +38,7 @@ public class DataBean implements Serializable {
 
     private static final int READONLY_ROWS = 200;
     private static final int INPUT_ROWS = 35;
-    private static final int UNROLLED_ROWS = 100;
+    private static final int FOREACH_ROWS = 100;
     private static final int GROUPS = 5;
     private static final int GROUP_ROWS = 10;
 
@@ -47,7 +47,7 @@ public class DataBean implements Serializable {
 
     private List<Row> readonlyRows;
     private List<Row> inputRows;
-    private List<Row> unrolledRows;
+    private List<Row> foreachRows;
     private List<Group> groups;
 
     /** Readonly (outputs-only) table/repeat/composite rows, e.g. {@code #{dataBean.readonlyRows}}. */
@@ -66,12 +66,12 @@ public class DataBean implements Serializable {
         return inputRows;
     }
 
-    /** Rows the {@code *-unrolled} {@code c:forEach} iterates, e.g. {@code #{dataBean.unrolledRows}}. */
-    public List<Row> getUnrolledRows() {
-        if (unrolledRows == null) {
-            unrolledRows = rowFactory.generate(UNROLLED_ROWS);
+    /** Rows the {@code foreach-*} {@code c:forEach} iterates, e.g. {@code #{dataBean.foreachRows}}. */
+    public List<Row> getForeachRows() {
+        if (foreachRows == null) {
+            foreachRows = rowFactory.generate(FOREACH_ROWS);
         }
-        return unrolledRows;
+        return foreachRows;
     }
 
     /** Nested scenarios: {@value #GROUPS} groups of {@value #GROUP_ROWS} rows, e.g. {@code #{dataBean.groups}}. */

--- a/test/perf/src/main/webapp/WEB-INF/web.xml
+++ b/test/perf/src/main/webapp/WEB-INF/web.xml
@@ -52,11 +52,11 @@
     <!-- Must match amount of stateful pages in this perf bench WAR. -->
     <context-param>
         <param-name>com.sun.faces.numberOfLogicalViews</param-name>
-        <param-value>16</param-value>
+        <param-value>25</param-value>
     </context-param>
     <context-param>
         <param-name>org.apache.myfaces.NUMBER_OF_VIEWS_IN_SESSION</param-name>
-        <param-value>16</param-value>
+        <param-value>25</param-value>
     </context-param>
 
     <!-- Escape hatch for any other context-param; pass raw <context-param> XML via -Dwebapp.additionalContextParams=... -->

--- a/test/perf/src/main/webapp/composite-build.xhtml
+++ b/test/perf/src/main/webapp/composite-build.xhtml
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="#{facesContext.viewRoot.locale.language}"
+    xmlns:h="jakarta.faces.html"
+    xmlns:c="jakarta.tags.core"
+    xmlns:cc="jakarta.faces.composite/cc"
+>
+    <h:head>
+        <title>composite-build</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <c:forEach items="#{dataBean.foreachRows}" var="row">
+                <cc:cell value="#{row.id}"/>
+            </c:forEach>
+            <h:commandButton id="submit" value="Submit" />
+        </h:form>
+    </h:body>
+</html>

--- a/test/perf/src/main/webapp/composite-inputs-ajax.xhtml
+++ b/test/perf/src/main/webapp/composite-inputs-ajax.xhtml
@@ -19,24 +19,23 @@
 <html lang="#{facesContext.viewRoot.locale.language}"
     xmlns:h="jakarta.faces.html"
     xmlns:f="jakarta.faces.core"
-    xmlns:c="jakarta.tags.core"
+    xmlns:ui="jakarta.faces.facelets"
+    xmlns:cc="jakarta.faces.composite/cc"
 >
     <h:head>
-        <title>view-unrolled-ajax</title>
+        <title>composite-inputs-ajax</title>
     </h:head>
     <h:body>
         <h:form id="form">
-            <c:forEach items="#{dataBean.unrolledRows}" var="row" varStatus="loop">
-                <h:panelGroup id="row_#{loop.index + 1}" layout="block">
-                    <h:outputText value="#{row.name}"/>
-                    <h:outputText value="#{row.description}"/>
-                    <h:outputText value="#{row.quantity}"/>
-                    <h:outputText value="#{row.active}"/>
-                </h:panelGroup>
-            </c:forEach>
-            <h:commandButton id="submit" value="Submit">
-                <f:ajax execute="@form" render="@form"/>
+            <h:panelGroup id="rows" layout="block">
+                <ui:repeat value="#{dataBean.inputRows}" var="row">
+                    <cc:inputs row="#{row}"/>
+                </ui:repeat>
+            </h:panelGroup>
+            <h:commandButton id="submit" value="Save" action="#{dataBean.save}">
+                <f:ajax execute="@form" render="rows messages"/>
             </h:commandButton>
+            <h:messages id="messages" globalOnly="false"/>
         </h:form>
     </h:body>
 </html>

--- a/test/perf/src/main/webapp/composite-nested-ajax.xhtml
+++ b/test/perf/src/main/webapp/composite-nested-ajax.xhtml
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="#{facesContext.viewRoot.locale.language}"
+    xmlns:h="jakarta.faces.html"
+    xmlns:f="jakarta.faces.core"
+    xmlns:ui="jakarta.faces.facelets"
+    xmlns:cc="jakarta.faces.composite/cc"
+>
+    <h:head>
+        <title>composite-nested-ajax</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <h:panelGroup id="rows" layout="block">
+                <ui:repeat value="#{dataBean.groups}" var="group">
+                    <h:panelGroup id="group" layout="block">
+                        <h2>#{group.name}</h2>
+                        <ui:repeat value="#{group.rows}" var="row">
+                            <cc:inputs row="#{row}"/>
+                        </ui:repeat>
+                    </h:panelGroup>
+                </ui:repeat>
+            </h:panelGroup>
+            <h:commandButton id="submit" value="Save" action="#{dataBean.save}">
+                <f:ajax execute="@form" render="rows messages"/>
+            </h:commandButton>
+            <h:messages id="messages" globalOnly="false"/>
+        </h:form>
+    </h:body>
+</html>

--- a/test/perf/src/main/webapp/foreach-build.xhtml
+++ b/test/perf/src/main/webapp/foreach-build.xhtml
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="#{facesContext.viewRoot.locale.language}"
+    xmlns:h="jakarta.faces.html"
+    xmlns:c="jakarta.tags.core"
+>
+    <h:head>
+        <title>foreach-build</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <c:forEach items="#{dataBean.foreachRows}" var="row" varStatus="loop">
+                <h:panelGroup id="row_#{loop.index + 1}" layout="block">
+                    <h:outputText value="#{row.name}"/>
+                    <h:outputText value="#{row.description}"/>
+                    <h:outputText value="#{row.quantity}"/>
+                    <h:outputText value="#{row.active}"/>
+                </h:panelGroup>
+            </c:forEach>
+            <h:commandButton id="submit" value="Submit"/>
+        </h:form>
+    </h:body>
+</html>

--- a/test/perf/src/main/webapp/foreach-inputs-ajax.xhtml
+++ b/test/perf/src/main/webapp/foreach-inputs-ajax.xhtml
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="#{facesContext.viewRoot.locale.language}"
+    xmlns:h="jakarta.faces.html"
+    xmlns:f="jakarta.faces.core"
+    xmlns:c="jakarta.tags.core"
+>
+    <h:head>
+        <title>foreach-inputs-ajax</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <h:panelGroup id="rows" layout="block">
+                <c:forEach items="#{dataBean.inputRows}" var="row" varStatus="loop">
+                    <h:panelGroup id="row_#{loop.index + 1}" layout="block">
+                        <h:outputText value="#{row.id}"/>
+                        <h:inputText value="#{row.name}">
+                            <f:converter converterId="trimConverter"/>
+                            <f:validator validatorId="lengthRangeValidator"/>
+                        </h:inputText>
+                        <h:inputText value="#{row.quantity}">
+                            <f:convertNumber integerOnly="true"/>
+                        </h:inputText>
+                        <h:inputText value="#{row.price}">
+                            <f:convertNumber type="currency" currencyCode="EUR"/>
+                        </h:inputText>
+                        <h:inputText value="#{row.date}"/>
+                        <h:selectBooleanCheckbox value="#{row.active}"/>
+                    </h:panelGroup>
+                </c:forEach>
+            </h:panelGroup>
+            <h:commandButton id="submit" value="Save" action="#{dataBean.save}">
+                <f:ajax execute="@form" render="rows messages"/>
+            </h:commandButton>
+            <h:messages id="messages" globalOnly="false"/>
+        </h:form>
+    </h:body>
+</html>

--- a/test/perf/src/main/webapp/foreach-inputs.xhtml
+++ b/test/perf/src/main/webapp/foreach-inputs.xhtml
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="#{facesContext.viewRoot.locale.language}"
+    xmlns:h="jakarta.faces.html"
+    xmlns:f="jakarta.faces.core"
+    xmlns:c="jakarta.tags.core"
+>
+    <h:head>
+        <title>foreach-inputs</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <c:forEach items="#{dataBean.inputRows}" var="row" varStatus="loop">
+                <h:panelGroup id="row_#{loop.index + 1}" layout="block">
+                    <h:outputText value="#{row.id}"/>
+                    <h:inputText value="#{row.name}">
+                        <f:converter converterId="trimConverter"/>
+                        <f:validator validatorId="lengthRangeValidator"/>
+                    </h:inputText>
+                    <h:inputText value="#{row.quantity}">
+                        <f:convertNumber integerOnly="true"/>
+                    </h:inputText>
+                    <h:inputText value="#{row.price}">
+                        <f:convertNumber type="currency" currencyCode="EUR"/>
+                    </h:inputText>
+                    <h:inputText value="#{row.date}"/>
+                    <h:selectBooleanCheckbox value="#{row.active}"/>
+                </h:panelGroup>
+            </c:forEach>
+            <h:commandButton id="submit" value="Save" action="#{dataBean.save}"/>
+            <h:messages globalOnly="false"/>
+        </h:form>
+    </h:body>
+</html>

--- a/test/perf/src/main/webapp/foreach-nested-ajax.xhtml
+++ b/test/perf/src/main/webapp/foreach-nested-ajax.xhtml
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="#{facesContext.viewRoot.locale.language}"
+    xmlns:h="jakarta.faces.html"
+    xmlns:f="jakarta.faces.core"
+    xmlns:c="jakarta.tags.core"
+>
+    <h:head>
+        <title>foreach-nested-ajax</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <h:panelGroup id="rows" layout="block">
+                <c:forEach items="#{dataBean.groups}" var="group" varStatus="gloop">
+                    <h:panelGroup id="group_#{gloop.index + 1}" layout="block">
+                        <h2>#{group.name}</h2>
+                        <c:forEach items="#{group.rows}" var="row" varStatus="rloop">
+                            <h:panelGroup id="row_#{gloop.index + 1}_#{rloop.index + 1}" layout="block">
+                                <h:outputText value="#{row.id}"/> - <h:outputText value="#{row.name}"/>
+                                <h:inputText value="#{row.quantity}">
+                                    <f:convertNumber integerOnly="true"/>
+                                </h:inputText>
+                                <h:inputText value="#{row.price}">
+                                    <f:convertNumber type="currency" currencyCode="EUR"/>
+                                </h:inputText>
+                            </h:panelGroup>
+                        </c:forEach>
+                    </h:panelGroup>
+                </c:forEach>
+            </h:panelGroup>
+            <h:commandButton id="submit" value="Save" action="#{dataBean.save}">
+                <f:ajax execute="@form" render="rows messages"/>
+            </h:commandButton>
+            <h:messages id="messages" globalOnly="false"/>
+        </h:form>
+    </h:body>
+</html>

--- a/test/perf/src/main/webapp/foreach-nested.xhtml
+++ b/test/perf/src/main/webapp/foreach-nested.xhtml
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="#{facesContext.viewRoot.locale.language}"
+    xmlns:h="jakarta.faces.html"
+    xmlns:f="jakarta.faces.core"
+    xmlns:c="jakarta.tags.core"
+>
+    <h:head>
+        <title>foreach-nested</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <c:forEach items="#{dataBean.groups}" var="group" varStatus="gloop">
+                <h:panelGroup id="group_#{gloop.index + 1}" layout="block">
+                    <h2>#{group.name}</h2>
+                    <c:forEach items="#{group.rows}" var="row" varStatus="rloop">
+                        <h:panelGroup id="row_#{gloop.index + 1}_#{rloop.index + 1}" layout="block">
+                            <h:outputText value="#{row.id}"/> - <h:outputText value="#{row.name}"/>
+                            <h:inputText value="#{row.quantity}">
+                                <f:convertNumber integerOnly="true"/>
+                            </h:inputText>
+                            <h:inputText value="#{row.price}">
+                                <f:convertNumber type="currency" currencyCode="EUR"/>
+                            </h:inputText>
+                        </h:panelGroup>
+                    </c:forEach>
+                </h:panelGroup>
+            </c:forEach>
+            <h:commandButton id="submit" value="Save" action="#{dataBean.save}"/>
+            <h:messages globalOnly="false"/>
+        </h:form>
+    </h:body>
+</html>

--- a/test/perf/src/main/webapp/foreach-readonly.xhtml
+++ b/test/perf/src/main/webapp/foreach-readonly.xhtml
@@ -21,19 +21,16 @@
     xmlns:c="jakarta.tags.core"
 >
     <h:head>
-        <title>view-unrolled</title>
+        <title>foreach-readonly</title>
     </h:head>
     <h:body>
-        <h:form id="form">
-            <c:forEach items="#{dataBean.unrolledRows}" var="row" varStatus="loop">
-                <h:panelGroup id="row_#{loop.index + 1}" layout="block">
-                    <h:outputText value="#{row.name}"/>
-                    <h:outputText value="#{row.description}"/>
-                    <h:outputText value="#{row.quantity}"/>
-                    <h:outputText value="#{row.active}"/>
-                </h:panelGroup>
-            </c:forEach>
-            <h:commandButton id="submit" value="Submit"/>
-        </h:form>
+        <c:forEach items="#{dataBean.foreachRows}" var="row" varStatus="loop">
+            <h:panelGroup id="row_#{loop.index + 1}" layout="block">
+                <h:outputText value="#{row.name}"/>
+                <h:outputText value="#{row.description}"/>
+                <h:outputText value="#{row.quantity}"/>
+                <h:outputText value="#{row.active}"/>
+            </h:panelGroup>
+        </c:forEach>
     </h:body>
 </html>

--- a/test/perf/src/main/webapp/index.xhtml
+++ b/test/perf/src/main/webapp/index.xhtml
@@ -29,26 +29,36 @@
         <h:outputScript name="app.js" target="head"/>
         <h1>#{appConfig.appName}</h1>
         <ul>
-            <li><h:link outcome="form-inputs"         value="form-inputs"/></li>
-			<li><h:link outcome="form-invalid"        value="form-invalid"/></li>
-            <li><h:link outcome="table-readonly"      value="table-readonly"/></li>
-            <li><h:link outcome="table-inputs"        value="table-inputs"/></li>
-            <li><h:link outcome="repeat-readonly"     value="repeat-readonly"/></li>
-            <li><h:link outcome="repeat-inputs"       value="repeat-inputs"/></li>
-            <li><h:link outcome="repeat-nested"       value="repeat-nested"/></li>
-            <li><h:link outcome="composite-readonly"  value="composite-readonly"/></li>
-            <li><h:link outcome="composite-inputs"    value="composite-inputs"/></li>
-            <li><h:link outcome="composite-nested"    value="composite-nested"/></li>
-            <li><h:link outcome="table-nested"        value="table-nested"/></li>
-            <li><h:link outcome="composite-unrolled"  value="composite-unrolled"/></li>
-            <li><h:link outcome="view-unrolled"       value="view-unrolled"/></li>
-            <li><h:link outcome="form-inputs-ajax"    value="form-inputs-ajax"/></li>
-            <li><h:link outcome="table-inputs-ajax"   value="table-inputs-ajax"/></li>
-            <li><h:link outcome="repeat-inputs-ajax"  value="repeat-inputs-ajax"/></li>
-            <li><h:link outcome="view-unrolled-ajax"  value="view-unrolled-ajax"/></li>
-            <li><h:link outcome="dynamic-form-ajax"   value="dynamic-form-ajax"/></li>
-            <li><h:link outcome="dynamic-toggle-ajax" value="dynamic-toggle-ajax"/></li>
-            <li><h:link outcome="viewparam-get"       value="viewparam-get?id=42"/></li>
+            <li><h:link outcome="form-inputs"           value="form-inputs"/></li>
+            <li><h:link outcome="form-invalid"          value="form-invalid"/></li>
+            <li><h:link outcome="table-readonly"        value="table-readonly"/></li>
+            <li><h:link outcome="repeat-readonly"       value="repeat-readonly"/></li>
+            <li><h:link outcome="composite-readonly"    value="composite-readonly"/></li>
+            <li><h:link outcome="foreach-readonly"      value="foreach-readonly"/></li>
+            <li><h:link outcome="table-inputs"          value="table-inputs"/></li>
+            <li><h:link outcome="repeat-inputs"         value="repeat-inputs"/></li>
+            <li><h:link outcome="composite-inputs"      value="composite-inputs"/></li>
+            <li><h:link outcome="foreach-inputs"        value="foreach-inputs"/></li>
+            <li><h:link outcome="table-nested"          value="table-nested"/></li>
+            <li><h:link outcome="repeat-nested"         value="repeat-nested"/></li>
+            <li><h:link outcome="composite-nested"      value="composite-nested"/></li>
+            <li><h:link outcome="foreach-nested"        value="foreach-nested"/></li>
+            <li><h:link outcome="table-build"           value="table-build"/></li>
+            <li><h:link outcome="repeat-build"          value="repeat-build"/></li>
+            <li><h:link outcome="composite-build"       value="composite-build"/></li>
+            <li><h:link outcome="foreach-build"         value="foreach-build"/></li>
+            <li><h:link outcome="form-inputs-ajax"      value="form-inputs-ajax"/></li>
+            <li><h:link outcome="table-inputs-ajax"     value="table-inputs-ajax"/></li>
+            <li><h:link outcome="repeat-inputs-ajax"    value="repeat-inputs-ajax"/></li>
+            <li><h:link outcome="composite-inputs-ajax" value="composite-inputs-ajax"/></li>
+            <li><h:link outcome="foreach-inputs-ajax"   value="foreach-inputs-ajax"/></li>
+            <li><h:link outcome="table-nested-ajax"     value="table-nested-ajax"/></li>
+            <li><h:link outcome="repeat-nested-ajax"    value="repeat-nested-ajax"/></li>
+            <li><h:link outcome="composite-nested-ajax" value="composite-nested-ajax"/></li>
+            <li><h:link outcome="foreach-nested-ajax"   value="foreach-nested-ajax"/></li>
+            <li><h:link outcome="dynamic-form-ajax"     value="dynamic-form-ajax"/></li>
+            <li><h:link outcome="dynamic-toggle-ajax"   value="dynamic-toggle-ajax"/></li>
+            <li><h:link outcome="viewparam-get"         value="viewparam-get?id=42"/></li>
             <li><a href="perf-stats">/perf-stats</a></li>
         </ul>
     </h:body>

--- a/test/perf/src/main/webapp/repeat-build.xhtml
+++ b/test/perf/src/main/webapp/repeat-build.xhtml
@@ -18,18 +18,27 @@
 -->
 <html lang="#{facesContext.viewRoot.locale.language}"
     xmlns:h="jakarta.faces.html"
-    xmlns:c="jakarta.tags.core"
-    xmlns:cc="jakarta.faces.composite/cc"
+    xmlns:f="jakarta.faces.core"
+    xmlns:ui="jakarta.faces.facelets"
 >
     <h:head>
-        <title>composite-unrolled</title>
+        <title>repeat-build</title>
     </h:head>
     <h:body>
         <h:form id="form">
-            <c:forEach items="#{dataBean.unrolledRows}" var="row">
-                <cc:cell value="#{row.id}"/>
-            </c:forEach>
-            <h:commandButton id="submit" value="Submit" />
+            <ul>
+                <ui:repeat value="#{dataBean.readonlyRows}" var="row">
+                    <li>
+                        #{row.id} - #{row.name} - #{row.description} - qty #{row.quantity} -
+                        <h:outputText value="#{row.price}">
+                            <f:convertNumber type="currency" currencyCode="EUR"/>
+                        </h:outputText>
+                        - <h:outputText value="#{row.date}"/>
+                        - active=#{row.active}
+                    </li>
+                </ui:repeat>
+            </ul>
+            <h:commandButton id="submit" value="Submit"/>
         </h:form>
     </h:body>
 </html>

--- a/test/perf/src/main/webapp/repeat-nested-ajax.xhtml
+++ b/test/perf/src/main/webapp/repeat-nested-ajax.xhtml
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="#{facesContext.viewRoot.locale.language}"
+    xmlns:h="jakarta.faces.html"
+    xmlns:f="jakarta.faces.core"
+    xmlns:ui="jakarta.faces.facelets"
+>
+    <h:head>
+        <title>repeat-nested-ajax</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <h:panelGroup id="rows" layout="block">
+                <ui:repeat value="#{dataBean.groups}" var="group">
+                    <h:panelGroup id="group" layout="block">
+                        <h2>#{group.name}</h2>
+                        <ui:repeat value="#{group.rows}" var="row">
+                            <h:panelGroup id="row" layout="block">
+                                <h:outputText value="#{row.id}"/> - <h:outputText value="#{row.name}"/>
+                                <h:inputText value="#{row.quantity}">
+                                    <f:convertNumber integerOnly="true"/>
+                                </h:inputText>
+                                <h:inputText value="#{row.price}">
+                                    <f:convertNumber type="currency" currencyCode="EUR"/>
+                                </h:inputText>
+                            </h:panelGroup>
+                        </ui:repeat>
+                    </h:panelGroup>
+                </ui:repeat>
+            </h:panelGroup>
+            <h:commandButton id="submit" value="Save" action="#{dataBean.save}">
+                <f:ajax execute="@form" render="rows messages"/>
+            </h:commandButton>
+            <h:messages id="messages" globalOnly="false"/>
+        </h:form>
+    </h:body>
+</html>

--- a/test/perf/src/main/webapp/table-build.xhtml
+++ b/test/perf/src/main/webapp/table-build.xhtml
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="#{facesContext.viewRoot.locale.language}"
+    xmlns:h="jakarta.faces.html"
+    xmlns:f="jakarta.faces.core"
+>
+    <h:head>
+        <title>table-build</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <h:dataTable value="#{dataBean.readonlyRows}" var="row">
+                <h:column><f:facet name="header">#</f:facet>#{row.id}</h:column>
+                <h:column><f:facet name="header">Name</f:facet>#{row.name}</h:column>
+                <h:column><f:facet name="header">Description</f:facet>#{row.description}</h:column>
+                <h:column><f:facet name="header">Qty</f:facet>#{row.quantity}</h:column>
+                <h:column>
+                    <f:facet name="header">Price</f:facet>
+                    <h:outputText value="#{row.price}">
+                        <f:convertNumber type="currency" currencyCode="EUR"/>
+                    </h:outputText>
+                </h:column>
+                <h:column>
+                    <f:facet name="header">Date</f:facet>
+                    <h:outputText value="#{row.date}"/>
+                </h:column>
+                <h:column><f:facet name="header">Active</f:facet>#{row.active}</h:column>
+            </h:dataTable>
+            <h:commandButton id="submit" value="Submit"/>
+        </h:form>
+    </h:body>
+</html>

--- a/test/perf/src/main/webapp/table-nested-ajax.xhtml
+++ b/test/perf/src/main/webapp/table-nested-ajax.xhtml
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="#{facesContext.viewRoot.locale.language}"
+    xmlns:h="jakarta.faces.html"
+    xmlns:f="jakarta.faces.core"
+    xmlns:cc="jakarta.faces.composite/cc"
+>
+    <h:head>
+        <title>table-nested-ajax</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <h:dataTable id="table" value="#{dataBean.groups}" var="group">
+                <h:column>
+                    <h2>#{group.name}</h2>
+                    <h:dataTable value="#{group.rows}" var="row">
+                        <h:column>
+                            <cc:inputs row="#{row}"/>
+                        </h:column>
+                    </h:dataTable>
+                </h:column>
+            </h:dataTable>
+            <h:commandButton id="submit" value="Save" action="#{dataBean.save}">
+                <f:ajax execute="@form" render="table messages"/>
+            </h:commandButton>
+            <h:messages id="messages" globalOnly="false"/>
+        </h:form>
+    </h:body>
+</html>

--- a/test/perf/src/test/java/org/eclipse/mojarra/test/perf/BuildViewBenchIT.java
+++ b/test/perf/src/test/java/org/eclipse/mojarra/test/perf/BuildViewBenchIT.java
@@ -38,7 +38,7 @@ import org.openqa.selenium.WebDriver;
  *
  * <p>Gated behind {@code -Dbuildview=true}. Iteration counts reuse {@code -Dperf.warmup}/{@code
  * -Dperf.runs} (defaults 50/2000); {@code -Dperf.scenarios=<one>} selects the view (default
- * composite-unrolled).
+ * composite-build).
  */
 @EnabledIfSystemProperty(named = "buildview", matches = "true")
 class BuildViewBenchIT extends BaseIT {
@@ -61,9 +61,9 @@ class BuildViewBenchIT extends BaseIT {
 
     @Test
     void buildView() throws Exception {
-        String scenario = System.getProperty("perf.scenarios", "composite-unrolled").trim();
+        String scenario = System.getProperty("perf.scenarios", "composite-build").trim();
         if (scenario.isEmpty() || scenario.contains(",")) {
-            scenario = "composite-unrolled";
+            scenario = "composite-build";
         }
 
         HttpClient client = HttpClient.newBuilder()

--- a/test/perf/src/test/java/org/eclipse/mojarra/test/perf/EncodeAllBenchIT.java
+++ b/test/perf/src/test/java/org/eclipse/mojarra/test/perf/EncodeAllBenchIT.java
@@ -38,7 +38,7 @@ import org.openqa.selenium.WebDriver;
  *
  * <p>Gated behind {@code -Drender=true}. Iteration counts reuse {@code -Dperf.warmup}/{@code
  * -Dperf.runs} (defaults 50/2000); {@code -Dperf.scenarios=<one>} selects the view (default
- * composite-unrolled).
+ * composite-build).
  */
 @EnabledIfSystemProperty(named = "render", matches = "true")
 class EncodeAllBenchIT extends BaseIT {
@@ -61,9 +61,9 @@ class EncodeAllBenchIT extends BaseIT {
 
     @Test
     void renderResponse() throws Exception {
-        String scenario = System.getProperty("perf.scenarios", "composite-unrolled").trim();
+        String scenario = System.getProperty("perf.scenarios", "composite-build").trim();
         if (scenario.isEmpty() || scenario.contains(",")) {
-            scenario = "composite-unrolled";
+            scenario = "composite-build";
         }
 
         HttpClient client = HttpClient.newBuilder()

--- a/test/perf/src/test/java/org/eclipse/mojarra/test/perf/PerfBenchIT.java
+++ b/test/perf/src/test/java/org/eclipse/mojarra/test/perf/PerfBenchIT.java
@@ -125,20 +125,26 @@ class PerfBenchIT extends BaseIT {
             Map.entry("table-readonly", "table-readonly.xhtml"),
             Map.entry("repeat-readonly", "repeat-readonly.xhtml"),
             Map.entry("composite-readonly", "composite-readonly.xhtml"),
+            Map.entry("foreach-readonly", "foreach-readonly.xhtml"),
             Map.entry("viewparam-get", "viewparam-get.xhtml?id=42")));
 
-    /** Full (non-ajax) form postbacks. */
+    /** Full (non-ajax) form postbacks. The {@code *-build} scenarios are readonly (no input fields), so their
+     *  postback isolates state restore + encode from any input-processing cost. */
     private static final List<String> POSTBACK = only(List.of(
             "form-inputs",
             "form-invalid",
             "table-inputs",
             "repeat-inputs",
             "composite-inputs",
+            "foreach-inputs",
             "table-nested",
             "repeat-nested",
             "composite-nested",
-            "composite-unrolled",
-            "view-unrolled"));
+            "foreach-nested",
+            "table-build",
+            "repeat-build",
+            "composite-build",
+            "foreach-build"));
 
     /** Ajax-partial postbacks. Same body fields as their non-ajax twin plus the
      *  {@code jakarta.faces.partial.*} markers and the {@code Faces-Request} header. */
@@ -146,7 +152,12 @@ class PerfBenchIT extends BaseIT {
             "form-inputs-ajax",
             "table-inputs-ajax",
             "repeat-inputs-ajax",
-            "view-unrolled-ajax",
+            "composite-inputs-ajax",
+            "foreach-inputs-ajax",
+            "table-nested-ajax",
+            "repeat-nested-ajax",
+            "composite-nested-ajax",
+            "foreach-nested-ajax",
             "dynamic-form-ajax",
             "dynamic-toggle-ajax"));
 


### PR DESCRIPTION
Part of the #5753 perf-bench effort.

Restructures the `test/perf` bench into a clean **component-family × variant matrix**. The four component families (`table`, `repeat`, `composite`, `foreach`) now span the same six variants, so any structure can be compared against any other at matched request shape:

| family | iterator | readonly (GET) | build | inputs | nested | inputs-ajax | nested-ajax |
|---|---|:-:|:-:|:-:|:-:|:-:|:-:|
| table | `h:dataTable` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| repeat | `ui:repeat` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| composite | composite components | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| foreach | `c:forEach items` (build-time unrolled) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |

## New `build` variant

A readonly (no-input) **full postback**: empty ARV/PV/UMV, so it isolates the state-**restore** + encode path from any input processing. This is the representative postback cost for readonly content, and the postback twin of the readonly GET render (same tree → clean `buildView`-vs-`restore` A/B). `table-build`/`repeat-build` re-post the standard readonly tree; `composite-build` (the #4811 all-NamingContainer case) and `foreach-build` are the `c:forEach`-built trees.

## Renames (history preserved)

- `view-unrolled` → `foreach-build`
- `composite-unrolled` → `composite-build`
- `view-unrolled-ajax` → `foreach-inputs-ajax` (now carries inputs)

## New scenarios

`foreach-readonly`, `foreach-inputs`, `foreach-nested`, `foreach-nested-ajax`, `table-build`, `repeat-build`, `composite-inputs-ajax`, `table-nested-ajax`, `repeat-nested-ajax`, `composite-nested-ajax`.

## Wiring

- `DataBean` `unrolledRows` → `foreachRows`; sizing constants unchanged (`READONLY_ROWS` 200, `INPUT_ROWS` 35, `FOREACH_ROWS` 100, `GROUPS`×`GROUP_ROWS` 5×10).
- `numberOfLogicalViews` / `NUMBER_OF_VIEWS_IN_SESSION` 16 → 25 (14 postback + 11 ajax-postback retained views per driver loop).
- `BuildViewBench`/`EncodeAllBench` default scenario → `composite-build`.
- `index.xhtml` + `README.md` regenerated to the matrix.

Bench-only; no production code touched.

## Benchmark results (Tomcat, warmup 50 / 1000 runs, governor `performance`)

Three-way, 31 scenarios. Suite totals (summed `total_us` over the suite, seconds):

| | 4.1.9 | 4.1.10 | MyFaces 4.1.4 | 4.1.10 vs 4.1.9 | 4.1.10 vs MyFaces |
|---|--:|--:|--:|--:|--:|
| tomcat | 159.5 | 79.2 | 74.1 | **−50%** | **+7%** |

**The matrix immediately isolates where 4.1.10 still trails MyFaces: the `c:forEach`-unrolled family.** Everything else is at parity or faster.

vs MyFaces (positive = Mojarra slower):

| scenario | RV | PV | UMV | RR | total |
|---|--:|--:|--:|--:|--:|
| foreach-readonly | – | – | – | +40% | **+41%** |
| foreach-build | +8% | – | – | +62% | **+38%** |
| foreach-inputs | −7% | +56% | +81% | +20% | **+23%** |
| foreach-inputs-ajax | −5% | +56% | +80% | +15% | **+22%** |
| foreach-nested | +9% | +112% | +126% | +49% | **+53%** |
| foreach-nested-ajax | +7% | +111% | +124% | +40% | **+49%** |
| composite-build (unrolled #4811) | +6% | – | – | +53% | **+32%** |

The other three families sit at parity — several *faster* than MyFaces:

| family | representative scenarios (vs MyFaces) |
|---|---|
| table | table-nested +1% · table-build −12% · table-inputs −5% |
| repeat | repeat-nested +5% · repeat-build −10% · repeat-readonly −15% |
| composite | composite-nested +1% · composite-inputs +2% · composite-readonly −1% |

The new `build`/`readonly` isolation splits the `foreach` deficit cleanly into two independent costs, giving concrete follow-up targets:

- **encode path** — `foreach-readonly` +40% and `foreach-build` +62% RR with *no inputs*: pure encode of an unrolled tree (`composite-build` +53% RR confirms it is the unrolled-tree render, not input-specific).
- **PV/UMV state path** — appears only once inputs are present: `foreach-nested` PV +112% / UMV +126%, per-component state on the unrolled input tree, distinct from the render cost.

RESTORE is *not* the gap here (RV +7–9%, minor).

🤖 Generated with Claude Opus 4.8
