### PR TITLE
Memoize the c:forEach items expression per phase

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/IndexedValueExpression.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/IndexedValueExpression.java
@@ -49,7 +49,7 @@ public final class IndexedValueExpression extends ValueExpression {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T getValue(ELContext context) {
-        Object base = orig.getValue(context);
+        Object base = IterationBaseCache.getValue(context, orig);
         if (base != null) {
             context.setPropertyResolved(false);
             return (T) context.getELResolver().getValue(context, base, i);
@@ -64,7 +64,7 @@ public final class IndexedValueExpression extends ValueExpression {
      */
     @Override
     public void setValue(ELContext context, Object value) {
-        Object base = orig.getValue(context);
+        Object base = IterationBaseCache.getValue(context, orig);
         if (base != null) {
             context.setPropertyResolved(false);
             context.getELResolver().setValue(context, base, i, value);
@@ -78,7 +78,7 @@ public final class IndexedValueExpression extends ValueExpression {
      */
     @Override
     public boolean isReadOnly(ELContext context) {
-        Object base = orig.getValue(context);
+        Object base = IterationBaseCache.getValue(context, orig);
         if (base != null) {
             context.setPropertyResolved(false);
             return context.getELResolver().isReadOnly(context, base, i);
@@ -93,7 +93,7 @@ public final class IndexedValueExpression extends ValueExpression {
      */
     @Override
     public Class<?> getType(ELContext context) {
-        Object base = orig.getValue(context);
+        Object base = IterationBaseCache.getValue(context, orig);
         if (base != null) {
             context.setPropertyResolved(false);
             return context.getELResolver().getType(context, base, i);

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/IteratedValueExpression.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/IteratedValueExpression.java
@@ -47,7 +47,7 @@ public final class IteratedValueExpression extends ValueExpression {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T getValue(ELContext context) {
-        Collection<?> collection = (Collection<?>) orig.getValue(context);
+        Collection<?> collection = (Collection<?>) IterationBaseCache.getValue(context, orig);
         Iterator<?> iterator = collection.iterator();
         Object result = null;
         int i = start;

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/IterationBaseCache.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/IterationBaseCache.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.mojarra.facelets.tag.jstl.core;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+import jakarta.el.ELContext;
+import jakarta.el.ValueExpression;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.event.PhaseId;
+
+/**
+ * Per-phase memoization of a {@code c:forEach} <em>items</em> expression.
+ *
+ * <p>Every unrolled iteration var expression ({@link IndexedValueExpression}, {@link IteratedValueExpression},
+ * {@link MappedValueExpression}) resolves the same shared items expression ({@code orig}) to reach its element, and
+ * resolving it is the expensive part - it walks the whole EL/CDI chain (e.g. {@code #{dataBean.groups}} through the
+ * CDI/bean resolvers). Because the body is unrolled, that walk is paid once per cell per phase even though every cell
+ * of one {@code c:forEach} shares the same {@code orig} instance and the same result.
+ *
+ * <p>Within a single lifecycle phase the items collection is stable - it is only structurally replaced <em>between</em>
+ * phases (by an action), not mid-phase - so this caches {@code orig}'s value keyed by {@code orig} identity and scoped
+ * to the current {@link PhaseId}. The chain is then walked once per items expression per phase instead of once per
+ * cell, while staying live across phases: a content change made by an action is picked up by the render phase's fresh
+ * cache, and a reused component still reads current content because its var expression holds the same {@code orig}.
+ */
+final class IterationBaseCache {
+
+    private static final String KEY = "org.glassfish.mojarra.facelets.forEachBaseCache";
+
+    /** Distinguishes a cached {@code null} result from an absent entry, so a null-valued source is cached too. */
+    private static final Object NULL = new Object();
+
+    private final PhaseId phase;
+    private final Map<ValueExpression, Object> bases = new IdentityHashMap<>();
+
+    private IterationBaseCache(PhaseId phase) {
+        this.phase = phase;
+    }
+
+    /**
+     * Resolve {@code orig} against the current phase's cache, populating it on first use. Falls back to a direct,
+     * uncached resolution when there is no active lifecycle phase (nothing to key the cache by).
+     */
+    static Object getValue(ELContext elContext, ValueExpression orig) {
+        FacesContext context = FacesContext.getCurrentInstance();
+        PhaseId phase = context == null ? null : context.getCurrentPhaseId();
+        if (phase == null) {
+            return orig.getValue(elContext);
+        }
+
+        Map<Object, Object> attributes = context.getAttributes();
+        IterationBaseCache cache = (IterationBaseCache) attributes.get(KEY);
+        if (cache == null || cache.phase != phase) {
+            cache = new IterationBaseCache(phase);
+            attributes.put(KEY, cache);
+        }
+
+        Object base = cache.bases.get(orig);
+        if (base == null) {
+            base = orig.getValue(elContext);
+            cache.bases.put(orig, base == null ? NULL : base);
+            return base;
+        }
+        return base == NULL ? null : base;
+    }
+}

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/MappedValueExpression.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/jstl/core/MappedValueExpression.java
@@ -81,7 +81,7 @@ public final class MappedValueExpression extends ValueExpression {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T getValue(ELContext context) {
-        Object base = orig.getValue(context);
+        Object base = IterationBaseCache.getValue(context, orig);
         if (base != null) {
             context.setPropertyResolved(true);
             return (T) new Entry((Map<Object, Object>) base, key);
@@ -97,7 +97,7 @@ public final class MappedValueExpression extends ValueExpression {
      */
     @Override
     public void setValue(ELContext context, Object value) {
-        Object base = orig.getValue(context);
+        Object base = IterationBaseCache.getValue(context, orig);
         if (base != null) {
             context.setPropertyResolved(false);
             context.getELResolver().setValue(context, base, key, value);
@@ -111,7 +111,7 @@ public final class MappedValueExpression extends ValueExpression {
      */
     @Override
     public boolean isReadOnly(ELContext context) {
-        Object base = orig.getValue(context);
+        Object base = IterationBaseCache.getValue(context, orig);
         if (base != null) {
             context.setPropertyResolved(false);
             return context.getELResolver().isReadOnly(context, base, key);
@@ -126,7 +126,7 @@ public final class MappedValueExpression extends ValueExpression {
      */
     @Override
     public Class<?> getType(ELContext context) {
-        Object base = orig.getValue(context);
+        Object base = IterationBaseCache.getValue(context, orig);
         if (base != null) {
             context.setPropertyResolved(false);
             return context.getELResolver().getType(context, base, key);


### PR DESCRIPTION
Every unrolled c:forEach iteration var (#{row}, #{group}, #{entry}) resolves the same shared items expression to reach its element, and that resolution walks the whole EL/CDI chain (e.g. #{bean.items}). Because the body is unrolled, the walk was paid once per cell per phase, dominating PROCESS_VALIDATIONS and UPDATE_MODEL_VALUES on input-bearing c:forEach views.

Within a lifecycle phase the items collection is stable - it is only replaced between phases, by an action - so IterationBaseCache memoizes the items value keyed by the items-expression identity and scoped to the current PhaseId. The chain is then walked once per items expression per phase instead of once per cell, while staying live across phases: an action's content change is picked up by the render phase's fresh cache, and a reused component reads current content because its var expression holds the same items expression. Nothing is captured into component state, so full state saving is unaffected.

Indexed/Iterated/MappedValueExpression route orig.getValue() through the cache; ForEachHandler is unchanged.

TCK has been expanded on this via https://github.com/jakartaee/faces/pull/2198

foreach-nested (5.0, tomcat): PROCESS_VALIDATIONS 1156->593us, UPDATE_MODEL_VALUES 242->120us, RENDER_RESPONSE 1208->859us; foreach-build RENDER_RESPONSE 1212->851us - at or below MyFaces on each.

Part of #5753 