### PR TITLE
Reuse built-in by-type converters per target class

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/application/applicationimpl/InstanceFactory.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/applicationimpl/InstanceFactory.java
@@ -152,6 +152,9 @@ public class InstanceFactory {
     private final ViewMemberInstanceFactoryMetadataMap<String, Object> validatorMap;
     private final Map<Class<?>, Constructor<?>> constructorCache;
 
+    // Standard built-in (jakarta.faces.convert) by-type converters, reused per target class (see createConverter).
+    private final Map<Class<?>, Converter<?>> builtinConverterByType = new ConcurrentHashMap<>();
+
     private final Set<String> defaultValidatorIds;
     private volatile Map<String, String> defaultValidatorInfo;
 
@@ -454,6 +457,11 @@ public class InstanceFactory {
     public Converter<?> createConverter(Class<?> targetClass) {
         notNull("targetClass", targetClass);
 
+        Converter<?> cached = builtinConverterByType.get(targetClass);
+        if (cached != null) {
+            return cached;
+        }
+
         Converter<?> returnVal = CdiUtils.createConverter(getBeanManager(), targetClass);
         if (returnVal != null) {
             return returnVal;
@@ -488,9 +496,25 @@ public class InstanceFactory {
                 ((DateTimeConverter) returnVal).setTimeZone(systemTimeZone);
             }
             associate.getAnnotationManager().applyConverterAnnotations(FacesContext.getCurrentInstance(), returnVal);
+
+            // Reuse standard built-in converters per target class: the resolution walk, reflective (re)creation and
+            // annotation application are otherwise paid on every conversion.
+            if (isReusableByType(returnVal)) {
+                builtinConverterByType.put(targetClass, returnVal);
+            }
         }
 
         return returnVal;
+    }
+
+    /**
+     * A by-type converter may be reused per target class when it is one of the standard built-in converters
+     * (package {@code jakarta.faces.convert}); these are effectively immutable once resolved for a given target class
+     * (EnumConverter's target enum type and any application-scoped default time zone are fixed). Custom
+     * {@code converter-for-class} registrations are excluded as they may be stateful or scoped.
+     */
+    private static boolean isReusableByType(Converter<?> converter) {
+        return converter.getClass().getName().startsWith("jakarta.faces.convert.");
     }
 
     /*


### PR DESCRIPTION
`Application.createConverter(Class)` re-ran the CDI lookup, the type-resolution walk, reflective instantiation and annotation application on **every** call — i.e. on every by-type conversion (`Integer`, `BigDecimal`, `Boolean`, `Enum`, … resolved via `converter-for-class`).

This caches the resolved standard `jakarta.faces.convert` converter per target class. The package guard only admits the stateless built-ins; custom `converter-for-class` registrations stay on the per-call path (they may be stateful or scoped). `EnumConverter` is cached safely too — the cache is keyed by **target class**, so each enum type gets its own `EnumConverter(SomeEnum)` instance.

### Benchmark (Tomcat, 50 warmup / 1000 runs, vs MyFaces 5.0)

Measured together with the complementary `jakarta.faces-api` formatter cache (jakartaee/faces#2199) — the two are complementary; both cut render-time converter allocation. See #5753.

| phase | Mojarra 5.0 | MyFaces 5.0 | Δ |
|---|--:|--:|--:|
| RENDER_RESPONSE | 36.9s | 39.2s | **−6%** |
| suite total | 71.1s | 71.5s | **−1%** |

Render-heavy views converting currency + date on every row now beat MyFaces by −14…−18% (`table-readonly`, `repeat-readonly`, `table-build`, `repeat-build`).

🤖 Generated with Claude Opus 4.8
