### PR TITLE
Backport converter + c:forEach caching to 4.0 (#5828, #5829, jakartaee/faces#2199)

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/applicationimpl/InstanceFactory.java
+++ b/impl/src/main/java/com/sun/faces/application/applicationimpl/InstanceFactory.java
@@ -139,6 +139,9 @@ public class InstanceFactory {
     private ViewMemberInstanceFactoryMetadataMap<String, Object> validatorMap;
     private final Map<Class<?>, Constructor<?>> constructorCache;
 
+    // Standard built-in (jakarta.faces.convert) by-type converters, reused per target class (see createConverter).
+    private final Map<Class<?>, Converter> builtinConverterByType = new ConcurrentHashMap<>();
+
     private Set<String> defaultValidatorIds;
     private volatile Map<String, String> defaultValidatorInfo;
 
@@ -440,6 +443,11 @@ public class InstanceFactory {
     public Converter createConverter(Class<?> targetClass) {
         notNull("targetClass", targetClass);
 
+        Converter cached = builtinConverterByType.get(targetClass);
+        if (cached != null) {
+            return cached;
+        }
+
         Converter returnVal = CdiUtils.createConverter(getBeanManager(), targetClass);
         if (returnVal != null) {
             return returnVal;
@@ -474,9 +482,25 @@ public class InstanceFactory {
                 ((DateTimeConverter) returnVal).setTimeZone(systemTimeZone);
             }
             associate.getAnnotationManager().applyConverterAnnotations(FacesContext.getCurrentInstance(), returnVal);
+
+            // Reuse standard built-in converters per target class: the resolution walk, reflective (re)creation and
+            // annotation application are otherwise paid on every conversion.
+            if (isReusableByType(returnVal)) {
+                builtinConverterByType.put(targetClass, returnVal);
+            }
         }
 
         return returnVal;
+    }
+
+    /**
+     * A by-type converter may be reused per target class when it is one of the standard built-in converters
+     * (package {@code jakarta.faces.convert}); these are effectively immutable once resolved for a given target class
+     * (EnumConverter's target enum type and any application-scoped default time zone are fixed). Custom
+     * {@code converter-for-class} registrations are excluded as they may be stateful or scoped.
+     */
+    private static boolean isReusableByType(Converter converter) {
+        return converter.getClass().getName().startsWith("jakarta.faces.convert.");
     }
 
     /*

--- a/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/IndexedValueExpression.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/IndexedValueExpression.java
@@ -48,7 +48,7 @@ public final class IndexedValueExpression extends ValueExpression {
      */
     @Override
     public Object getValue(ELContext context) {
-        Object base = orig.getValue(context);
+        Object base = IterationBaseCache.getValue(context, orig);
         if (base != null) {
             context.setPropertyResolved(false);
             return context.getELResolver().getValue(context, base, i);
@@ -63,7 +63,7 @@ public final class IndexedValueExpression extends ValueExpression {
      */
     @Override
     public void setValue(ELContext context, Object value) {
-        Object base = orig.getValue(context);
+        Object base = IterationBaseCache.getValue(context, orig);
         if (base != null) {
             context.setPropertyResolved(false);
             context.getELResolver().setValue(context, base, i, value);
@@ -77,7 +77,7 @@ public final class IndexedValueExpression extends ValueExpression {
      */
     @Override
     public boolean isReadOnly(ELContext context) {
-        Object base = orig.getValue(context);
+        Object base = IterationBaseCache.getValue(context, orig);
         if (base != null) {
             context.setPropertyResolved(false);
             return context.getELResolver().isReadOnly(context, base, i);
@@ -92,7 +92,7 @@ public final class IndexedValueExpression extends ValueExpression {
      */
     @Override
     public Class getType(ELContext context) {
-        Object base = orig.getValue(context);
+        Object base = IterationBaseCache.getValue(context, orig);
         if (base != null) {
             context.setPropertyResolved(false);
             return context.getELResolver().getType(context, base, i);

--- a/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/IteratedValueExpression.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/IteratedValueExpression.java
@@ -46,7 +46,7 @@ public final class IteratedValueExpression extends ValueExpression {
      */
     @Override
     public Object getValue(ELContext context) {
-        Collection collection = (Collection) orig.getValue(context);
+        Collection collection = (Collection) IterationBaseCache.getValue(context, orig);
         Iterator iterator = collection.iterator();
         Object result = null;
         int i = start;

--- a/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/IterationBaseCache.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/IterationBaseCache.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.facelets.tag.jstl.core;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+import jakarta.el.ELContext;
+import jakarta.el.ValueExpression;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.event.PhaseId;
+
+/**
+ * Per-phase memoization of a {@code c:forEach} <em>items</em> expression.
+ *
+ * <p>Every unrolled iteration var expression ({@link IndexedValueExpression}, {@link IteratedValueExpression},
+ * {@link MappedValueExpression}) resolves the same shared items expression ({@code orig}) to reach its element, and
+ * resolving it is the expensive part - it walks the whole EL/CDI chain (e.g. {@code #{dataBean.groups}} through the
+ * CDI/bean resolvers). Because the body is unrolled, that walk is paid once per cell per phase even though every cell
+ * of one {@code c:forEach} shares the same {@code orig} instance and the same result.
+ *
+ * <p>Within a single lifecycle phase the items collection is stable - it is only structurally replaced <em>between</em>
+ * phases (by an action), not mid-phase - so this caches {@code orig}'s value keyed by {@code orig} identity and scoped
+ * to the current {@link PhaseId}. The chain is then walked once per items expression per phase instead of once per
+ * cell, while staying live across phases: a content change made by an action is picked up by the render phase's fresh
+ * cache, and a reused component still reads current content because its var expression holds the same {@code orig}.
+ */
+final class IterationBaseCache {
+
+    private static final String KEY = "com.sun.faces.facelets.forEachBaseCache";
+
+    /** Distinguishes a cached {@code null} result from an absent entry, so a null-valued source is cached too. */
+    private static final Object NULL = new Object();
+
+    private final PhaseId phase;
+    private final Map<ValueExpression, Object> bases = new IdentityHashMap<>();
+
+    private IterationBaseCache(PhaseId phase) {
+        this.phase = phase;
+    }
+
+    /**
+     * Resolve {@code orig} against the current phase's cache, populating it on first use. Falls back to a direct,
+     * uncached resolution when there is no active lifecycle phase (nothing to key the cache by).
+     */
+    static Object getValue(ELContext elContext, ValueExpression orig) {
+        FacesContext context = FacesContext.getCurrentInstance();
+        PhaseId phase = context == null ? null : context.getCurrentPhaseId();
+        if (phase == null) {
+            return orig.getValue(elContext);
+        }
+
+        Map<Object, Object> attributes = context.getAttributes();
+        IterationBaseCache cache = (IterationBaseCache) attributes.get(KEY);
+        if (cache == null || cache.phase != phase) {
+            cache = new IterationBaseCache(phase);
+            attributes.put(KEY, cache);
+        }
+
+        Object base = cache.bases.get(orig);
+        if (base == null) {
+            base = orig.getValue(elContext);
+            cache.bases.put(orig, base == null ? NULL : base);
+            return base;
+        }
+        return base == NULL ? null : base;
+    }
+}

--- a/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/MappedValueExpression.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/MappedValueExpression.java
@@ -80,7 +80,7 @@ public final class MappedValueExpression extends ValueExpression {
      */
     @Override
     public Object getValue(ELContext context) {
-        Object base = orig.getValue(context);
+        Object base = IterationBaseCache.getValue(context, orig);
         if (base != null) {
             context.setPropertyResolved(true);
             return new Entry((Map) base, key);
@@ -96,7 +96,7 @@ public final class MappedValueExpression extends ValueExpression {
      */
     @Override
     public void setValue(ELContext context, Object value) {
-        Object base = orig.getValue(context);
+        Object base = IterationBaseCache.getValue(context, orig);
         if (base != null) {
             context.setPropertyResolved(false);
             context.getELResolver().setValue(context, base, key, value);
@@ -110,7 +110,7 @@ public final class MappedValueExpression extends ValueExpression {
      */
     @Override
     public boolean isReadOnly(ELContext context) {
-        Object base = orig.getValue(context);
+        Object base = IterationBaseCache.getValue(context, orig);
         if (base != null) {
             context.setPropertyResolved(false);
             return context.getELResolver().isReadOnly(context, base, key);
@@ -125,7 +125,7 @@ public final class MappedValueExpression extends ValueExpression {
      */
     @Override
     public Class getType(ELContext context) {
-        Object base = orig.getValue(context);
+        Object base = IterationBaseCache.getValue(context, orig);
         if (base != null) {
             context.setPropertyResolved(false);
             return context.getELResolver().getType(context, base, key);

--- a/impl/src/main/java/jakarta/faces/convert/DateTimeConverter.java
+++ b/impl/src/main/java/jakarta/faces/convert/DateTimeConverter.java
@@ -38,6 +38,7 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQuery;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
@@ -497,14 +498,10 @@ public class DateTimeConverter implements Converter, PartialStateHolder {
                 return (String) value;
             }
 
-            // Identify the Locale to use for formatting
-            Locale locale = getLocale(context);
-
-            // Create and configure the formatter to be used
-            FormatWrapper formatter = getDateFormat(locale, false);
-            if (null != timeZone) {
-                formatter.setTimeZone(timeZone);
-            }
+            // Create and configure the formatter to be used, reused per FacesContext across equal configurations (see
+            // getCachedFormatter): it is a function of this converter's configuration only, and rebuilding it per value
+            // dominated allocation on conversion-heavy views (e.g. a per-row f:convertDateTime unrolled by c:forEach).
+            FormatWrapper formatter = getCachedFormatter(context);
 
             // Perform the requested formatting
             return formatter.format(value);
@@ -530,9 +527,65 @@ public class DateTimeConverter implements Converter, PartialStateHolder {
      *                   {@code false} if it will be used for formatting output
      * @throws ConverterException if no instance can be created
      */
-    private FormatWrapper getDateFormat(Locale locale, boolean forParsing) {
+    private static final String FORMATTER_CACHE_KEY = "jakarta.faces.convert.DateTimeConverter.formatters";
 
-        // PENDING(craigmcc) - Implement pooling if needed for performance?
+    /**
+     * Upper bound on the per-FacesContext formatter cache, kept as an LRU so a view whose converters are all
+     * differently configured cannot retain an unbounded number of formatters for the request, while a recurring working
+     * set stays cached. Normal views use only a handful of configurations.
+     */
+    private static final int FORMATTER_CACHE_LIMIT = 64;
+
+    /** Bounded, access-ordered (LRU) formatter cache stored per {@link FacesContext}. */
+    private static final class FormatterCache extends LinkedHashMap<String, FormatWrapper> {
+
+        private static final long serialVersionUID = 1L;
+
+        FormatterCache() {
+            super(16, 0.75f, true);
+        }
+
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<String, FormatWrapper> eldest) {
+            return size() > FORMATTER_CACHE_LIMIT;
+        }
+    }
+
+    /**
+     * Return the fully configured formatter for {@link #getAsString}, cached in the FacesContext attributes keyed by
+     * this converter's format-determining configuration. The formatter is a function of that configuration only, so two
+     * converters with equal configuration share one instance within a FacesContext - single-threaded, so sequential
+     * {@code format} calls are safe - turning a per-value format rebuild into a single build per configuration.
+     */
+    private FormatWrapper getCachedFormatter(FacesContext context) {
+        Locale locale = getLocale(context);
+        Map<Object, Object> attributes = context.getAttributes();
+        @SuppressWarnings("unchecked")
+        Map<String, FormatWrapper> cache = (Map<String, FormatWrapper>) attributes.get(FORMATTER_CACHE_KEY);
+        if (cache == null) {
+            cache = new FormatterCache();
+            attributes.put(FORMATTER_CACHE_KEY, cache);
+        }
+        String key = formatterKey(locale);
+        FormatWrapper formatter = cache.get(key);
+        if (formatter == null) {
+            formatter = getDateFormat(locale, false);
+            if (timeZone != null) {
+                formatter.setTimeZone(timeZone);
+            }
+            cache.put(key, formatter);
+        }
+        return formatter;
+    }
+
+    /** Key over every property {@link #getCachedFormatter} reads to build the formatter. */
+    private String formatterKey(Locale locale) {
+        return new StringBuilder(48).append(pattern).append('|').append(type).append('|').append(dateStyle).append('|')
+                .append(timeStyle).append('|').append(locale).append('|')
+                .append(timeZone == null ? null : timeZone.getID()).toString();
+    }
+
+    private FormatWrapper getDateFormat(Locale locale, boolean forParsing) {
 
         if (pattern == null && type == null) {
             throw new IllegalArgumentException("Either pattern or type must" + " be specified.");

--- a/impl/src/main/java/jakarta/faces/convert/NumberConverter.java
+++ b/impl/src/main/java/jakarta/faces/convert/NumberConverter.java
@@ -22,7 +22,9 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.text.ParseException;
+import java.util.LinkedHashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import jakarta.faces.component.PartialStateHolder;
@@ -657,15 +659,11 @@ public class NumberConverter implements Converter, PartialStateHolder {
                 return (String) value;
             }
 
-            // Identify the Locale to use for formatting
-            Locale locale = getLocale(context);
-
-            // Create and configure the formatter to be used
-            NumberFormat formatter = getNumberFormat(locale);
-            if (pattern != null && pattern.length() != 0 || "currency".equals(type)) {
-                configureCurrency(formatter);
-            }
-            configureFormatter(formatter);
+            // Create and configure the formatter to be used, reused per FacesContext across equal configurations (see
+            // getCachedFormatter): the formatter is a function of this converter's configuration only, and rebuilding
+            // it per value - a DecimalFormat plus a locale-data DecimalFormatSymbols - dominated allocation on
+            // conversion-heavy views (e.g. a per-row f:convertNumber unrolled by c:forEach).
+            NumberFormat formatter = getCachedFormatter(context);
 
             // Perform the requested formatting
             return formatter.format(value);
@@ -858,13 +856,72 @@ public class NumberConverter implements Converter, PartialStateHolder {
      * @param locale The <code>Locale</code> used to select formatting and parsing conventions
      * @throws ConverterException if no instance can be created
      */
+    private static final String FORMATTER_CACHE_KEY = "jakarta.faces.convert.NumberConverter.formatters";
+
+    /**
+     * Upper bound on the per-FacesContext formatter cache, kept as an LRU so a view whose converters are all
+     * differently configured (e.g. a per-row {@code pattern}) cannot retain an unbounded number of formatters for the
+     * request, while a recurring working set stays cached. Normal views use only a handful of configurations.
+     */
+    private static final int FORMATTER_CACHE_LIMIT = 64;
+
+    /** Bounded, access-ordered (LRU) formatter cache stored per {@link FacesContext}. */
+    private static final class FormatterCache extends LinkedHashMap<String, NumberFormat> {
+
+        private static final long serialVersionUID = 1L;
+
+        FormatterCache() {
+            super(16, 0.75f, true);
+        }
+
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<String, NumberFormat> eldest) {
+            return size() > FORMATTER_CACHE_LIMIT;
+        }
+    }
+
+    /**
+     * Return the fully configured formatter for {@link #getAsString}, cached in the FacesContext attributes keyed by
+     * this converter's format-determining configuration. The formatter is a function of that configuration only, so two
+     * converters with equal configuration share one instance within a FacesContext - single-threaded, so sequential
+     * {@code format} calls are safe - turning a per-value {@code DecimalFormat} + locale-data
+     * {@code DecimalFormatSymbols} rebuild into a single build per configuration.
+     */
+    private NumberFormat getCachedFormatter(FacesContext context) throws Exception {
+        Locale locale = getLocale(context);
+        Map<Object, Object> attributes = context.getAttributes();
+        @SuppressWarnings("unchecked")
+        Map<String, NumberFormat> cache = (Map<String, NumberFormat>) attributes.get(FORMATTER_CACHE_KEY);
+        if (cache == null) {
+            cache = new FormatterCache();
+            attributes.put(FORMATTER_CACHE_KEY, cache);
+        }
+        String key = formatterKey(locale);
+        NumberFormat formatter = cache.get(key);
+        if (formatter == null) {
+            formatter = getNumberFormat(locale);
+            if (pattern != null && pattern.length() != 0 || "currency".equals(type)) {
+                configureCurrency(formatter);
+            }
+            configureFormatter(formatter);
+            cache.put(key, formatter);
+        }
+        return formatter;
+    }
+
+    /** Key over every property {@link #getCachedFormatter} reads to build the formatter. */
+    private String formatterKey(Locale locale) {
+        return new StringBuilder(64).append(pattern).append('|').append(type).append('|').append(locale).append('|')
+                .append(currencyCode).append('|').append(currencySymbol).append('|').append(groupingUsed).append('|')
+                .append(minIntegerDigits).append('|').append(maxIntegerDigits).append('|').append(minFractionDigits)
+                .append('|').append(maxFractionDigits).toString();
+    }
+
     private NumberFormat getNumberFormat(Locale locale) {
 
         if (pattern == null && type == null) {
             throw new IllegalArgumentException("Either pattern or type must" + " be specified.");
         }
-
-        // PENDING(craigmcc) - Implement pooling if needed for performance?
 
         // If pattern is specified, type is ignored
         if (pattern != null) {


### PR DESCRIPTION
Backports three 5.0 converter/`c:forEach` perf changes to 4.0. All land in the `impl` module (on 4.x `jakarta.faces.*` lives in-tree). Hand-ported due to the 5.0→4.0 differences (`org.glassfish.mojarra` → `com.sun.faces`, split-out faces API → in-tree, raw converter types); behavior is identical to the 5.0 originals.

- **#5828** — memoize the `c:forEach` *items* expression per phase (`IterationBaseCache` + `Indexed`/`Iterated`/`MappedValueExpression` routing).
- **#5829** — reuse built-in by-type converters per target class (`InstanceFactory.createConverter(Class)`).
- **jakartaee/faces#2199** — cache `NumberConverter`/`DateTimeConverter` formatters per `FacesContext` in `getAsString`, and retire the long-pending `PENDING(craigmcc) - Implement pooling` marker.

The jakartaee/faces#2199 **TCK test** is not part of this backport — it lives in jakartaee/faces.

`impl` builds green (JDK 17, release 11). Refs #5753.

🤖 Generated with Claude Opus 4.8
