### PR TITLE
Add missing f:convertDateTime to the shared form-fields date input

### DIFF
--- a/test/perf/src/main/webapp/WEB-INF/includes/form-fields.xhtml
+++ b/test/perf/src/main/webapp/WEB-INF/includes/form-fields.xhtml
@@ -55,8 +55,10 @@
                 <f:convertNumber type="currency" currencyCode="EUR"/>
             </h:inputText>
 
-            <h:outputLabel for="date" value="Date (yyyy-MM-dd)"/>
-            <h:inputText id="date" value="#{formBean.date}"/>
+            <h:outputLabel for="date" value="Date"/>
+            <h:inputText id="date" value="#{formBean.date}">
+                <f:convertDateTime type="localDate"/>
+            </h:inputText>
 
             <h:outputLabel for="active" value="Active"/>
             <h:selectBooleanCheckbox id="active" value="#{formBean.active}"/>


### PR DESCRIPTION
Completes #5830. `form-inputs`, `form-inputs-ajax` and `form-invalid` share `WEB-INF/includes/form-fields.xhtml`, whose `LocalDate` date input was left without an explicit converter. Faces has no built-in by-type converter for `java.time.LocalDate`, so — unlike the table/repeat/foreach and `cc/inputs` scenarios that #5830 wrapped — that field never exercised the `DateTimeConverter` path; it only rendered via `LocalDate.toString()`.

It also meant the form postback wasn't a clean happy path: with no converter, `getConvertedValue` returned the submitted String unchanged, then `updateModel` failed to coerce String→`LocalDate` (no `PropertyEditor`) → a caught `ELException` + `validationFailed()`, silent in Production stage.

Adds `<f:convertDateTime type="localDate">` to match, and drops the now-inaccurate "(yyyy-MM-dd)" label (the `localDate` type renders the locale-default format). Benchmark WAR only (`test/perf`), no impl change.

Refs #5753.

🤖 Generated with Claude Opus 4.8
