### PR TITLE
Backport #5835 to 4.0: index the Facelets tag-id lookup on refresh

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentSupport.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentSupport.java
@@ -21,6 +21,7 @@ import static com.sun.faces.config.WebConfiguration.BooleanWebContextInitParamet
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -78,6 +79,10 @@ public final class ComponentSupport {
     public static final String MARK_CREATED_REMOVED = StateContext.class.getName() + "_MARK_CREATED_REMOVED";
 
     private final static String IMPLICIT_PANEL = "com.sun.faces.facelets.IMPLICIT_PANEL";
+
+    // Request-scoped IdentityHashMap<UIComponent, Object[]{index, generation}> memoizing each refreshed parent's
+    // MARK_CREATED -> component index for findChildByTagIdIndexed. Lives for the build; keyed by parent identity.
+    private final static String REFRESH_INDEX = "com.sun.faces.facelets.refreshIndex";
 
     /**
      * Key to a FacesContext scoped Map where the keys are UIComponent instances and the values are Tag instances.
@@ -240,7 +245,72 @@ public final class ComponentSupport {
         if (context.getAttributes().get(BUILDING_FRESH_SUBTREE) == Boolean.TRUE) {
             return null;
         }
-        return findChildByTagIdFullStateSaving(context, parent, id);
+        return findChildByTagIdIndexed(context, parent, id);
+    }
+
+    /**
+     * Indexed variant of the refresh-time tag-id lookup. A parent's body applies one child tag after another, each
+     * calling this for a distinct id; the plain scan re-reads every sibling's MARK_CREATED (a string-keyed
+     * AttributesMap.get) on every call, so reconciling a K-child parent costs O(K^2) map reads. Instead build a
+     * MARK_CREATED -> component index once per parent and look up in O(1). The index is request-scoped and guarded
+     * by the parent's child+facet count: a body that creates a new child (count grows) rebuilds it, so it can never
+     * return a stale or detached component. The facetName fast-path and coverage mirror
+     * {@link #findChildByTagIdFullStateSaving} exactly.
+     */
+    private static UIComponent findChildByTagIdIndexed(FacesContext context, UIComponent parent, String id) {
+        String facetName = getFacetName(parent);
+        if (facetName != null) {
+            UIComponent facet = parent.getFacet(facetName);
+            // A facet name without a matching facet occurs with composite-component facets; fall through to the index.
+            if (facet != null && id.equals(facet.getAttributes().get(MARK_CREATED))) {
+                return facet;
+            }
+        }
+        return refreshIndex(context, parent).get(id);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, UIComponent> refreshIndex(FacesContext context, UIComponent parent) {
+        Map<UIComponent, Object[]> cache = (Map<UIComponent, Object[]>) context.getAttributes().get(REFRESH_INDEX);
+        if (cache == null) {
+            cache = new IdentityHashMap<>();
+            context.getAttributes().put(REFRESH_INDEX, cache);
+        }
+        int generation = parent.getChildCount() + parent.getFacetCount();
+        Object[] entry = cache.get(parent);
+        if (entry == null || (Integer) entry[1] != generation) {
+            entry = new Object[] { buildTagIdIndex(parent), generation };
+            cache.put(parent, entry);
+        }
+        return (Map<String, UIComponent>) entry[0];
+    }
+
+    private static Map<String, UIComponent> buildTagIdIndex(UIComponent parent) {
+        Map<String, UIComponent> index = new HashMap<>();
+        if (parent.getFacetCount() > 0) {
+            for (UIComponent facet : parent.getFacets().values()) {
+                indexTagId(index, facet);
+            }
+        }
+        List<UIComponent> children = parent.getChildren();
+        for (int i = 0, len = children.size(); i < len; i++) {
+            UIComponent c = children.get(i);
+            indexTagId(index, c);
+            if (c instanceof UIPanel && c.getAttributes().containsKey(IMPLICIT_PANEL)) {
+                for (UIComponent c2 : c.getChildren()) {
+                    indexTagId(index, c2);
+                }
+            }
+        }
+        return index;
+    }
+
+    private static void indexTagId(Map<String, UIComponent> index, UIComponent c) {
+        String cid = (String) c.getAttributes().get(MARK_CREATED);
+        if (cid != null) {
+            // First put wins, matching the scan's facets-then-children, top-to-bottom first-match order.
+            index.putIfAbsent(cid, c);
+        }
     }
 
     private static UIComponent findChildByTagIdFullStateSaving(FacesContext context, UIComponent parent, String id) {

--- a/test/perf/src/test/java/org/eclipse/mojarra/test/perf/PerfBenchIT.java
+++ b/test/perf/src/test/java/org/eclipse/mojarra/test/perf/PerfBenchIT.java
@@ -206,15 +206,26 @@ class PerfBenchIT extends BaseIT {
         get(client, "perf-stats?reset=1");
 
         long startWall = System.nanoTime();
-        for (int i = 0; i < RUNS; i++) {
-            for (String url : GET_ONLY.values()) {
+        // Block-wise measurement: run each scenario RUNS times back-to-back rather than round-robin, so its
+        // code+data stay cache-resident within its block. This isolates intrinsic per-phase cost from the
+        // cross-scenario cache interleaving. Warmup above stays round-robin so shared lifecycle code is still compiled against
+        // every scenario's types (realistic mixed JIT state). Each form's ViewState went stale during the prior
+        // block, so re-GET a live ViewState at the start of each block before posting (never submit an expired one).
+        for (String url : GET_ONLY.values()) {
+            for (int i = 0; i < RUNS; i++) {
                 get(client, url);
             }
-            for (FormSpec form : forms.values()) {
-                postAndRefresh(client, form);
+        }
+        for (Map.Entry<String, FormSpec> entry : forms.entrySet()) {
+            refreshViewState(client, entry.getKey(), entry.getValue());
+            for (int i = 0; i < RUNS; i++) {
+                postAndRefresh(client, entry.getValue());
             }
-            for (FormSpec form : ajaxForms.values()) {
-                ajaxPostAndRefresh(client, form);
+        }
+        for (Map.Entry<String, FormSpec> entry : ajaxForms.entrySet()) {
+            refreshViewState(client, entry.getKey(), entry.getValue());
+            for (int i = 0; i < RUNS; i++) {
+                ajaxPostAndRefresh(client, entry.getValue());
             }
         }
         long elapsedMs = (System.nanoTime() - startWall) / 1_000_000L;
@@ -257,6 +268,20 @@ class PerfBenchIT extends BaseIT {
     private void postAndRefresh(HttpClient client, FormSpec form) throws IOException, InterruptedException {
         String body = post(client, form);
         Matcher vs = VIEW_STATE.matcher(body);
+        if (vs.find()) {
+            form.fields.put("jakarta.faces.ViewState", vs.group(1) != null ? vs.group(1) : vs.group(2));
+        }
+    }
+
+    /**
+     * Re-GET the scenario page to install a live ViewState into the form: in the block-wise measurement loop a
+     * form's stored ViewState goes stale (and, under server-side state saving, gets evicted) while the previous
+     * scenario's block runs, so the block's first post would otherwise submit an expired ViewState. Only the
+     * ViewState is replaced; the form's input values (including injected invalids) are left intact.
+     */
+    private void refreshViewState(HttpClient client, String scenario, FormSpec form) throws IOException, InterruptedException {
+        String html = get(client, scenario + ".xhtml");
+        Matcher vs = VIEW_STATE.matcher(html);
         if (vs.find()) {
             form.fields.put("jakarta.faces.ViewState", vs.group(1) != null ? vs.group(1) : vs.group(2));
         }


### PR DESCRIPTION
Backport of #5835 to the 4.0 branch.

## Index the Facelets tag-id lookup on refresh

On a partial-state-saving postback, `buildView` re-applies the Facelet to reconcile the existing tree: each child tag calls `ComponentSupport.findChildByTagId` to locate its previously-created component. That method scanned the parent's children linearly, re-reading every sibling's `MARK_CREATED` via `getAttributes().get(...)` (a string-keyed `AttributesMap`/`HashMap` lookup) on every call — so reconciling a K-child parent costs **O(K²)** map reads, and it was a top contributor to `AttributesMap`/string-hash traffic in restore profiling.

Build a `MARK_CREATED → component` index once per parent and look it up in O(1). The index is:

- **request-scoped**, in an `IdentityHashMap` keyed by parent identity;
- **generation-guarded** by the parent's child + facet count, so a body that creates a new child during apply rebuilds it — it can never return a stale or detached component.

The `facetName` fast-path and coverage (facets, children, implicit-panel grandchildren, first-match order) **mirror the original scan exactly**; the `BUILDING_FRESH_SUBTREE` gate still bypasses it for fresh builds, and the composite `findChildByTagIdDeep` path keeps the raw scan. So this is behavior-identical, only faster on the hot refresh path.

## Measure each perf scenario block-wise instead of round-robin

Run each scenario `RUNS` times back-to-back so it stays cache-resident within its block, yielding intrinsic per-phase cost. Warmup stays round-robin so shared lifecycle code is still compiled against every scenario's types. Each block re-GETs a live ViewState before posting: the stored one goes stale (and, under server-side state saving, is evicted) while the previous block runs.

## Backport notes

Straight port; adapted only for 4.0's differences — the `com.sun.faces.facelets.*` constant prefix (vs `org.glassfish.mojarra.facelets.*`) and the `org.eclipse.mojarra.test.perf` perf-test package.

- `impl` and `test/perf` both compile clean on JDK 17.
- Refs #5753

🤖 Generated with Claude Opus 4.8
