### PR TITLE
Backport jakartaee/faces#2201 to 4.0: app-scope java.time formatters

### DIFF
--- a/impl/src/main/java/jakarta/faces/convert/DateTimeConverter.java
+++ b/impl/src/main/java/jakarta/faces/convert/DateTimeConverter.java
@@ -37,6 +37,7 @@ import java.time.format.ResolverStyle;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQuery;
+import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Locale;
@@ -550,15 +551,55 @@ public class DateTimeConverter implements Converter, PartialStateHolder {
 
     /**
      * Return the fully configured formatter for {@link #getAsString} ({@code forParsing == false}) or {@link #getAsObject}
-     * ({@code forParsing == true}), cached in the FacesContext attributes keyed by this converter's format-determining
-     * configuration plus {@code forParsing}. The formatter is a function of those inputs only, so two converters with equal
-     * configuration share one instance within a FacesContext - single-threaded, so sequential {@code format}/{@code parse}
-     * calls are safe - turning a per-value formatter rebuild into a single build per configuration. Parser and formatter
-     * are cached separately because they diverge for the java.time local/offset/zoned types (the parser normalizes
-     * fixed-width whitespace).
+     * ({@code forParsing == true}). The java.time-backed formatters (the {@code localDate}/{@code localDateTime}/{@code
+     * localTime}/{@code offsetTime}/{@code offsetDateTime}/{@code zonedDateTime} types) are immutable and thread-safe, so
+     * they are cached once per application across requests (see {@link #getApplicationCachedFormatter}); the legacy
+     * {@link DateFormat}-backed formatters are mutable, so they stay in a per-{@link FacesContext} cache (see
+     * {@link #getRequestCachedFormatter}).
      */
     private FormatWrapper getCachedFormatter(FacesContext context, boolean forParsing) {
         Locale locale = getLocale(context);
+        if (type != null && JAVA_TIME_TYPES.containsKey(type)) {
+            return getApplicationCachedFormatter(context, locale, forParsing);
+        }
+        return getRequestCachedFormatter(context, locale, forParsing);
+    }
+
+    /**
+     * Resolve an immutable java.time formatter from a cache shared across the whole application. {@link DateTimeFormatter}
+     * is immutable and thread-safe and, unlike the {@link DateFormat} path, ignores {@link #timeZone} (the offset/zoned
+     * types carry their zone in the parsed text), so a single instance is safely reused by every request and converter -
+     * a flat form's one date field no longer rebuilds its formatter each request. Bounded, so an application using many
+     * distinct configurations cannot retain formatters without limit.
+     */
+    private FormatWrapper getApplicationCachedFormatter(FacesContext context, Locale locale, boolean forParsing) {
+        Map<String, Object> applicationMap = context.getExternalContext().getApplicationMap();
+        @SuppressWarnings("unchecked")
+        Map<String, FormatWrapper> cache = (Map<String, FormatWrapper>) applicationMap.get(FORMATTER_CACHE_KEY);
+        if (cache == null) {
+            // Access-synchronized: the access-ordered LRU is structurally mutated on get, and this cache is shared across
+            // request threads. A concurrent first use may build two maps and lose one put; harmless - the losing entries
+            // are simply rebuilt.
+            cache = Collections.synchronizedMap(new FormatterCache());
+            applicationMap.put(FORMATTER_CACHE_KEY, cache);
+        }
+        String key = formatterKey(locale, forParsing);
+        FormatWrapper formatter = cache.get(key);
+        if (formatter == null) {
+            formatter = getDateFormat(locale, forParsing);
+            cache.put(key, formatter);
+        }
+        return formatter;
+    }
+
+    /**
+     * Resolve a mutable {@link DateFormat}-backed formatter from the per-{@link FacesContext} cache, keyed by this
+     * converter's format-determining configuration plus {@code forParsing}, building it once per distinct configuration.
+     * Two converters with equal configuration share one instance within a FacesContext - single-threaded, so sequential
+     * {@code format}/{@code parse} calls are safe - so an unrolled view (a per-row {@code f:convertDateTime} multiplied by
+     * {@code c:forEach}) builds the formatter once rather than per row, even though each row has its own converter instance.
+     */
+    private FormatWrapper getRequestCachedFormatter(FacesContext context, Locale locale, boolean forParsing) {
         Map<Object, Object> attributes = context.getAttributes();
         @SuppressWarnings("unchecked")
         Map<String, FormatWrapper> cache = (Map<String, FormatWrapper>) attributes.get(FORMATTER_CACHE_KEY);
@@ -708,8 +749,27 @@ public class DateTimeConverter implements Converter, PartialStateHolder {
     }
 
     private static String normalizeWhitespace(CharSequence text) {
+        if (!mayContainFixedOrZeroWidthWhitespace(text)) {
+            return text.toString();
+        }
         String normalized = FIXED_WIDTH_WHITESPACE.matcher(text).replaceAll(" ");
         return ZERO_WIDTH_WHITESPACE.matcher(normalized).replaceAll("");
+    }
+
+    /**
+     * Fast pre-check for {@link #normalizeWhitespace}: every code point either {@link #FIXED_WIDTH_WHITESPACE} or
+     * {@link #ZERO_WIDTH_WHITESPACE} can match is at or above {@code U+00A0}, so text whose characters are all below that
+     * (all ASCII input, e.g. {@code "Jul 8, 2026"}) cannot match either and needs no normalization. Skips the two
+     * {@link java.util.regex.Matcher} allocations plus the regex scan on the hot per-value parse path. Keep the lower
+     * bound in sync should either pattern ever gain a lower code point.
+     */
+    private static boolean mayContainFixedOrZeroWidthWhitespace(CharSequence text) {
+        for (int i = 0, length = text.length(); i < length; i++) {
+            if (text.charAt(i) >= '\u00a0') {
+                return true;
+            }
+        }
+        return false;
     }
 
    private static FormatStyle getFormatStyle(String name) {

--- a/impl/src/test/java/jakarta/faces/convert/DateTimeConverterTest.java
+++ b/impl/src/test/java/jakarta/faces/convert/DateTimeConverterTest.java
@@ -26,11 +26,14 @@ import java.time.chrono.IsoChronology;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.FormatStyle;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 import jakarta.faces.application.Application;
 import jakarta.faces.component.UIPanel;
 import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
 
 import org.junit.jupiter.api.AfterEach;
@@ -55,9 +58,13 @@ public class DateTimeConverterTest {
         facesContext = Mockito.mock(FacesContext.class);
         UIViewRoot viewRoot = Mockito.mock(UIViewRoot.class);
         Application application = Mockito.mock(Application.class);
+        ExternalContext externalContext = Mockito.mock(ExternalContext.class);
+        Map<String, Object> applicationMap = new HashMap<>();
 
         Mockito.when(facesContext.getViewRoot()).thenReturn(viewRoot);
         Mockito.when(facesContext.getApplication()).thenReturn(application);
+        Mockito.when(facesContext.getExternalContext()).thenReturn(externalContext);
+        Mockito.when(externalContext.getApplicationMap()).thenReturn(applicationMap);
         Mockito.when(viewRoot.createUniqueId()).thenReturn("test");
         Mockito.when(viewRoot.getLocale()).thenReturn(Locale.US);
 


### PR DESCRIPTION
Backport of jakartaee/faces#2201 to the 4.0 in-tree `jakarta.faces` API.

## What

`DateTimeConverter.getAsString` cached its formatter only per `FacesContext`, so a flat form with a single date field rebuilt the java.time formatter on every request rather than reusing one across requests.

## Change

The java.time formatters — the `localDate`, `localDateTime`, `localTime`, `offsetTime`, `offsetDateTime` and `zonedDateTime` types — are backed by an immutable, thread-safe `DateTimeFormatter` and ignore the converter `timeZone`, so a single instance is safely shared across requests. These are now resolved from a bounded, access-ordered LRU held in the application map.

The legacy `java.text.DateFormat`-backed formatters (`date` / `time` / `both`) are mutable and not thread-safe, so they stay in the existing per-`FacesContext` cache. Parser and formatter remain keyed separately.

Additionally, `normalizeWhitespace` gets a fast pre-check: it scans for a character at or above `U+00A0` and skips the two regex replacements when none is present (all-ASCII input, the common case).

## Issue #5399 — no regression

Both the fixed-width and zero-width whitespace patterns only match code points at or above `U+00A0`, so the guard is behavior-neutral: the fixed-width whitespace normalization added for #5399 still runs whenever such a character is present, and its parsing is unchanged.

Note that _before_ the issue 5399 changes, the formatters were cached in JDK itself. Only since issue 5399 the formatters were manually built and hence JDK-managed cache couldn't be used and hence the performance penalty.

## Testing

`DateTimeConverterTest` (the issue 5399 whitespace round-trips) is green on JDK 21; its mock `FacesContext` now supplies an `ExternalContext` and application map for the application-scoped cache.

Refs #5753

🤖 Generated with Claude Opus 4.8
