### PR TITLE
Fix #5837 render event handler attribute once when set via expression

### DIFF
--- a/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
@@ -311,7 +311,7 @@ public class RenderKitUtils {
             behaviors = null;
         }
 
-        renderPassThruAttributesInternal(context, writer, component, attributes, behaviors);
+        renderPassThruAttributesInternal(context, writer, component, attributes, behaviors, null);
     }
 
     /**
@@ -371,7 +371,7 @@ public class RenderKitUtils {
             }
         }
 
-        renderPassThruAttributesInternal(context, writer, component, attributes, behaviors);
+        renderPassThruAttributesInternal(context, writer, component, attributes, behaviors, defaultDomEvent);
 
         if ("valueChange".equals(defaultComponentEvent)) {
             renderValueChangeEventListener(context, component, clientId, defaultComponentEvent, defaultDomEvent, hasValueChangeBehavior, incExec);
@@ -379,7 +379,7 @@ public class RenderKitUtils {
     }
 
     private static void renderPassThruAttributesInternal(FacesContext context, ResponseWriter writer, UIComponent component,
-            Attribute[] attributes, Map<String, List<ClientBehavior>> behaviors) throws IOException {
+            Attribute[] attributes, Map<String, List<ClientBehavior>> behaviors, String defaultDomEvent) throws IOException {
 
         assert null != writer;
         assert null != component;
@@ -390,15 +390,21 @@ public class RenderKitUtils {
 
         List<String> setAttributes = getAttributesThatAreSet(component);
 
+        // The handler attribute of the default DOM event (e.g. "onclick" for "click") is rendered separately by the
+        // caller through renderOnclickEventListener/renderValueChangeEventListener, which chain in any behavior and
+        // submit scripts. Skip it here so it is not additionally emitted as a raw attribute; that would duplicate it
+        // when it was set through a (non-literal) expression, as such attributes end up in getAttributesThatAreSet.
+        String excludedEventAttribute = defaultDomEvent != null ? BEHAVIOR_EVENT_ATTRIBUTE_PREFIX + defaultDomEvent : null;
+
         if (canBeOptimized(component, behaviors)) {
             // Iterates only the attributes actually set (none => renders nothing but the optional single behavior),
             // instead of the unoptimized path's reflective read of every known attribute.
-            renderPassThruAttributesOptimized(context, writer, component, attributes, setAttributes, behaviors);
+            renderPassThruAttributesOptimized(context, writer, component, attributes, setAttributes, behaviors, excludedEventAttribute);
         } else {
             // this block should only be hit by custom components leveraging
             // the RI's rendering code, or in cases where we have behaviors
             // attached to multiple events. We make no assumptions and loop through
-            renderPassThruAttributesUnoptimized(context, writer, component, attributes, setAttributes, behaviors);
+            renderPassThruAttributesUnoptimized(context, writer, component, attributes, setAttributes, behaviors, excludedEventAttribute);
         }
     }
 
@@ -684,7 +690,7 @@ public class RenderKitUtils {
      * @throws IOException if an error occurs during the write
      */
     private static void renderPassThruAttributesOptimized(FacesContext context, ResponseWriter writer, UIComponent component, Attribute[] knownAttributes,
-            List<String> setAttributes, Map<String, List<ClientBehavior>> behaviors) throws IOException {
+            List<String> setAttributes, Map<String, List<ClientBehavior>> behaviors, String excludedEventAttribute) throws IOException {
 
         // We should only come in here if we've got zero or one behavior event
         assert behaviors != null && behaviors.size() < 2;
@@ -695,6 +701,10 @@ public class RenderKitUtils {
         boolean isXhtml = RIConstants.XHTML_CONTENT_TYPE.equals(writer.getContentType());
         Map<String, Object> attrMap = component.getAttributes();
         for (String name : setAttributes) {
+
+            if (name.equals(excludedEventAttribute)) {
+                continue;
+            }
 
             // Note that this search can be optimized by switching from
             // an array to a Map<String, Attribute>. This would change
@@ -775,7 +785,7 @@ public class RenderKitUtils {
      * @throws IOException if an error occurs during the write
      */
     private static void renderPassThruAttributesUnoptimized(FacesContext context, ResponseWriter writer, UIComponent component, Attribute[] knownAttributes,
-            List<String> setAttributes, Map<String, List<ClientBehavior>> behaviors) throws IOException {
+            List<String> setAttributes, Map<String, List<ClientBehavior>> behaviors, String excludedEventAttribute) throws IOException {
 
         boolean isXhtml = RIConstants.XHTML_CONTENT_TYPE.equals(writer.getContentType());
 
@@ -790,6 +800,11 @@ public class RenderKitUtils {
 
         for (Attribute attribute : knownAttributes) {
             String attrName = attribute.getName();
+            if (attrName.equals(excludedEventAttribute)) {
+                // Skipping before the remove() below leaves the excluded event in behaviorEventNames, so the second
+                // loop must skip it too; otherwise it would re-emit the handler the caller renders separately.
+                continue;
+            }
             String[] events = attribute.getEvents();
             String eventName = events != null && events.length > 0 ? events[0] : null;
             renderPassthruAttribute(context, writer, component, behaviors, isXhtml, attrMap, attrName, eventName);
@@ -797,6 +812,9 @@ public class RenderKitUtils {
         }
 
         for (String eventName : behaviorEventNames) {
+            if ((BEHAVIOR_EVENT_ATTRIBUTE_PREFIX + eventName).equals(excludedEventAttribute)) {
+                continue;
+            }
             renderPassthruAttribute(context, writer, component, behaviors, isXhtml, attrMap, BEHAVIOR_EVENT_ATTRIBUTE_PREFIX + eventName, eventName);
         }
     }

--- a/test/issue5837/pom.xml
+++ b/test/issue5837/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.mojarra.test</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.0.19-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>issue5837</artifactId>
+    <packaging>war</packaging>
+
+    <name>Mojarra ${project.version} - INTEGRATION TESTS - ${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.mojarra.test</groupId>
+            <artifactId>base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/test/issue5837/src/main/java/org/eclipse/mojarra/test/issue5837/Issue5837.java
+++ b/test/issue5837/src/main/java/org/eclipse/mojarra/test/issue5837/Issue5837.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.eclipse.mojarra.test.issue5837;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class Issue5837 {
+
+    public String getFoo() {
+        return "bar";
+    }
+}

--- a/test/issue5837/src/main/webapp/WEB-INF/beans.xml
+++ b/test/issue5837/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/test/issue5837/src/main/webapp/WEB-INF/web.xml
+++ b/test/issue5837/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+    version="5.0"
+>
+    <servlet>
+        <servlet-name>facesServlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>facesServlet</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/test/issue5837/src/main/webapp/issue5837.xhtml
+++ b/test/issue5837/src/main/webapp/issue5837.xhtml
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="en"
+    xmlns:f="jakarta.faces.core"
+    xmlns:h="jakarta.faces.html"
+>
+    <h:head>
+        <title>issue5837</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <h:commandLink id="commandLink" value="commandLink" onclick="commandLinkFn('#{issue5837.foo}');" />
+            <h:commandButton id="commandButton" value="commandButton" onclick="commandButtonFn('#{issue5837.foo}');" />
+            <h:selectBooleanCheckbox id="checkbox" onclick="checkboxFn('#{issue5837.foo}');" />
+            <h:inputText id="input" onchange="inputFn('#{issue5837.foo}');" />
+
+            <!-- Control: a literal (non-EL) onclick was never affected; must stay single. -->
+            <h:commandLink id="commandLinkLiteral" value="commandLinkLiteral" onclick="commandLinkLiteralFn('bar');" />
+        </h:form>
+    </h:body>
+</html>

--- a/test/issue5837/src/test/java/org/eclipse/mojarra/test/issue5837/Issue5837IT.java
+++ b/test/issue5837/src/test/java/org/eclipse/mojarra/test/issue5837/Issue5837IT.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package org.eclipse.mojarra.test.issue5837;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.mojarra.test.base.BaseIT;
+import org.junit.jupiter.api.Test;
+
+class Issue5837IT extends BaseIT {
+
+    /**
+     * A DOM event handler attribute set via a (non-literal) expression must be rendered exactly once, even when the
+     * renderer handles that event specially (chained submit/behavior script). Regression from #5723.
+     *
+     * https://github.com/eclipse-ee4j/mojarra/issues/5837
+     */
+    @Test
+    void testEventHandlerAttributeRenderedOnce() {
+        String body = getResponseBody("issue5837.xhtml");
+
+        assertEquals(1, countAttributeInTag(body, "form:commandLink", "onclick"), body);
+        assertEquals(1, countAttributeInTag(body, "form:commandButton", "onclick"), body);
+        assertEquals(1, countAttributeInTag(body, "form:checkbox", "onclick"), body);
+        assertEquals(1, countAttributeInTag(body, "form:input", "onchange"), body);
+        assertEquals(1, countAttributeInTag(body, "form:commandLinkLiteral", "onclick"), body);
+    }
+
+    /**
+     * Counts how many times the given attribute occurs in the opening tag of the element with the given id.
+     */
+    private static int countAttributeInTag(String body, String id, String attribute) {
+        int idIndex = body.indexOf("id=\"" + id + "\"");
+        if (idIndex == -1) {
+            throw new IllegalStateException("No element with id " + id + " in response:\n" + body);
+        }
+
+        int tagStart = body.lastIndexOf('<', idIndex);
+        int tagEnd = body.indexOf('>', idIndex);
+        String tag = body.substring(tagStart, tagEnd);
+
+        int count = 0;
+        for (int from = tag.indexOf(attribute + "="); from != -1; from = tag.indexOf(attribute + "=", from + 1)) {
+            count++;
+        }
+        return count;
+    }
+}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -56,6 +56,7 @@
         <module>issue5676</module>
         <module>issue5750</module>
         <module>issue5772</module>
+        <module>issue5837</module>
         <module>perf</module>
     </modules>
 


### PR DESCRIPTION
Fixes #5837.

### Problem

Since 4.1.9 an `on*` event handler containing an expression is rendered **twice** on `h:commandLink`:

```html
<a id="j_idt10" href="#"
   onclick="downloadBinary('bar');"
   onclick="faces.util.chain(this,event,'downloadBinary(\'bar\');','mojarra.cljs(...)');event.preventDefault()">...</a>
```

### Root cause

An `on*` handler set through a **non-literal** expression is recorded in `attributesThatAreSet` (`UIComponent.setValueExpression`), so `RenderKitUtils.renderPassThruAttributesOptimized` emits it as a raw attribute — while the renderer *also* emits it, chained with the submit/behavior script, via `renderOnclickEventListener` / `renderValueChangeEventListener`. Hence the duplicate.

Regression from #5723, which moved the non-CSP handler render in front of the `</a>` close (previously it was emitted after the element and silently dropped).

A **literal** handler is unaffected because its setter path does not record it in `attributesThatAreSet`, so the optimized pass-thru never emits it.

Confirmed to affect `h:commandLink`, `h:commandButton`, `h:selectBooleanCheckbox` (`onclick`) and `h:inputText` / `h:inputTextarea` (`onchange`) — every renderer that passes a `defaultDomEvent` to `renderPassThruAttributes` and renders that event's handler separately.

### Fix

Thread the caller's `defaultDomEvent` into `renderPassThruAttributesInternal` and skip the `"on" + defaultDomEvent` attribute in both the optimized and unoptimized pass-thru loops. That attribute is always rendered separately by the caller (`renderOnclickEventListener` for command/passthrough components, `renderValueChangeEventListener` for value-change components), so it is never dropped. The no-event overload passes `null` and skips nothing.

As a side benefit this also suppresses a raw inline `onclick` that leaked under CSP, and a latent duplication on the rare unoptimized (2+ behaviors) path.

### Tests

New `test/issue5837` IT asserts each of the four affected components renders its handler exactly once, with a literal-`onclick` control guarding against over-fixing to zero. Red before the fix (`expected: <1> but was: <2>`), green after. Regression ITs `issue5606`, `issue5741` and `csp`/`Spec1590` remain green.

🤖 Generated with Claude Opus 4.8
