### PR TITLE
test/perf: share one input set across scenarios; per-field messages + typed form fields

### DIFF
--- a/test/perf/src/main/java/org/eclipse/mojarra/test/perf/beans/FormBean.java
+++ b/test/perf/src/main/java/org/eclipse/mojarra/test/perf/beans/FormBean.java
@@ -160,7 +160,7 @@ public class FormBean implements Serializable {
     public static class Address implements Serializable {
         private static final long serialVersionUID = 1L;
         private String street = "Main Street";
-        private String houseNumber = "42";
+        private Integer houseNumber = 42;
         private String addition = "B";
         private String postalCode = "1000 AA";
         private String city = "Amsterdam";
@@ -169,8 +169,8 @@ public class FormBean implements Serializable {
 
         public String getStreet() { return street; }
         public void setStreet(String street) { this.street = street; }
-        public String getHouseNumber() { return houseNumber; }
-        public void setHouseNumber(String houseNumber) { this.houseNumber = houseNumber; }
+        public Integer getHouseNumber() { return houseNumber; }
+        public void setHouseNumber(Integer houseNumber) { this.houseNumber = houseNumber; }
         public String getAddition() { return addition; }
         public void setAddition(String addition) { this.addition = addition; }
         public String getPostalCode() { return postalCode; }
@@ -233,8 +233,8 @@ public class FormBean implements Serializable {
         private static final long serialVersionUID = 1L;
         private String cardName = "A. Acme";
         private String cardNumber = "4111111111111111";
-        private String expiryMonth = "12";
-        private String expiryYear = "2030";
+        private Integer expiryMonth = 12;
+        private Integer expiryYear = 2030;
         private String cvc = "123";
         private String iban = "NL91ABNA0417164300";
         private String currency = "EUR";
@@ -243,10 +243,10 @@ public class FormBean implements Serializable {
         public void setCardName(String cardName) { this.cardName = cardName; }
         public String getCardNumber() { return cardNumber; }
         public void setCardNumber(String cardNumber) { this.cardNumber = cardNumber; }
-        public String getExpiryMonth() { return expiryMonth; }
-        public void setExpiryMonth(String expiryMonth) { this.expiryMonth = expiryMonth; }
-        public String getExpiryYear() { return expiryYear; }
-        public void setExpiryYear(String expiryYear) { this.expiryYear = expiryYear; }
+        public Integer getExpiryMonth() { return expiryMonth; }
+        public void setExpiryMonth(Integer expiryMonth) { this.expiryMonth = expiryMonth; }
+        public Integer getExpiryYear() { return expiryYear; }
+        public void setExpiryYear(Integer expiryYear) { this.expiryYear = expiryYear; }
         public String getCvc() { return cvc; }
         public void setCvc(String cvc) { this.cvc = cvc; }
         public String getIban() { return iban; }
@@ -284,19 +284,19 @@ public class FormBean implements Serializable {
     public static class Shipping implements Serializable {
         private static final long serialVersionUID = 1L;
         private String street = "Depot Road";
-        private String houseNumber = "7";
+        private Integer houseNumber = 7;
         private String postalCode = "2000 BB";
         private String city = "Rotterdam";
         private String country = "NL";
         private String method = "Standard";
         private String instructions = "Leave at reception";
         private boolean giftWrap = false;
-        private String deliveryDate = "2026-02-01";
+        private LocalDate deliveryDate = LocalDate.of(2026, 2, 1);
 
         public String getStreet() { return street; }
         public void setStreet(String street) { this.street = street; }
-        public String getHouseNumber() { return houseNumber; }
-        public void setHouseNumber(String houseNumber) { this.houseNumber = houseNumber; }
+        public Integer getHouseNumber() { return houseNumber; }
+        public void setHouseNumber(Integer houseNumber) { this.houseNumber = houseNumber; }
         public String getPostalCode() { return postalCode; }
         public void setPostalCode(String postalCode) { this.postalCode = postalCode; }
         public String getCity() { return city; }
@@ -309,7 +309,7 @@ public class FormBean implements Serializable {
         public void setInstructions(String instructions) { this.instructions = instructions; }
         public boolean isGiftWrap() { return giftWrap; }
         public void setGiftWrap(boolean giftWrap) { this.giftWrap = giftWrap; }
-        public String getDeliveryDate() { return deliveryDate; }
-        public void setDeliveryDate(String deliveryDate) { this.deliveryDate = deliveryDate; }
+        public LocalDate getDeliveryDate() { return deliveryDate; }
+        public void setDeliveryDate(LocalDate deliveryDate) { this.deliveryDate = deliveryDate; }
     }
 }

--- a/test/perf/src/main/webapp/WEB-INF/includes/form-fields.xhtml
+++ b/test/perf/src/main/webapp/WEB-INF/includes/form-fields.xhtml
@@ -16,11 +16,13 @@
 
 -->
 <!--
-    Shared field body for form-inputs, form-inputs-ajax and form-invalid: one realistic multi-section form
-    (product, contact, address, company, payment, preferences) over a mix of input types, converters, validators
-    and select items. The optional #{ajax} param enables the live-validation client-behavior chain on the "name"
-    field (two f:ajax on distinct events) — the unoptimized pass-through-attribute renderer path in Mojarra — for
-    the ajax variant only; the plain variants leave those behaviors disabled so their character stays a pure POST.
+    Shared field body for the form-* scenarios: one realistic multi-section form (product, contact,
+    address, company, payment, preferences, shipping) over a mix of input types, converters, validators
+    and select items, each field paired with its own h:message (label / input / message per grid row).
+    The optional #{ajax} param enables the live-validation client-behavior chain on the "name" field
+    (two f:ajax on distinct events, re-rendering its message by id) — the unoptimized pass-through-
+    attribute renderer path in Mojarra — for the ajax variant only; the plain variants leave those
+    behaviors disabled so their character stays a pure POST.
 -->
 <ui:composition
     xmlns:h="jakarta.faces.html"
@@ -29,224 +31,284 @@
 >
     <h:panelGroup id="product" layout="block">
         <h:outputText value="Product"/>
-        <h:panelGrid columns="2">
+        <h:panelGrid columns="3">
             <h:outputLabel for="name" value="Name"/>
             <h:inputText id="name" value="#{formBean.name}" required="true">
                 <f:converter converterId="trimConverter"/>
                 <f:validator validatorId="lengthRangeValidator"/>
                 <f:validator validatorId="prohibitedWordsValidator"/>
-                <f:ajax event="keyup" render="messages" disabled="#{empty ajax or !ajax}"/>
-                <f:ajax event="blur" execute="@this" render="messages" disabled="#{empty ajax or !ajax}"/>
+                <f:ajax event="keyup" render="nameMessage" disabled="#{empty ajax or !ajax}"/>
+                <f:ajax event="blur" execute="@this" render="nameMessage" disabled="#{empty ajax or !ajax}"/>
             </h:inputText>
+            <h:message for="name" id="nameMessage"/>
 
             <h:outputLabel for="description" value="Description"/>
             <h:inputTextarea id="description" value="#{formBean.description}">
                 <f:validator validatorId="lengthRangeValidator"/>
             </h:inputTextarea>
+            <h:message for="description"/>
 
             <h:outputLabel for="quantity" value="Quantity"/>
             <h:inputText id="quantity" value="#{formBean.quantity}">
                 <f:convertNumber integerOnly="true"/>
                 <f:validateLongRange minimum="0" maximum="10000"/>
             </h:inputText>
+            <h:message for="quantity"/>
 
             <h:outputLabel for="price" value="Price"/>
             <h:inputText id="price" value="#{formBean.price}">
                 <f:convertNumber type="currency" currencyCode="EUR"/>
             </h:inputText>
+            <h:message for="price"/>
 
             <h:outputLabel for="date" value="Date"/>
             <h:inputText id="date" value="#{formBean.date}">
                 <f:convertDateTime type="localDate"/>
             </h:inputText>
+            <h:message for="date"/>
 
             <h:outputLabel for="active" value="Active"/>
             <h:selectBooleanCheckbox id="active" value="#{formBean.active}"/>
+            <h:message for="active"/>
 
             <h:outputLabel for="country" value="Country"/>
             <h:selectOneMenu id="country" value="#{formBean.country}">
                 <f:converter converterId="upperCaseConverter"/>
                 <f:selectItems value="#{appConfig.countries}"/>
             </h:selectOneMenu>
+            <h:message for="country"/>
 
             <h:outputLabel for="category" value="Category"/>
             <h:selectOneRadio id="category" value="#{formBean.category}">
                 <f:selectItems value="#{appConfig.categories}"/>
             </h:selectOneRadio>
+            <h:message for="category"/>
         </h:panelGrid>
     </h:panelGroup>
 
     <h:panelGroup id="contact" layout="block">
         <h:outputText value="Contact"/>
-        <h:panelGrid columns="2">
+        <h:panelGrid columns="3">
             <h:outputLabel for="email" value="Email"/>
             <h:inputText id="email" value="#{formBean.contact.email}">
                 <f:validateRegex pattern="[^@\s]+@[^@\s]+\.[^@\s]+"/>
             </h:inputText>
+            <h:message for="email"/>
 
             <h:outputLabel for="phone" value="Phone"/>
             <h:inputText id="phone" value="#{formBean.contact.phone}"/>
+            <h:message for="phone"/>
 
             <h:outputLabel for="mobile" value="Mobile"/>
             <h:inputText id="mobile" value="#{formBean.contact.mobile}"/>
+            <h:message for="mobile"/>
 
             <h:outputLabel for="fax" value="Fax"/>
             <h:inputText id="fax" value="#{formBean.contact.fax}"/>
+            <h:message for="fax"/>
 
             <h:outputLabel for="skype" value="Skype"/>
             <h:inputText id="skype" value="#{formBean.contact.skype}"/>
+            <h:message for="skype"/>
         </h:panelGrid>
     </h:panelGroup>
 
     <h:panelGroup id="address" layout="block">
         <h:outputText value="Address"/>
-        <h:panelGrid columns="2">
+        <h:panelGrid columns="3">
             <h:outputLabel for="street" value="Street"/>
             <h:inputText id="street" value="#{formBean.address.street}"/>
+            <h:message for="street"/>
 
             <h:outputLabel for="houseNumber" value="House number"/>
-            <h:inputText id="houseNumber" value="#{formBean.address.houseNumber}"/>
+            <h:inputText id="houseNumber" value="#{formBean.address.houseNumber}">
+                <f:convertNumber integerOnly="true"/>
+            </h:inputText>
+            <h:message for="houseNumber"/>
 
             <h:outputLabel for="addition" value="Addition"/>
             <h:inputText id="addition" value="#{formBean.address.addition}"/>
+            <h:message for="addition"/>
 
             <h:outputLabel for="postalCode" value="Postal code"/>
             <h:inputText id="postalCode" value="#{formBean.address.postalCode}"/>
+            <h:message for="postalCode"/>
 
             <h:outputLabel for="city" value="City"/>
             <h:inputText id="city" value="#{formBean.address.city}"/>
+            <h:message for="city"/>
 
             <h:outputLabel for="state" value="State"/>
             <h:inputText id="state" value="#{formBean.address.state}"/>
+            <h:message for="state"/>
 
             <h:outputLabel for="region" value="Region"/>
             <h:inputText id="region" value="#{formBean.address.region}"/>
+            <h:message for="region"/>
         </h:panelGrid>
     </h:panelGroup>
 
     <h:panelGroup id="company" layout="block">
         <h:outputText value="Company"/>
-        <h:panelGrid columns="2">
+        <h:panelGrid columns="3">
             <h:outputLabel for="companyName" value="Company name"/>
             <h:inputText id="companyName" value="#{formBean.company.companyName}"/>
+            <h:message for="companyName"/>
 
             <h:outputLabel for="department" value="Department"/>
             <h:inputText id="department" value="#{formBean.company.department}"/>
+            <h:message for="department"/>
 
             <h:outputLabel for="jobTitle" value="Job title"/>
             <h:inputText id="jobTitle" value="#{formBean.company.jobTitle}"/>
+            <h:message for="jobTitle"/>
 
             <h:outputLabel for="vatNumber" value="VAT number"/>
             <h:inputText id="vatNumber" value="#{formBean.company.vatNumber}">
                 <f:validateLength minimum="4" maximum="20"/>
             </h:inputText>
+            <h:message for="vatNumber"/>
 
             <h:outputLabel for="employees" value="Employees"/>
             <h:inputText id="employees" value="#{formBean.company.employees}">
                 <f:convertNumber integerOnly="true"/>
             </h:inputText>
+            <h:message for="employees"/>
 
             <h:outputLabel for="website" value="Website"/>
             <h:inputText id="website" value="#{formBean.company.website}"/>
+            <h:message for="website"/>
 
             <h:outputLabel for="industry" value="Industry"/>
             <h:selectOneMenu id="industry" value="#{formBean.company.industry}">
                 <f:selectItems value="#{appConfig.categories}"/>
             </h:selectOneMenu>
+            <h:message for="industry"/>
         </h:panelGrid>
     </h:panelGroup>
 
     <h:panelGroup id="payment" layout="block">
         <h:outputText value="Payment"/>
-        <h:panelGrid columns="2">
+        <h:panelGrid columns="3">
             <h:outputLabel for="cardName" value="Cardholder"/>
             <h:inputText id="cardName" value="#{formBean.payment.cardName}"/>
+            <h:message for="cardName"/>
 
             <h:outputLabel for="cardNumber" value="Card number"/>
             <h:inputText id="cardNumber" value="#{formBean.payment.cardNumber}">
                 <f:validateLength minimum="12" maximum="19"/>
             </h:inputText>
+            <h:message for="cardNumber"/>
 
             <h:outputLabel for="expiryMonth" value="Expiry month"/>
-            <h:inputText id="expiryMonth" value="#{formBean.payment.expiryMonth}"/>
+            <h:inputText id="expiryMonth" value="#{formBean.payment.expiryMonth}">
+                <f:convertNumber integerOnly="true"/>
+            </h:inputText>
+            <h:message for="expiryMonth"/>
 
             <h:outputLabel for="expiryYear" value="Expiry year"/>
-            <h:inputText id="expiryYear" value="#{formBean.payment.expiryYear}"/>
+            <h:inputText id="expiryYear" value="#{formBean.payment.expiryYear}">
+                <f:convertNumber integerOnly="true"/>
+            </h:inputText>
+            <h:message for="expiryYear"/>
 
             <h:outputLabel for="cvc" value="CVC"/>
             <h:inputSecret id="cvc" value="#{formBean.payment.cvc}" redisplay="true"/>
+            <h:message for="cvc"/>
 
             <h:outputLabel for="iban" value="IBAN"/>
             <h:inputText id="iban" value="#{formBean.payment.iban}"/>
+            <h:message for="iban"/>
 
             <h:outputLabel for="currency" value="Currency"/>
             <h:inputText id="currency" value="#{formBean.payment.currency}"/>
+            <h:message for="currency"/>
         </h:panelGrid>
     </h:panelGroup>
 
     <h:panelGroup id="preferences" layout="block">
         <h:outputText value="Preferences"/>
-        <h:panelGrid columns="2">
+        <h:panelGrid columns="3">
             <h:outputLabel for="newsletter" value="Newsletter"/>
             <h:selectBooleanCheckbox id="newsletter" value="#{formBean.preferences.newsletter}"/>
+            <h:message for="newsletter"/>
 
             <h:outputLabel for="language" value="Language"/>
             <h:selectOneMenu id="language" value="#{formBean.preferences.language}">
                 <f:selectItems value="#{appConfig.languages}"/>
             </h:selectOneMenu>
+            <h:message for="language"/>
 
             <h:outputLabel for="timezone" value="Timezone"/>
             <h:selectOneMenu id="timezone" value="#{formBean.preferences.timezone}">
                 <f:selectItems value="#{appConfig.timezones}"/>
             </h:selectOneMenu>
+            <h:message for="timezone"/>
 
             <h:outputLabel for="theme" value="Theme"/>
             <h:selectOneRadio id="theme" value="#{formBean.preferences.theme}">
                 <f:selectItems value="#{appConfig.themes}"/>
             </h:selectOneRadio>
+            <h:message for="theme"/>
 
             <h:outputLabel for="referral" value="Referral"/>
             <h:inputText id="referral" value="#{formBean.preferences.referral}"/>
+            <h:message for="referral"/>
 
             <h:outputLabel for="comments" value="Comments"/>
             <h:inputTextarea id="comments" value="#{formBean.preferences.comments}"/>
+            <h:message for="comments"/>
 
             <h:outputLabel for="acceptTerms" value="Accept terms"/>
             <h:selectBooleanCheckbox id="acceptTerms" value="#{formBean.preferences.acceptTerms}"/>
+            <h:message for="acceptTerms"/>
         </h:panelGrid>
     </h:panelGroup>
 
     <h:panelGroup id="shipping" layout="block">
         <h:outputText value="Shipping"/>
-        <h:panelGrid columns="2">
+        <h:panelGrid columns="3">
             <h:outputLabel for="shipStreet" value="Street"/>
             <h:inputText id="shipStreet" value="#{formBean.shipping.street}"/>
+            <h:message for="shipStreet"/>
 
             <h:outputLabel for="shipHouseNumber" value="House number"/>
-            <h:inputText id="shipHouseNumber" value="#{formBean.shipping.houseNumber}"/>
+            <h:inputText id="shipHouseNumber" value="#{formBean.shipping.houseNumber}">
+                <f:convertNumber integerOnly="true"/>
+            </h:inputText>
+            <h:message for="shipHouseNumber"/>
 
             <h:outputLabel for="shipPostalCode" value="Postal code"/>
             <h:inputText id="shipPostalCode" value="#{formBean.shipping.postalCode}"/>
+            <h:message for="shipPostalCode"/>
 
             <h:outputLabel for="shipCity" value="City"/>
             <h:inputText id="shipCity" value="#{formBean.shipping.city}"/>
+            <h:message for="shipCity"/>
 
             <h:outputLabel for="shipCountry" value="Country"/>
             <h:selectOneMenu id="shipCountry" value="#{formBean.shipping.country}">
                 <f:selectItems value="#{appConfig.countries}"/>
             </h:selectOneMenu>
+            <h:message for="shipCountry"/>
 
             <h:outputLabel for="shipMethod" value="Method"/>
             <h:inputText id="shipMethod" value="#{formBean.shipping.method}"/>
+            <h:message for="shipMethod"/>
 
             <h:outputLabel for="shipInstructions" value="Instructions"/>
             <h:inputTextarea id="shipInstructions" value="#{formBean.shipping.instructions}"/>
+            <h:message for="shipInstructions"/>
 
             <h:outputLabel for="shipGiftWrap" value="Gift wrap"/>
             <h:selectBooleanCheckbox id="shipGiftWrap" value="#{formBean.shipping.giftWrap}"/>
+            <h:message for="shipGiftWrap"/>
 
             <h:outputLabel for="shipDeliveryDate" value="Delivery date"/>
-            <h:inputText id="shipDeliveryDate" value="#{formBean.shipping.deliveryDate}"/>
+            <h:inputText id="shipDeliveryDate" value="#{formBean.shipping.deliveryDate}">
+                <f:convertDateTime type="localDate"/>
+            </h:inputText>
+            <h:message for="shipDeliveryDate"/>
         </h:panelGrid>
     </h:panelGroup>
 </ui:composition>

--- a/test/perf/src/main/webapp/WEB-INF/includes/inputs-columns.xhtml
+++ b/test/perf/src/main/webapp/WEB-INF/includes/inputs-columns.xhtml
@@ -1,0 +1,62 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!--
+    Column form of the shared per-row input set (see inputs.xhtml) for the h:dataTable table-* scenarios: the same
+    canonical fields, one per h:column with a header facet, so the table family exercises the identical inputs as the
+    repeat/composite/forEach families while keeping the realistic multi-column layout. Include as a direct child of
+    an h:dataTable and bind the row via <ui:param name="row">.
+-->
+<ui:composition
+    xmlns:h="jakarta.faces.html"
+    xmlns:f="jakarta.faces.core"
+    xmlns:ui="jakarta.faces.facelets"
+>
+    <h:column>
+        <f:facet name="header">#</f:facet>
+        <h:outputText value="#{row.id}"/>
+    </h:column>
+    <h:column>
+        <f:facet name="header">Name</f:facet>
+        <h:inputText value="#{row.name}">
+            <f:converter converterId="trimConverter"/>
+            <f:validator validatorId="lengthRangeValidator"/>
+        </h:inputText>
+    </h:column>
+    <h:column>
+        <f:facet name="header">Qty</f:facet>
+        <h:inputText value="#{row.quantity}">
+            <f:convertNumber integerOnly="true"/>
+        </h:inputText>
+    </h:column>
+    <h:column>
+        <f:facet name="header">Price</f:facet>
+        <h:inputText value="#{row.price}">
+            <f:convertNumber type="currency" currencyCode="EUR"/>
+        </h:inputText>
+    </h:column>
+    <h:column>
+        <f:facet name="header">Date</f:facet>
+        <h:inputText value="#{row.date}">
+            <f:convertDateTime type="localDate"/>
+        </h:inputText>
+    </h:column>
+    <h:column>
+        <f:facet name="header">Active</f:facet>
+        <h:selectBooleanCheckbox value="#{row.active}"/>
+    </h:column>
+</ui:composition>

--- a/test/perf/src/main/webapp/WEB-INF/includes/inputs.xhtml
+++ b/test/perf/src/main/webapp/WEB-INF/includes/inputs.xhtml
@@ -1,0 +1,44 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!--
+    Shared per-row input block for the table/repeat/composite/forEach *-inputs and *-nested scenarios: the single
+    source of truth for the fields, so every iteration container exercises an identical input set and the only
+    variable across those scenarios is the container itself. Each caller binds the row via <ui:param name="row">
+    (the iteration or forEach var, or #{cc.attrs.row} for the composite).
+-->
+<ui:composition
+    xmlns:h="jakarta.faces.html"
+    xmlns:f="jakarta.faces.core"
+    xmlns:ui="jakarta.faces.facelets"
+>
+    <h:outputText value="#{row.id}"/>
+    <h:inputText value="#{row.name}">
+        <f:converter converterId="trimConverter"/>
+        <f:validator validatorId="lengthRangeValidator"/>
+    </h:inputText>
+    <h:inputText value="#{row.quantity}">
+        <f:convertNumber integerOnly="true"/>
+    </h:inputText>
+    <h:inputText value="#{row.price}">
+        <f:convertNumber type="currency" currencyCode="EUR"/>
+    </h:inputText>
+    <h:inputText value="#{row.date}">
+        <f:convertDateTime type="localDate"/>
+    </h:inputText>
+    <h:selectBooleanCheckbox value="#{row.active}"/>
+</ui:composition>

--- a/test/perf/src/main/webapp/foreach-inputs-ajax.xhtml
+++ b/test/perf/src/main/webapp/foreach-inputs-ajax.xhtml
@@ -19,6 +19,7 @@
 <html lang="#{facesContext.viewRoot.locale.language}"
     xmlns:h="jakarta.faces.html"
     xmlns:f="jakarta.faces.core"
+    xmlns:ui="jakarta.faces.facelets"
     xmlns:c="jakarta.tags.core"
 >
     <h:head>
@@ -29,21 +30,9 @@
             <h:panelGroup id="rows" layout="block">
                 <c:forEach items="#{dataBean.inputRows}" var="row" varStatus="loop">
                     <h:panelGroup id="row_#{loop.index + 1}" layout="block">
-                        <h:outputText value="#{row.id}"/>
-                        <h:inputText value="#{row.name}">
-                            <f:converter converterId="trimConverter"/>
-                            <f:validator validatorId="lengthRangeValidator"/>
-                        </h:inputText>
-                        <h:inputText value="#{row.quantity}">
-                            <f:convertNumber integerOnly="true"/>
-                        </h:inputText>
-                        <h:inputText value="#{row.price}">
-                            <f:convertNumber type="currency" currencyCode="EUR"/>
-                        </h:inputText>
-                        <h:inputText value="#{row.date}">
-                            <f:convertDateTime type="localDate"/>
-                        </h:inputText>
-                        <h:selectBooleanCheckbox value="#{row.active}"/>
+                        <ui:include src="/WEB-INF/includes/inputs.xhtml">
+                            <ui:param name="row" value="#{row}"/>
+                        </ui:include>
                     </h:panelGroup>
                 </c:forEach>
             </h:panelGroup>

--- a/test/perf/src/main/webapp/foreach-inputs.xhtml
+++ b/test/perf/src/main/webapp/foreach-inputs.xhtml
@@ -18,7 +18,7 @@
 -->
 <html lang="#{facesContext.viewRoot.locale.language}"
     xmlns:h="jakarta.faces.html"
-    xmlns:f="jakarta.faces.core"
+    xmlns:ui="jakarta.faces.facelets"
     xmlns:c="jakarta.tags.core"
 >
     <h:head>
@@ -28,21 +28,9 @@
         <h:form id="form">
             <c:forEach items="#{dataBean.inputRows}" var="row" varStatus="loop">
                 <h:panelGroup id="row_#{loop.index + 1}" layout="block">
-                    <h:outputText value="#{row.id}"/>
-                    <h:inputText value="#{row.name}">
-                        <f:converter converterId="trimConverter"/>
-                        <f:validator validatorId="lengthRangeValidator"/>
-                    </h:inputText>
-                    <h:inputText value="#{row.quantity}">
-                        <f:convertNumber integerOnly="true"/>
-                    </h:inputText>
-                    <h:inputText value="#{row.price}">
-                        <f:convertNumber type="currency" currencyCode="EUR"/>
-                    </h:inputText>
-                    <h:inputText value="#{row.date}">
-                        <f:convertDateTime type="localDate"/>
-                    </h:inputText>
-                    <h:selectBooleanCheckbox value="#{row.active}"/>
+                    <ui:include src="/WEB-INF/includes/inputs.xhtml">
+                        <ui:param name="row" value="#{row}"/>
+                    </ui:include>
                 </h:panelGroup>
             </c:forEach>
             <h:commandButton id="submit" value="Save" action="#{dataBean.save}"/>

--- a/test/perf/src/main/webapp/foreach-nested-ajax.xhtml
+++ b/test/perf/src/main/webapp/foreach-nested-ajax.xhtml
@@ -19,6 +19,7 @@
 <html lang="#{facesContext.viewRoot.locale.language}"
     xmlns:h="jakarta.faces.html"
     xmlns:f="jakarta.faces.core"
+    xmlns:ui="jakarta.faces.facelets"
     xmlns:c="jakarta.tags.core"
 >
     <h:head>
@@ -32,13 +33,9 @@
                         <h2>#{group.name}</h2>
                         <c:forEach items="#{group.rows}" var="row" varStatus="rloop">
                             <h:panelGroup id="row_#{gloop.index + 1}_#{rloop.index + 1}" layout="block">
-                                <h:outputText value="#{row.id}"/> - <h:outputText value="#{row.name}"/>
-                                <h:inputText value="#{row.quantity}">
-                                    <f:convertNumber integerOnly="true"/>
-                                </h:inputText>
-                                <h:inputText value="#{row.price}">
-                                    <f:convertNumber type="currency" currencyCode="EUR"/>
-                                </h:inputText>
+                                <ui:include src="/WEB-INF/includes/inputs.xhtml">
+                                    <ui:param name="row" value="#{row}"/>
+                                </ui:include>
                             </h:panelGroup>
                         </c:forEach>
                     </h:panelGroup>

--- a/test/perf/src/main/webapp/foreach-nested.xhtml
+++ b/test/perf/src/main/webapp/foreach-nested.xhtml
@@ -18,7 +18,7 @@
 -->
 <html lang="#{facesContext.viewRoot.locale.language}"
     xmlns:h="jakarta.faces.html"
-    xmlns:f="jakarta.faces.core"
+    xmlns:ui="jakarta.faces.facelets"
     xmlns:c="jakarta.tags.core"
 >
     <h:head>
@@ -31,13 +31,9 @@
                     <h2>#{group.name}</h2>
                     <c:forEach items="#{group.rows}" var="row" varStatus="rloop">
                         <h:panelGroup id="row_#{gloop.index + 1}_#{rloop.index + 1}" layout="block">
-                            <h:outputText value="#{row.id}"/> - <h:outputText value="#{row.name}"/>
-                            <h:inputText value="#{row.quantity}">
-                                <f:convertNumber integerOnly="true"/>
-                            </h:inputText>
-                            <h:inputText value="#{row.price}">
-                                <f:convertNumber type="currency" currencyCode="EUR"/>
-                            </h:inputText>
+                            <ui:include src="/WEB-INF/includes/inputs.xhtml">
+                                <ui:param name="row" value="#{row}"/>
+                            </ui:include>
                         </h:panelGroup>
                     </c:forEach>
                 </h:panelGroup>

--- a/test/perf/src/main/webapp/form-inputs-ajax.xhtml
+++ b/test/perf/src/main/webapp/form-inputs-ajax.xhtml
@@ -33,7 +33,7 @@
             <h:commandButton id="submit" value="Submit" action="#{formBean.submit}">
                 <f:ajax execute="@form" render="@form messages"/>
             </h:commandButton>
-            <h:messages id="messages" globalOnly="false"/>
+            <h:messages id="messages" globalOnly="true"/>
         </h:form>
     </h:body>
 </html>

--- a/test/perf/src/main/webapp/form-inputs.xhtml
+++ b/test/perf/src/main/webapp/form-inputs.xhtml
@@ -28,7 +28,7 @@
             <ui:include src="/WEB-INF/includes/form-fields.xhtml"/>
 
             <h:commandButton id="submit" value="Submit" action="#{formBean.submit}"/>
-            <h:messages id="messages" globalOnly="false"/>
+            <h:messages id="messages" globalOnly="true"/>
         </h:form>
     </h:body>
 </html>

--- a/test/perf/src/main/webapp/form-invalid-ajax.xhtml
+++ b/test/perf/src/main/webapp/form-invalid-ajax.xhtml
@@ -33,7 +33,7 @@
             <h:commandButton id="submit" value="Submit" action="#{formBean.submit}">
                 <f:ajax execute="@form" render="@form messages"/>
             </h:commandButton>
-            <h:messages id="messages" globalOnly="false"/>
+            <h:messages id="messages" globalOnly="true"/>
         </h:form>
     </h:body>
 </html>

--- a/test/perf/src/main/webapp/form-invalid.xhtml
+++ b/test/perf/src/main/webapp/form-invalid.xhtml
@@ -28,7 +28,7 @@
             <ui:include src="/WEB-INF/includes/form-fields.xhtml"/>
 
             <h:commandButton id="submit" value="Submit" action="#{formBean.submit}"/>
-            <h:messages id="messages" globalOnly="false"/>
+            <h:messages id="messages" globalOnly="true"/>
         </h:form>
     </h:body>
 </html>

--- a/test/perf/src/main/webapp/repeat-inputs-ajax.xhtml
+++ b/test/perf/src/main/webapp/repeat-inputs-ajax.xhtml
@@ -28,21 +28,10 @@
         <h:form id="form">
             <h:panelGroup id="rows" layout="block">
                 <ui:repeat value="#{dataBean.inputRows}" var="row">
-                    <h:panelGroup id="row" ayout="block">
-                        <h:outputText value="#{row.id}"/>
-                        <h:inputText value="#{row.name}">
-                            <f:converter converterId="trimConverter"/>
-                            <f:validator validatorId="lengthRangeValidator"/>
-                        </h:inputText>
-                        <h:inputText value="#{row.quantity}">
-                            <f:convertNumber integerOnly="true"/>
-                        </h:inputText>
-                        <h:inputText value="#{row.price}">
-                            <f:convertNumber type="currency" currencyCode="EUR"/>
-                        </h:inputText>
-                        <h:inputText value="#{row.date}">
-                            <f:convertDateTime type="localDate"/>
-                        </h:inputText>
+                    <h:panelGroup id="row" layout="block">
+                        <ui:include src="/WEB-INF/includes/inputs.xhtml">
+                            <ui:param name="row" value="#{row}"/>
+                        </ui:include>
                     </h:panelGroup>
                 </ui:repeat>
             </h:panelGroup>

--- a/test/perf/src/main/webapp/repeat-inputs.xhtml
+++ b/test/perf/src/main/webapp/repeat-inputs.xhtml
@@ -18,7 +18,6 @@
 -->
 <html lang="#{facesContext.viewRoot.locale.language}"
     xmlns:h="jakarta.faces.html"
-    xmlns:f="jakarta.faces.core"
     xmlns:ui="jakarta.faces.facelets"
 >
     <h:head>
@@ -28,21 +27,9 @@
         <h:form id="form">
             <ui:repeat value="#{dataBean.inputRows}" var="row">
                 <h:panelGroup id="row" layout="block">
-                    <h:outputText value="#{row.id}"/>
-                    <h:inputText value="#{row.name}">
-                        <f:converter converterId="trimConverter"/>
-                        <f:validator validatorId="lengthRangeValidator"/>
-                    </h:inputText>
-                    <h:inputText value="#{row.quantity}">
-                        <f:convertNumber integerOnly="true"/>
-                    </h:inputText>
-                    <h:inputText value="#{row.price}">
-                        <f:convertNumber type="currency" currencyCode="EUR"/>
-                    </h:inputText>
-                    <h:inputText value="#{row.date}">
-                        <f:convertDateTime type="localDate"/>
-                    </h:inputText>
-                    <h:selectBooleanCheckbox value="#{row.active}"/>
+                    <ui:include src="/WEB-INF/includes/inputs.xhtml">
+                        <ui:param name="row" value="#{row}"/>
+                    </ui:include>
                 </h:panelGroup>
             </ui:repeat>
             <h:commandButton id="submit" value="Save" action="#{dataBean.save}"/>

--- a/test/perf/src/main/webapp/repeat-nested-ajax.xhtml
+++ b/test/perf/src/main/webapp/repeat-nested-ajax.xhtml
@@ -32,13 +32,9 @@
                         <h2>#{group.name}</h2>
                         <ui:repeat value="#{group.rows}" var="row">
                             <h:panelGroup id="row" layout="block">
-                                <h:outputText value="#{row.id}"/> - <h:outputText value="#{row.name}"/>
-                                <h:inputText value="#{row.quantity}">
-                                    <f:convertNumber integerOnly="true"/>
-                                </h:inputText>
-                                <h:inputText value="#{row.price}">
-                                    <f:convertNumber type="currency" currencyCode="EUR"/>
-                                </h:inputText>
+                                <ui:include src="/WEB-INF/includes/inputs.xhtml">
+                                    <ui:param name="row" value="#{row}"/>
+                                </ui:include>
                             </h:panelGroup>
                         </ui:repeat>
                     </h:panelGroup>

--- a/test/perf/src/main/webapp/repeat-nested.xhtml
+++ b/test/perf/src/main/webapp/repeat-nested.xhtml
@@ -18,7 +18,6 @@
 -->
 <html lang="#{facesContext.viewRoot.locale.language}"
     xmlns:h="jakarta.faces.html"
-    xmlns:f="jakarta.faces.core"
     xmlns:ui="jakarta.faces.facelets"
 >
     <h:head>
@@ -31,13 +30,9 @@
                     <h2>#{group.name}</h2>
                     <ui:repeat value="#{group.rows}" var="row">
                         <h:panelGroup id="row" layout="block">
-                            <h:outputText value="#{row.id}"/> - <h:outputText value="#{row.name}"/>
-                            <h:inputText value="#{row.quantity}">
-                                <f:convertNumber integerOnly="true"/>
-                            </h:inputText>
-                            <h:inputText value="#{row.price}">
-                                <f:convertNumber type="currency" currencyCode="EUR"/>
-                            </h:inputText>
+                            <ui:include src="/WEB-INF/includes/inputs.xhtml">
+                                <ui:param name="row" value="#{row}"/>
+                            </ui:include>
                         </h:panelGroup>
                     </ui:repeat>
                 </h:panelGroup>

--- a/test/perf/src/main/webapp/resources/cc/inputs.xhtml
+++ b/test/perf/src/main/webapp/resources/cc/inputs.xhtml
@@ -17,7 +17,6 @@
 -->
 <ui:component
     xmlns:h="jakarta.faces.html"
-    xmlns:f="jakarta.faces.core"
     xmlns:ui="jakarta.faces.facelets"
     xmlns:cc="jakarta.faces.composite"
 >
@@ -26,21 +25,9 @@
     </cc:interface>
     <cc:implementation>
         <h:panelGroup id="inputs" layout="block">
-            <h:outputText value="#{cc.attrs.row.id}"/>
-            <h:inputText value="#{cc.attrs.row.name}">
-                <f:converter converterId="trimConverter"/>
-                <f:validator validatorId="lengthRangeValidator"/>
-            </h:inputText>
-            <h:inputText value="#{cc.attrs.row.quantity}">
-                <f:convertNumber integerOnly="true"/>
-            </h:inputText>
-            <h:inputText value="#{cc.attrs.row.price}">
-                <f:convertNumber type="currency" currencyCode="EUR"/>
-            </h:inputText>
-            <h:inputText value="#{cc.attrs.row.date}">
-                <f:convertDateTime type="localDate"/>
-            </h:inputText>
-            <h:selectBooleanCheckbox value="#{cc.attrs.row.active}"/>
+            <ui:include src="/WEB-INF/includes/inputs.xhtml">
+                <ui:param name="row" value="#{cc.attrs.row}"/>
+            </ui:include>
         </h:panelGroup>
     </cc:implementation>
 </ui:component>

--- a/test/perf/src/main/webapp/table-inputs-ajax.xhtml
+++ b/test/perf/src/main/webapp/table-inputs-ajax.xhtml
@@ -19,6 +19,7 @@
 <html lang="#{facesContext.viewRoot.locale.language}"
     xmlns:h="jakarta.faces.html"
     xmlns:f="jakarta.faces.core"
+    xmlns:ui="jakarta.faces.facelets"
 >
     <h:head>
         <title>table-inputs-ajax</title>
@@ -26,35 +27,9 @@
     <h:body>
         <h:form id="form">
             <h:dataTable id="table" value="#{dataBean.inputRows}" var="row">
-                <h:column>
-                    <f:facet name="header">#</f:facet>
-                    <h:outputText value="#{row.id}"/>
-                </h:column>
-                <h:column>
-                    <f:facet name="header">Name</f:facet>
-                    <h:inputText value="#{row.name}" required="true">
-                        <f:converter converterId="trimConverter"/>
-                        <f:validator validatorId="lengthRangeValidator"/>
-                    </h:inputText>
-                </h:column>
-                <h:column>
-                    <f:facet name="header">Qty</f:facet>
-                    <h:inputText value="#{row.quantity}">
-                        <f:convertNumber integerOnly="true"/>
-                    </h:inputText>
-                </h:column>
-                <h:column>
-                    <f:facet name="header">Price</f:facet>
-                    <h:inputText value="#{row.price}">
-                        <f:convertNumber type="currency" currencyCode="EUR"/>
-                    </h:inputText>
-                </h:column>
-                <h:column>
-                    <f:facet name="header">Date</f:facet>
-                    <h:inputText value="#{row.date}">
-                        <f:convertDateTime type="localDate"/>
-                    </h:inputText>
-                </h:column>
+                <ui:include src="/WEB-INF/includes/inputs-columns.xhtml">
+                    <ui:param name="row" value="#{row}"/>
+                </ui:include>
             </h:dataTable>
             <h:commandButton id="submit" value="Save" action="#{dataBean.save}">
                 <f:ajax execute="@form" render="table messages"/>

--- a/test/perf/src/main/webapp/table-inputs.xhtml
+++ b/test/perf/src/main/webapp/table-inputs.xhtml
@@ -18,7 +18,7 @@
 -->
 <html lang="#{facesContext.viewRoot.locale.language}"
     xmlns:h="jakarta.faces.html"
-    xmlns:f="jakarta.faces.core"
+    xmlns:ui="jakarta.faces.facelets"
 >
     <h:head>
         <title>table-inputs</title>
@@ -26,40 +26,9 @@
     <h:body>
         <h:form id="form">
             <h:dataTable value="#{dataBean.inputRows}" var="row">
-                <h:column>
-                    <f:facet name="header">#</f:facet>
-                    <h:outputText value="#{row.id}"/>
-                </h:column>
-                <h:column>
-                    <f:facet name="header">Name</f:facet>
-                    <h:inputText value="#{row.name}" required="true">
-                        <f:converter converterId="trimConverter"/>
-                        <f:validator validatorId="lengthRangeValidator"/>
-                    </h:inputText>
-                </h:column>
-                <h:column>
-                    <f:facet name="header">Qty</f:facet>
-                    <h:inputText value="#{row.quantity}">
-                        <f:convertNumber integerOnly="true"/>
-                        <f:validateLongRange minimum="0" maximum="10000"/>
-                    </h:inputText>
-                </h:column>
-                <h:column>
-                    <f:facet name="header">Price</f:facet>
-                    <h:inputText value="#{row.price}">
-                        <f:convertNumber type="currency" currencyCode="EUR"/>
-                    </h:inputText>
-                </h:column>
-                <h:column>
-                    <f:facet name="header">Date</f:facet>
-                    <h:inputText value="#{row.date}">
-                        <f:convertDateTime type="localDate"/>
-                    </h:inputText>
-                </h:column>
-                <h:column>
-                    <f:facet name="header">Active</f:facet>
-                    <h:selectBooleanCheckbox value="#{row.active}"/>
-                </h:column>
+                <ui:include src="/WEB-INF/includes/inputs-columns.xhtml">
+                    <ui:param name="row" value="#{row}"/>
+                </ui:include>
             </h:dataTable>
             <h:commandButton id="submit" value="Save" action="#{dataBean.save}"/>
             <h:messages globalOnly="false"/>

--- a/test/perf/src/main/webapp/table-nested-ajax.xhtml
+++ b/test/perf/src/main/webapp/table-nested-ajax.xhtml
@@ -19,7 +19,7 @@
 <html lang="#{facesContext.viewRoot.locale.language}"
     xmlns:h="jakarta.faces.html"
     xmlns:f="jakarta.faces.core"
-    xmlns:cc="jakarta.faces.composite/cc"
+    xmlns:ui="jakarta.faces.facelets"
 >
     <h:head>
         <title>table-nested-ajax</title>
@@ -30,9 +30,9 @@
                 <h:column>
                     <h2>#{group.name}</h2>
                     <h:dataTable value="#{group.rows}" var="row">
-                        <h:column>
-                            <cc:inputs row="#{row}"/>
-                        </h:column>
+                        <ui:include src="/WEB-INF/includes/inputs-columns.xhtml">
+                            <ui:param name="row" value="#{row}"/>
+                        </ui:include>
                     </h:dataTable>
                 </h:column>
             </h:dataTable>

--- a/test/perf/src/main/webapp/table-nested.xhtml
+++ b/test/perf/src/main/webapp/table-nested.xhtml
@@ -16,10 +16,10 @@
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 -->
-<!-- UIData twin of composite-nested: same data and composite, h:dataTable instead of ui:repeat, to isolate UIData's per-row child-state cost. -->
+<!-- UIData twin of repeat-nested: identical row inputs (includes/inputs-columns.xhtml), nested h:dataTable instead of ui:repeat, to isolate UIData's per-row child-state cost. -->
 <html lang="#{facesContext.viewRoot.locale.language}"
     xmlns:h="jakarta.faces.html"
-    xmlns:cc="jakarta.faces.composite/cc"
+    xmlns:ui="jakarta.faces.facelets"
 >
     <h:head>
         <title>table-nested</title>
@@ -30,9 +30,9 @@
                 <h:column>
                     <h2>#{group.name}</h2>
                     <h:dataTable value="#{group.rows}" var="row">
-                        <h:column>
-                            <cc:inputs row="#{row}"/>
-                        </h:column>
+                        <ui:include src="/WEB-INF/includes/inputs-columns.xhtml">
+                            <ui:param name="row" value="#{row}"/>
+                        </ui:include>
                     </h:dataTable>
                 </h:column>
             </h:dataTable>


### PR DESCRIPTION
## What

Cleanup of the `test/perf` benchmark webapp so the scenario families form a clean controlled matrix and the form scenarios are more representative. Test-only — no impl or API changes.

### 1. Share one row-input set across iteration scenarios (e1167571f)

The `table`/`repeat`/`composite`/`forEach` `*-inputs` and `*-nested` views each defined their own row inputs, which had drifted apart: a dropped `active` checkbox in two ajax variants, 2-field vs 6-field nested rows, a stray `required`/`validateLongRange` on `table` only, a `layout` typo, and `table-nested` secretly routed through the composite. They now share two fragments:

- `WEB-INF/includes/inputs.xhtml` — block form (repeat/composite/forEach)
- `WEB-INF/includes/inputs-columns.xhtml` — column form (`h:dataTable`)

Each call site binds the row via `<ui:param name="row">`. Result: within a family only the iteration container varies, and `table-nested` is now a genuine nested-`UIData` measurement rather than a composite one.

### 2. Per-field messages + typed form fields (aff462cc)

- Replace the single aggregate `h:messages` in `form-fields.xhtml` with a per-field `h:message` (grid `columns` 2 → 3), keeping one `h:messages globalOnly="true"` for form-level messages. This exercises the common `UIMessage` + `for`-resolution render path the suite previously never hit. The live-validated `name` field's message has an explicit id so its empty placeholder renders and the `f:ajax` has a node to update.
- Type the fields whose data is numeric or a date but were `String`-backed with no converter: `houseNumber`, `expiryMonth`, `expiryYear` → `Integer` (`f:convertNumber`); `deliveryDate` → `LocalDate` (`f:convertDateTime`).

## Verification

Tomcat build + `PerfBenchIT` green across all touched scenarios (GET render + POST round-trip).

## Notes

Only the templates and model bean were consolidated, so absolute numbers shift for the scenarios whose payload was normalised (nested rows gained fields; the form scenarios gained per-field messages and conversions). A Mojarra-vs-MyFaces run on Tomcat stays parity-to-faster overall (suite −5%).

Refs #5753 

🤖 Generated with Claude Opus 4.8
