### PR TITLE
Reduce EL resolution and composite component overhead

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/application/annotation/AnnotationManager.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/annotation/AnnotationManager.java
@@ -262,14 +262,38 @@ public class AnnotationManager {
      * @param ctx the {@link jakarta.faces.context.FacesContext} for the current request
      * @param targetClass class of the <code>processingTarget</code>
      * @param processingTarget the type of component that is being processed
-     * @param params one or more parameters to be passed to each {@link RuntimeAnnotationHandler}
+     * @param param the parameter to be passed to each {@link RuntimeAnnotationHandler}
      */
-    private void applyAnnotations(FacesContext ctx, Class<?> targetClass, ProcessingTarget processingTarget, Object... params) {
+    private void applyAnnotations(FacesContext ctx, Class<?> targetClass, ProcessingTarget processingTarget, Object param) {
         Map<Class<? extends Annotation>, RuntimeAnnotationHandler> map = getHandlerMap(targetClass, processingTarget);
         if (map != null && !map.isEmpty()) {
-            for (RuntimeAnnotationHandler handler : map.values()) {
-                handler.apply(ctx, params);
-            }
+            applyHandlers(ctx, map, new Object[] { param });
+        }
+    }
+
+    /**
+     * Apply all annotations associated with <code>targetClass</code>
+     *
+     * @param ctx the {@link jakarta.faces.context.FacesContext} for the current request
+     * @param targetClass class of the <code>processingTarget</code>
+     * @param processingTarget the type of component that is being processed
+     * @param param1 the first parameter to be passed to each {@link RuntimeAnnotationHandler}
+     * @param param2 the second parameter to be passed to each {@link RuntimeAnnotationHandler}
+     */
+    private void applyAnnotations(FacesContext ctx, Class<?> targetClass, ProcessingTarget processingTarget, Object param1, Object param2) {
+        Map<Class<? extends Annotation>, RuntimeAnnotationHandler> map = getHandlerMap(targetClass, processingTarget);
+        if (map != null && !map.isEmpty()) {
+            applyHandlers(ctx, map, new Object[] { param1, param2 });
+        }
+    }
+
+    /**
+     * The parameter array is built only once a handler is known to exist. Nearly every component, renderer, converter
+     * and validator carries no runtime annotation at all, and its handler map is empty.
+     */
+    private static void applyHandlers(FacesContext ctx, Map<Class<? extends Annotation>, RuntimeAnnotationHandler> map, Object[] params) {
+        for (RuntimeAnnotationHandler handler : map.values()) {
+            handler.apply(ctx, params);
         }
     }
 

--- a/impl/src/main/java/org/glassfish/mojarra/component/CompositeComponentStackManager.java
+++ b/impl/src/main/java/org/glassfish/mojarra/component/CompositeComponentStackManager.java
@@ -16,7 +16,8 @@
 
 package org.glassfish.mojarra.component;
 
-import java.util.Stack;
+import java.util.ArrayList;
+import java.util.List;
 
 import jakarta.faces.application.Resource;
 import jakarta.faces.component.UIComponent;
@@ -170,13 +171,12 @@ public class CompositeComponentStackManager {
     public UIComponent findCompositeComponentUsingLocation(FacesContext ctx, Location location) {
 
         StackHandler sh = getStackHandler(StackType.TreeCreation);
-        Stack<UIComponent> s = sh.getStack(false);
+        List<UIComponent> s = sh.getStack(false);
         if (s != null) {
             String path = location.getPath();
             for (int i = s.size(); i > 0; i--) {
                 UIComponent cc = s.get(i - 1);
-                Resource r = (Resource) cc.getAttributes().get(Resource.COMPONENT_RESOURCE_KEY);
-                if (path.endsWith('/' + r.getResourceName()) && path.contains(r.getLibraryName())) {
+                if (isResourceOf(path, cc)) {
                     return cc;
                 }
             }
@@ -185,8 +185,7 @@ public class CompositeComponentStackManager {
             String path = location.getPath();
             UIComponent cc = UIComponent.getCurrentCompositeComponent(ctx);
             while (cc != null) {
-                Resource r = (Resource) cc.getAttributes().get(Resource.COMPONENT_RESOURCE_KEY);
-                if (path.endsWith('/' + r.getResourceName()) && path.contains(r.getLibraryName())) {
+                if (isResourceOf(path, cc)) {
                     return cc;
                 }
                 cc = UIComponent.getCompositeComponentParent(cc);
@@ -200,7 +199,30 @@ public class CompositeComponentStackManager {
         return UIComponent.getCurrentCompositeComponent(ctx);
     }
 
+    /**
+     * <p>
+     * Return <code>true</code> if <code>path</code> ends with the composite component's resource name, preceded by a
+     * <code>/</code>, and contains its library name.
+     * </p>
+     */
+    private static boolean isResourceOf(String path, UIComponent compositeComponent) {
+
+        Resource resource = (Resource) compositeComponent.getAttributes().get(Resource.COMPONENT_RESOURCE_KEY);
+        String resourceName = resource.getResourceName();
+        int start = path.length() - resourceName.length() - 1;
+
+        return start >= 0 && path.charAt(start) == '/' && path.endsWith(resourceName) && path.contains(resource.getLibraryName());
+    }
+
     // --------------------------------------------------------- Private Methods
+
+    private static UIComponent last(List<UIComponent> stack) {
+        return stack.get(stack.size() - 1);
+    }
+
+    private static UIComponent removeLast(List<UIComponent> stack) {
+        return stack.remove(stack.size() - 1);
+    }
 
     private StackHandler getStackHandler(StackType type) {
 
@@ -233,15 +255,22 @@ public class CompositeComponentStackManager {
 
         void delete();
 
-        Stack<UIComponent> getStack(boolean create);
+        List<UIComponent> getStack(boolean create);
 
     }
 
     // ---------------------------------------------------------- Nested Classes
 
+    /**
+     * <p>
+     * Both stacks are confined to a single request and are never shared across threads. The backing list must support
+     * indexed access: {@link #findCompositeComponentUsingLocation} and
+     * {@link TreeCreationStackHandler#getParentCompositeComponent} address the stack by index.
+     * </p>
+     */
     private abstract class BaseStackHandler implements StackHandler {
 
-        protected Stack<UIComponent> stack;
+        protected List<UIComponent> stack;
 
         // ------------------------------------------- Methods from StackHandler
 
@@ -253,10 +282,10 @@ public class CompositeComponentStackManager {
         }
 
         @Override
-        public Stack<UIComponent> getStack(boolean create) {
+        public List<UIComponent> getStack(boolean create) {
 
             if (stack == null && create) {
-                stack = new Stack<>();
+                stack = new ArrayList<>();
             }
             return stack;
 
@@ -266,7 +295,7 @@ public class CompositeComponentStackManager {
         public UIComponent peek() {
 
             if (stack != null && !stack.isEmpty()) {
-                return stack.peek();
+                return last(stack);
             }
             return null;
 
@@ -281,7 +310,7 @@ public class CompositeComponentStackManager {
         @Override
         public void delete() {
 
-            Stack<UIComponent> s = getStack(false);
+            List<UIComponent> s = getStack(false);
             if (s != null) {
                 s.clear();
             }
@@ -291,9 +320,9 @@ public class CompositeComponentStackManager {
         @Override
         public void pop() {
 
-            Stack<UIComponent> s = getStack(false);
+            List<UIComponent> s = getStack(false);
             if (s != null && !s.isEmpty()) {
-                s.pop();
+                removeLast(s);
             }
 
         }
@@ -308,8 +337,8 @@ public class CompositeComponentStackManager {
         @Override
         public boolean push(UIComponent compositeComponent) {
 
-            Stack<UIComponent> tstack = treeCreation.getStack(false);
-            Stack<UIComponent> stack = getStack(false);
+            List<UIComponent> tstack = treeCreation.getStack(false);
+            List<UIComponent> stack = getStack(false);
             UIComponent ccp;
             if (tstack != null) {
                 // We have access to the stack of composite components
@@ -327,7 +356,7 @@ public class CompositeComponentStackManager {
 
                 if (compositeComponent == null) {
                     if (stack != null && !stack.isEmpty()) {
-                        ccp = getCompositeParent(stack.peek());
+                        ccp = getCompositeParent(last(stack));
                     } else {
                         ccp = getCompositeParent(UIComponent.getCurrentCompositeComponent(FacesContext.getCurrentInstance()));
                     }
@@ -340,7 +369,7 @@ public class CompositeComponentStackManager {
                 if (stack == null) {
                     stack = getStack(true);
                 }
-                stack.push(ccp);
+                stack.add(ccp);
                 return true;
             }
             return false;
@@ -371,9 +400,9 @@ public class CompositeComponentStackManager {
         @Override
         public void pop() {
 
-            Stack<UIComponent> s = getStack(false);
+            List<UIComponent> s = getStack(false);
             if (s != null && !stack.isEmpty()) {
-                stack.pop();
+                removeLast(stack);
                 if (stack.isEmpty()) {
                     delete();
                 }
@@ -393,8 +422,8 @@ public class CompositeComponentStackManager {
 
             if (compositeComponent != null) {
                 assert UIComponent.isCompositeComponent(compositeComponent);
-                Stack<UIComponent> s = getStack(true);
-                s.push(compositeComponent);
+                List<UIComponent> s = getStack(true);
+                s.add(compositeComponent);
                 return true;
             }
             return false;
@@ -404,7 +433,7 @@ public class CompositeComponentStackManager {
         @Override
         public UIComponent getParentCompositeComponent(FacesContext ctx, UIComponent forComponent) {
 
-            Stack<UIComponent> s = getStack(false);
+            List<UIComponent> s = getStack(false);
             if (s == null) {
                 return null;
             } else {

--- a/impl/src/main/java/org/glassfish/mojarra/el/DemuxCompositeELResolver.java
+++ b/impl/src/main/java/org/glassfish/mojarra/el/DemuxCompositeELResolver.java
@@ -32,10 +32,12 @@ public class DemuxCompositeELResolver extends FacesCompositeELResolver {
     private ELResolver[] _rootELResolvers = new ELResolver[2];
     private ELResolver[] _propertyELResolvers = new ELResolver[2];
     private ELResolver[] _allELResolvers = new ELResolver[2];
+    private ELResolver[] _convertELResolvers = new ELResolver[2];
 
     private int _rootELResolverCount = 0;
     private int _propertyELResolverCount = 0;
     private int _allELResolverCount = 0;
+    private int _convertELResolverCount = 0;
 
     public DemuxCompositeELResolver(ELResolverChainType chainType) {
         if (chainType == null) {
@@ -84,6 +86,37 @@ public class DemuxCompositeELResolver extends FacesCompositeELResolver {
         _rootELResolverCount++;
     }
 
+    /**
+     * Registers <code>elResolver</code> for {@link #convertToType} only when it actually declares that method.
+     * {@link ELResolver#convertToType} returns <code>null</code> without marking the property as resolved, so a
+     * resolver which inherits it can never contribute a conversion, and consulting it is a no-op.
+     */
+    private void _addConvertELResolver(ELResolver elResolver) {
+        if (!declaresConvertToType(elResolver)) {
+            return;
+        }
+
+        // grow array, if necessary
+        if (_convertELResolverCount == _convertELResolvers.length) {
+            ELResolver[] biggerResolvers = new ELResolver[_convertELResolverCount * 2];
+            System.arraycopy(_convertELResolvers, 0, biggerResolvers, 0, _convertELResolverCount);
+            _convertELResolvers = biggerResolvers;
+        }
+
+        // assign new resolver to end
+        _convertELResolvers[_convertELResolverCount] = elResolver;
+        _convertELResolverCount++;
+    }
+
+    private static boolean declaresConvertToType(ELResolver elResolver) {
+        try {
+            return elResolver.getClass().getMethod("convertToType", ELContext.class, Object.class, Class.class).getDeclaringClass() != ELResolver.class;
+        } catch (NoSuchMethodException e) {
+            // Cannot happen: convertToType is public on ELResolver itself.
+            return true;
+        }
+    }
+
     public void _addPropertyELResolver(ELResolver elResolver) {
         if (elResolver == null) {
             throw new NullPointerException();
@@ -109,6 +142,7 @@ public class DemuxCompositeELResolver extends FacesCompositeELResolver {
 
         _addRootELResolver(elResolver);
         _addAllELResolver(elResolver);
+        _addConvertELResolver(elResolver);
     }
 
     @Override
@@ -119,6 +153,7 @@ public class DemuxCompositeELResolver extends FacesCompositeELResolver {
 
         _addPropertyELResolver(elResolver);
         _addAllELResolver(elResolver);
+        _addConvertELResolver(elResolver);
     }
 
     @Override
@@ -130,6 +165,7 @@ public class DemuxCompositeELResolver extends FacesCompositeELResolver {
         _addRootELResolver(elResolver);
         _addPropertyELResolver(elResolver);
         _addAllELResolver(elResolver);
+        _addConvertELResolver(elResolver);
     }
 
     private Object _getValue(int resolverCount, ELResolver[] resolvers, ELContext context, Object base, Object property) throws ELException {
@@ -248,6 +284,21 @@ public class DemuxCompositeELResolver extends FacesCompositeELResolver {
         }
 
         return _isReadOnly(resolverCount, resolvers, context, base, property);
+    }
+
+    @Override
+    public <T> T convertToType(ELContext context, Object obj, Class<T> targetType) {
+        context.setPropertyResolved(false);
+
+        for (int i = 0; i < _convertELResolverCount; i++) {
+            T value = _convertELResolvers[i].convertToType(context, obj, targetType);
+
+            if (context.isPropertyResolved()) {
+                return value;
+            }
+        }
+
+        return null;
     }
 
     @Override

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
@@ -126,7 +126,8 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
 
         // grab our component
         UIComponent c = findChild(ctx, parent, id);
-        if (null == c && context.isPostback() && UIComponent.isCompositeComponent(parent) && parent.getAttributes().get(id) != null) {
+        // Reparenting only ever applies to a child of a composite component, so that test gates the costlier ones.
+        if (null == c && UIComponent.isCompositeComponent(parent) && context.isPostback() && parent.getAttributes().get(id) != null) {
             c = findReparentedComponent(ctx, parent, id);
         } else {
             /**


### PR DESCRIPTION
Ref #5753

Four impl-side changes found by JFR-profiling `test/perf` on Tomcat. Every number below comes from an **interleaved** A/B (prebuilt jars swapped between alternating runs, median of 3+ reps) — sequential legs on this bench drift by up to ±10% and are not trustworthy for effects this size.

The API-side companion is jakartaee/faces#2204, which must merge first so the `faces` submodule pin can be bumped here.

### 1. Skip ELResolvers which cannot contribute a conversion

`ELContext.convertToType` consults the `ELResolver` chain before falling back to `ExpressionFactory.coerceToType`, and `CompositeELResolver.convertToType` walks **every** resolver in it. No Mojarra `ELResolver` declares `convertToType`, and the inherited `ELResolver.convertToType` returns `null` *without* marking the property resolved — so consulting those resolvers cannot affect the result.

`DemuxCompositeELResolver` now tracks the resolvers which do declare it in a `_convertELResolvers` array, filled at `add()` time, and walks only those. In the default configuration only `jakarta.el.OptionalELResolver` qualifies, so the walk collapses from the whole chain to a single resolver. Registration order is preserved, and a nested `CompositeELResolver` still declares the method and is still walked.

Every `ValueExpression` built from a tag attribute carries an expected type of `Object.class`, so this runs on **every EL evaluation**.

| cell | before | after | Δ |
|---|--:|--:|--:|
| composite-inputs PROCESS_VALIDATIONS | 915 µs | 849 µs | **-7.2%** |
| composite-inputs RENDER_RESPONSE | 800 µs | 773 µs | -3.4% |

Verified with 10 assertions (non-overriders skipped; overriders consulted in registration order; first to set `propertyResolved` wins; a declining overrider falls through; a nested `CompositeELResolver` still walked) which the old and new implementations pass identically.

### 2. Back the composite component stacks by ArrayList

`CompositeComponentStackManager` kept both stacks in `java.util.Stack`, whose `Vector` superclass **synchronizes** every `push`, `pop`, `peek` and `isEmpty`. The stacks are request-confined and never shared across threads, so the monitor is pure overhead — and they are touched on every evaluation of every `#{cc}` expression.

`ArrayDeque` is not an option: `findCompositeComponentUsingLocation` and `TreeCreationStackHandler.getParentCompositeComponent` address the stack by index. Also extracts `isResourceOf`, which matches the trailing `/` positionally instead of building a `'/' + resourceName` string per candidate per evaluation.

| cell | before | after | Δ |
|---|--:|--:|--:|
| composite-inputs PROCESS_VALIDATIONS | 955 µs | 908 µs | **-4.9%** |
| composite-inputs RENDER_RESPONSE | 823 µs | 809 µs | -1.7% |

### 3. Gate the postback check behind the composite component check

Reparenting only ever applies to a child of a composite component, and `UIComponent.isCompositeComponent` is a field read whereas `FacesContext.isPostback` resolves through the `FacesContext` attributes map. Ordering them cheapest-first means a view without composite components never asks for the postback state while building.

**Wall time unchanged** — this is ordering hygiene, kept because it is simply the right order.

### 4. Build the annotation handler params only when a handler exists

`AnnotationManager.applyAnnotations` took `Object... params` and allocated the array **before** looking up the handler map. `ProcessAnnotationsTask` returns an empty map for any class with no `@ListenerFor`/`@ResourceDependency` — i.e. every standard component and renderer — so the array was discarded unused. It escapes into `RuntimeAnnotationHandler.apply`, so it cannot be scalar-replaced.

Roughly **99.3% of calls found an empty map**: 103.4 MB of `Object[]` (~3.5M arrays) against only 0.8 MB of `HashMap$ValueIterator`, which is allocated once per non-empty map iteration.

| | before | after | Δ |
|---|--:|--:|--:|
| AnnotationManager allocation | 12.78 KB/request | 0.17 KB/request | **-98.7%** |

**Wall time unchanged.** Called once per component created during `RESTORE_VIEW`. Kept for the allocation reduction, not for throughput.

### Suite result

Full `test/perf` suite on Tomcat, Mojarra vs MyFaces 4.1.4-SNAPSHOT, after all changes (impl + API companion):

| phase | Mojarra | MyFaces | Δ |
|---|--:|--:|--:|
| RESTORE_VIEW | 12.8 s | 13.2 s | -3% |
| APPLY_REQUEST_VALUES | 3.0 s | 3.5 s | -14% |
| PROCESS_VALIDATIONS | 10.9 s | 11.3 s | -4% |
| UPDATE_MODEL_VALUES | 3.5 s | 4.0 s | -12% |
| RENDER_RESPONSE | 35.5 s | 42.1 s | -16% |

`PROCESS_VALIDATIONS` crossed over from +9% to -4%; `RENDER_RESPONSE` went from -5% to -16%. Note the MyFaces control arm drifted +4.6% between sessions, so roughly half of the suite-total delta is drift — the per-cell numbers above, measured interleaved, are the trustworthy ones.

### Testing

Full Faces TCK green.

🤖 Generated with Claude Opus 4.8
