### PR TITLE
Backport EL resolution, composite component and component-id performance to 4.0

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/annotation/AnnotationManager.java
+++ b/impl/src/main/java/com/sun/faces/application/annotation/AnnotationManager.java
@@ -262,14 +262,38 @@ public class AnnotationManager {
      * @param ctx the {@link jakarta.faces.context.FacesContext} for the current request
      * @param targetClass class of the <code>processingTarget</code>
      * @param processingTarget the type of component that is being processed
-     * @param params one or more parameters to be passed to each {@link RuntimeAnnotationHandler}
+     * @param param the parameter to be passed to each {@link RuntimeAnnotationHandler}
      */
-    private void applyAnnotations(FacesContext ctx, Class<?> targetClass, ProcessingTarget processingTarget, Object... params) {
+    private void applyAnnotations(FacesContext ctx, Class<?> targetClass, ProcessingTarget processingTarget, Object param) {
         Map<Class<? extends Annotation>, RuntimeAnnotationHandler> map = getHandlerMap(targetClass, processingTarget);
         if (map != null && !map.isEmpty()) {
-            for (RuntimeAnnotationHandler handler : map.values()) {
-                handler.apply(ctx, params);
-            }
+            applyHandlers(ctx, map, new Object[] { param });
+        }
+    }
+
+    /**
+     * Apply all annotations associated with <code>targetClass</code>
+     *
+     * @param ctx the {@link jakarta.faces.context.FacesContext} for the current request
+     * @param targetClass class of the <code>processingTarget</code>
+     * @param processingTarget the type of component that is being processed
+     * @param param1 the first parameter to be passed to each {@link RuntimeAnnotationHandler}
+     * @param param2 the second parameter to be passed to each {@link RuntimeAnnotationHandler}
+     */
+    private void applyAnnotations(FacesContext ctx, Class<?> targetClass, ProcessingTarget processingTarget, Object param1, Object param2) {
+        Map<Class<? extends Annotation>, RuntimeAnnotationHandler> map = getHandlerMap(targetClass, processingTarget);
+        if (map != null && !map.isEmpty()) {
+            applyHandlers(ctx, map, new Object[] { param1, param2 });
+        }
+    }
+
+    /**
+     * The parameter array is built only once a handler is known to exist. Nearly every component, renderer, converter
+     * and validator carries no runtime annotation at all, and its handler map is empty.
+     */
+    private static void applyHandlers(FacesContext ctx, Map<Class<? extends Annotation>, RuntimeAnnotationHandler> map, Object[] params) {
+        for (RuntimeAnnotationHandler handler : map.values()) {
+            handler.apply(ctx, params);
         }
     }
 

--- a/impl/src/main/java/com/sun/faces/component/CompositeComponentStackManager.java
+++ b/impl/src/main/java/com/sun/faces/component/CompositeComponentStackManager.java
@@ -16,7 +16,8 @@
 
 package com.sun.faces.component;
 
-import java.util.Stack;
+import java.util.ArrayList;
+import java.util.List;
 
 import jakarta.faces.application.Resource;
 import jakarta.faces.component.UIComponent;
@@ -170,13 +171,12 @@ public class CompositeComponentStackManager {
     public UIComponent findCompositeComponentUsingLocation(FacesContext ctx, Location location) {
 
         StackHandler sh = getStackHandler(StackType.TreeCreation);
-        Stack<UIComponent> s = sh.getStack(false);
+        List<UIComponent> s = sh.getStack(false);
         if (s != null) {
             String path = location.getPath();
             for (int i = s.size(); i > 0; i--) {
                 UIComponent cc = s.get(i - 1);
-                Resource r = (Resource) cc.getAttributes().get(Resource.COMPONENT_RESOURCE_KEY);
-                if (path.endsWith('/' + r.getResourceName()) && path.contains(r.getLibraryName())) {
+                if (isResourceOf(path, cc)) {
                     return cc;
                 }
             }
@@ -185,8 +185,7 @@ public class CompositeComponentStackManager {
             String path = location.getPath();
             UIComponent cc = UIComponent.getCurrentCompositeComponent(ctx);
             while (cc != null) {
-                Resource r = (Resource) cc.getAttributes().get(Resource.COMPONENT_RESOURCE_KEY);
-                if (path.endsWith('/' + r.getResourceName()) && path.contains(r.getLibraryName())) {
+                if (isResourceOf(path, cc)) {
                     return cc;
                 }
                 cc = UIComponent.getCompositeComponentParent(cc);
@@ -200,7 +199,30 @@ public class CompositeComponentStackManager {
         return UIComponent.getCurrentCompositeComponent(ctx);
     }
 
+    /**
+     * <p>
+     * Return <code>true</code> if <code>path</code> ends with the composite component's resource name, preceded by a
+     * <code>/</code>, and contains its library name.
+     * </p>
+     */
+    private static boolean isResourceOf(String path, UIComponent compositeComponent) {
+
+        Resource resource = (Resource) compositeComponent.getAttributes().get(Resource.COMPONENT_RESOURCE_KEY);
+        String resourceName = resource.getResourceName();
+        int start = path.length() - resourceName.length() - 1;
+
+        return start >= 0 && path.charAt(start) == '/' && path.endsWith(resourceName) && path.contains(resource.getLibraryName());
+    }
+
     // --------------------------------------------------------- Private Methods
+
+    private static UIComponent last(List<UIComponent> stack) {
+        return stack.get(stack.size() - 1);
+    }
+
+    private static UIComponent removeLast(List<UIComponent> stack) {
+        return stack.remove(stack.size() - 1);
+    }
 
     private StackHandler getStackHandler(StackType type) {
 
@@ -233,15 +255,22 @@ public class CompositeComponentStackManager {
 
         void delete();
 
-        Stack<UIComponent> getStack(boolean create);
+        List<UIComponent> getStack(boolean create);
 
     }
 
     // ---------------------------------------------------------- Nested Classes
 
+    /**
+     * <p>
+     * Both stacks are confined to a single request and are never shared across threads. The backing list must support
+     * indexed access: {@link #findCompositeComponentUsingLocation} and
+     * {@link TreeCreationStackHandler#getParentCompositeComponent} address the stack by index.
+     * </p>
+     */
     private abstract class BaseStackHandler implements StackHandler {
 
-        protected Stack<UIComponent> stack;
+        protected List<UIComponent> stack;
 
         // ------------------------------------------- Methods from StackHandler
 
@@ -253,10 +282,10 @@ public class CompositeComponentStackManager {
         }
 
         @Override
-        public Stack<UIComponent> getStack(boolean create) {
+        public List<UIComponent> getStack(boolean create) {
 
             if (stack == null && create) {
-                stack = new Stack<>();
+                stack = new ArrayList<>();
             }
             return stack;
 
@@ -266,7 +295,7 @@ public class CompositeComponentStackManager {
         public UIComponent peek() {
 
             if (stack != null && !stack.isEmpty()) {
-                return stack.peek();
+                return last(stack);
             }
             return null;
 
@@ -281,7 +310,7 @@ public class CompositeComponentStackManager {
         @Override
         public void delete() {
 
-            Stack s = getStack(false);
+            List<UIComponent> s = getStack(false);
             if (s != null) {
                 s.clear();
             }
@@ -291,9 +320,9 @@ public class CompositeComponentStackManager {
         @Override
         public void pop() {
 
-            Stack s = getStack(false);
+            List<UIComponent> s = getStack(false);
             if (s != null && !s.isEmpty()) {
-                s.pop();
+                removeLast(s);
             }
 
         }
@@ -308,8 +337,8 @@ public class CompositeComponentStackManager {
         @Override
         public boolean push(UIComponent compositeComponent) {
 
-            Stack<UIComponent> tstack = treeCreation.getStack(false);
-            Stack<UIComponent> stack = getStack(false);
+            List<UIComponent> tstack = treeCreation.getStack(false);
+            List<UIComponent> stack = getStack(false);
             UIComponent ccp;
             if (tstack != null) {
                 // We have access to the stack of composite components
@@ -327,7 +356,7 @@ public class CompositeComponentStackManager {
 
                 if (compositeComponent == null) {
                     if (stack != null && !stack.isEmpty()) {
-                        ccp = getCompositeParent(stack.peek());
+                        ccp = getCompositeParent(last(stack));
                     } else {
                         ccp = getCompositeParent(UIComponent.getCurrentCompositeComponent(FacesContext.getCurrentInstance()));
                     }
@@ -340,7 +369,7 @@ public class CompositeComponentStackManager {
                 if (stack == null) {
                     stack = getStack(true);
                 }
-                stack.push(ccp);
+                stack.add(ccp);
                 return true;
             }
             return false;
@@ -371,9 +400,9 @@ public class CompositeComponentStackManager {
         @Override
         public void pop() {
 
-            Stack s = getStack(false);
+            List<UIComponent> s = getStack(false);
             if (s != null && !stack.isEmpty()) {
-                stack.pop();
+                removeLast(stack);
                 if (stack.isEmpty()) {
                     delete();
                 }
@@ -393,8 +422,8 @@ public class CompositeComponentStackManager {
 
             if (compositeComponent != null) {
                 assert UIComponent.isCompositeComponent(compositeComponent);
-                Stack<UIComponent> s = getStack(true);
-                s.push(compositeComponent);
+                List<UIComponent> s = getStack(true);
+                s.add(compositeComponent);
                 return true;
             }
             return false;
@@ -404,7 +433,7 @@ public class CompositeComponentStackManager {
         @Override
         public UIComponent getParentCompositeComponent(FacesContext ctx, UIComponent forComponent) {
 
-            Stack<UIComponent> s = getStack(false);
+            List<UIComponent> s = getStack(false);
             if (s == null) {
                 return null;
             } else {

--- a/impl/src/main/java/com/sun/faces/el/DemuxCompositeELResolver.java
+++ b/impl/src/main/java/com/sun/faces/el/DemuxCompositeELResolver.java
@@ -35,10 +35,12 @@ public class DemuxCompositeELResolver extends FacesCompositeELResolver {
     private ELResolver[] _rootELResolvers = new ELResolver[2];
     private ELResolver[] _propertyELResolvers = new ELResolver[2];
     private ELResolver[] _allELResolvers = new ELResolver[2];
+    private ELResolver[] _convertELResolvers = new ELResolver[2];
 
     private int _rootELResolverCount = 0;
     private int _propertyELResolverCount = 0;
     private int _allELResolverCount = 0;
+    private int _convertELResolverCount = 0;
 
     public DemuxCompositeELResolver(ELResolverChainType chainType) {
         if (chainType == null) {
@@ -87,6 +89,37 @@ public class DemuxCompositeELResolver extends FacesCompositeELResolver {
         _rootELResolverCount++;
     }
 
+    /**
+     * Registers <code>elResolver</code> for {@link #convertToType} only when it actually declares that method.
+     * {@link ELResolver#convertToType} returns <code>null</code> without marking the property as resolved, so a
+     * resolver which inherits it can never contribute a conversion, and consulting it is a no-op.
+     */
+    private void _addConvertELResolver(ELResolver elResolver) {
+        if (!declaresConvertToType(elResolver)) {
+            return;
+        }
+
+        // grow array, if necessary
+        if (_convertELResolverCount == _convertELResolvers.length) {
+            ELResolver[] biggerResolvers = new ELResolver[_convertELResolverCount * 2];
+            System.arraycopy(_convertELResolvers, 0, biggerResolvers, 0, _convertELResolverCount);
+            _convertELResolvers = biggerResolvers;
+        }
+
+        // assign new resolver to end
+        _convertELResolvers[_convertELResolverCount] = elResolver;
+        _convertELResolverCount++;
+    }
+
+    private static boolean declaresConvertToType(ELResolver elResolver) {
+        try {
+            return elResolver.getClass().getMethod("convertToType", ELContext.class, Object.class, Class.class).getDeclaringClass() != ELResolver.class;
+        } catch (NoSuchMethodException e) {
+            // Cannot happen: convertToType is public on ELResolver itself.
+            return true;
+        }
+    }
+
     public void _addPropertyELResolver(ELResolver elResolver) {
         if (elResolver == null) {
             throw new NullPointerException();
@@ -112,6 +145,7 @@ public class DemuxCompositeELResolver extends FacesCompositeELResolver {
 
         _addRootELResolver(elResolver);
         _addAllELResolver(elResolver);
+        _addConvertELResolver(elResolver);
     }
 
     @Override
@@ -122,6 +156,7 @@ public class DemuxCompositeELResolver extends FacesCompositeELResolver {
 
         _addPropertyELResolver(elResolver);
         _addAllELResolver(elResolver);
+        _addConvertELResolver(elResolver);
     }
 
     @Override
@@ -133,6 +168,7 @@ public class DemuxCompositeELResolver extends FacesCompositeELResolver {
         _addRootELResolver(elResolver);
         _addPropertyELResolver(elResolver);
         _addAllELResolver(elResolver);
+        _addConvertELResolver(elResolver);
     }
 
     private Object _getValue(int resolverCount, ELResolver[] resolvers, ELContext context, Object base, Object property) throws ELException {
@@ -326,6 +362,21 @@ public class DemuxCompositeELResolver extends FacesCompositeELResolver {
         private final int _resolverCount;
         private int _currResolverIndex;
         private Iterator<FeatureDescriptor> _currIterator;
+    }
+
+    @Override
+    public <T> T convertToType(ELContext context, Object obj, Class<T> targetType) {
+        context.setPropertyResolved(false);
+
+        for (int i = 0; i < _convertELResolverCount; i++) {
+            T value = _convertELResolvers[i].convertToType(context, obj, targetType);
+
+            if (context.isPropertyResolved()) {
+                return value;
+            }
+        }
+
+        return null;
     }
 
     @Override

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
@@ -126,7 +126,8 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
 
         // grab our component
         UIComponent c = findChild(ctx, parent, id);
-        if (null == c && context.isPostback() && UIComponent.isCompositeComponent(parent) && parent.getAttributes().get(id) != null) {
+        // Reparenting only ever applies to a child of a composite component, so that test gates the costlier ones.
+        if (null == c && UIComponent.isCompositeComponent(parent) && context.isPostback() && parent.getAttributes().get(id) != null) {
             c = findReparentedComponent(ctx, parent, id);
         } else {
             /**

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -3825,28 +3825,45 @@ public abstract class UIComponentBase extends UIComponent {
             return base;
         }
 
-        // Search through our facets and children
-        UIComponent component = null;
-        for (Iterator<UIComponent> i = base.getFacetsAndChildren(); i.hasNext();) {
-            UIComponent kid = i.next();
-            if (!(kid instanceof NamingContainer)) {
-                if (checkId && id.equals(kid.getId())) {
-                    component = kid;
-                    break;
-                }
-
-                component = findComponent(kid, id, true);
-
+        // Search through our facets and children, in the order getFacetsAndChildren() defines (facets first),
+        // but without that method's per-node wrapper collection and iterator: this walk recurses over the whole
+        // subtree, so allocating two objects per node visited dominates the cost of resolving a single id.
+        if (base.getFacetCount() != 0) {
+            for (UIComponent facet : base.getFacets().values()) {
+                UIComponent component = findComponentInKid(facet, id);
                 if (component != null) {
-                    break;
+                    return component;
                 }
-            } else if (id.equals(kid.getId())) {
-                component = kid;
-                break;
             }
         }
 
-        return component;
+        if (base.getChildCount() != 0) {
+            List<UIComponent> children = base.getChildren();
+            for (int i = 0, size = children.size(); i < size; i++) {
+                UIComponent component = findComponentInKid(children.get(i), id);
+                if (component != null) {
+                    return component;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * <p>
+     * Match <code>id</code> against a single facet or child of the component being searched: a
+     * {@link NamingContainer} matches only on its own id and is never descended into, any other kid is matched
+     * by a recursive scan which checks its own id first.
+     * </p>
+     */
+    private static UIComponent findComponentInKid(UIComponent kid, String id) {
+
+        if (kid instanceof NamingContainer) {
+            return id.equals(kid.getId()) ? kid : null;
+        }
+
+        return findComponent(kid, id, true);
     }
 
     private List<Object> collectChildState(FacesContext context, List<Object> stateList) {

--- a/impl/src/main/java/jakarta/faces/component/UIData.java
+++ b/impl/src/main/java/jakarta/faces/component/UIData.java
@@ -1225,10 +1225,16 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
 
     @Override
     public String createUniqueId(FacesContext context, String seed) {
+        // A seed is already unique within the view, so the counter -- and the state write backing it -- is only
+        // needed to generate an id when no seed is given.
+        if (seed != null) {
+            return UIViewRoot.UNIQUE_ID_PREFIX + seed;
+        }
+
         Integer i = (Integer) getStateHelper().get(PropertyKeys.lastId);
         int lastId = i != null ? i : 0;
         getStateHelper().put(PropertyKeys.lastId, ++lastId);
-        return UIViewRoot.UNIQUE_ID_PREFIX + (seed == null ? lastId : seed);
+        return UIViewRoot.UNIQUE_ID_PREFIX + lastId;
     }
 
     /**

--- a/impl/src/main/java/jakarta/faces/component/UIForm.java
+++ b/impl/src/main/java/jakarta/faces/component/UIForm.java
@@ -16,7 +16,6 @@
 
 package jakarta.faces.component;
 
-import static com.sun.faces.util.Util.coalesce;
 import static jakarta.faces.component.UIViewRoot.UNIQUE_ID_PREFIX;
 import static jakarta.faces.component.visit.VisitResult.COMPLETE;
 
@@ -275,11 +274,18 @@ public class UIForm extends UIComponentBase implements NamingContainer, UniqueId
     @Override
     public String createUniqueId(FacesContext context, String seed) {
         if (isPrependId()) {
-            int lastId = coalesce(getLastId(), 0);
+            // A seed is already unique within the view, so the counter -- and the state write backing it -- is only
+            // needed to generate an id when no seed is given.
+            if (seed != null) {
+                return UNIQUE_ID_PREFIX + seed;
+            }
+
+            Integer i = getLastId();
+            int lastId = i != null ? i : 0;
 
             setLastId(++lastId);
 
-            return UNIQUE_ID_PREFIX + coalesce(seed, lastId);
+            return UNIQUE_ID_PREFIX + lastId;
         }
 
         UIComponent ancestorNamingContainer = getParent() == null ? null : getParent().getNamingContainer();

--- a/impl/src/main/java/jakarta/faces/component/UINamingContainer.java
+++ b/impl/src/main/java/jakarta/faces/component/UINamingContainer.java
@@ -16,7 +16,6 @@
 
 package jakarta.faces.component;
 
-import static com.sun.faces.util.Util.coalesce;
 import static jakarta.faces.component.UIViewRoot.UNIQUE_ID_PREFIX;
 import static jakarta.faces.component.visit.VisitResult.COMPLETE;
 import static java.util.logging.Level.SEVERE;
@@ -167,10 +166,17 @@ public class UINamingContainer extends UIComponentBase implements NamingContaine
 
     @Override
     public String createUniqueId(FacesContext context, String seed) {
-        int lastId = coalesce(getLastId(), 0);
+        // A seed is already unique within the view, so the counter -- and the state write backing it -- is only
+        // needed to generate an id when no seed is given.
+        if (seed != null) {
+            return UNIQUE_ID_PREFIX + seed;
+        }
+
+        Integer i = getLastId();
+        int lastId = i != null ? i : 0;
         setLastId(++lastId);
 
-        return UNIQUE_ID_PREFIX + coalesce(seed, lastId);
+        return UNIQUE_ID_PREFIX + lastId;
     }
 
     // ----------------------------------------------------- Private Methods


### PR DESCRIPTION
Ref #5753

Backport of #5842 (impl) and jakartaee/faces#2204 (API) into 4.0. On 4.0 both live in `impl/`, so this is a single branch of six commits, ordered API-first.

All performance figures were measured on 4.1's `test/perf` with an **interleaved** A/B (prebuilt jars swapped between alternating runs, median of 3+ reps); 4.0 has no perf bench of its own. Sequential legs on this bench drift by up to ±10% and are not trustworthy for effects this size.

### Commits

| # | change | effect |
|---|---|---|
| 1 | `UIComponentBase.findComponent` iterates facets/children directly instead of allocating `getFacetsAndChildren()` per node | **RENDER_RESPONSE -12…-14%** on the `form-*` scenarios |
| 2 | `createUniqueId` skips the `lastId` state write when a seed is given | allocation + saved state; wall neutral |
| 3 | `DemuxCompositeELResolver` walks only the ELResolvers which declare `convertToType` | **PROCESS_VALIDATIONS -7.2%** on `composite-inputs` |
| 4 | `CompositeComponentStackManager` backs its stacks by `ArrayList` instead of the synchronized `java.util.Stack` | **PROCESS_VALIDATIONS -4.9%** on `composite-inputs` |
| 5 | `ComponentTagHandlerDelegateImpl` gates `isPostback()` behind the composite-component field read | wall neutral; ordering hygiene |
| 6 | `AnnotationManager` builds the handler params array only when a handler exists | **-98.7%** of that site's allocation; wall neutral |

Commits 2, 5 and 6 are explicitly wall-time **neutral** and are carried for allocation, saved state and correct ordering — not throughput. They are included so 4.0, 4.1 and 5.0 stay identical and the later upmerges are clean.

### Correction to #5842

The merged #5842 commit and description state that *"No Mojarra ELResolver declares `convertToType`"*. **That is wrong** — `EmptyStringToNullELResolver` declares it as `public <T> T convertToType`, which the original grep missed.

The code is unaffected. That resolver is registered through `addPropertyELResolver`, so `_addConvertELResolver` captures it, and it is still consulted and still marks the property resolved for the empty-string-to-null case. The same holds for the `CompositeELResolver` returned by `getApplicationELResolvers()`, which is always in the chain.

The accurate statement, used in this backport's commit message: the declaring resolvers are the application-resolvers `CompositeELResolver`, `EmptyStringToNullELResolver` when `jakarta.faces.INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL` is enabled, and whatever the Jakarta Expression Language implementation contributes (`OptionalELResolver` on EL 6; it does not exist in EL 5.0, which 4.0 compiles against). The walk therefore collapses from ~a dozen resolvers to one or two — the same win, just not "zero to one".

### Porting notes

Three files needed hand-porting rather than the 4.1 patch, because 4.0 has drifted:

- `CompositeComponentStackManager` — 4.0 has non-`final` handler fields and raw `Stack s` declarations. The fields are left non-`final` so no unrelated change sneaks in.
- `DemuxCompositeELResolver` — 4.0 still carries the deprecated `getFeatureDescriptors`, so it was edited in place rather than overwritten.
- `AnnotationManager` — this change originated on master and was ported down.

`jakarta.el-api` 5.0.0 declares the identical `<T> T convertToType(ELContext, Object, Class<T>)` signature, so the override compiles unchanged. 4.0 targets Java 11, so the stack helpers are explicit rather than `List.getLast()`.

### Testing

Builds clean on JDK 21. The three behavioural harnesses used on #5842 and jakartaee/faces#2204 were re-run against the 4.0 classes — 46 assertions, all green:

- `findComponent`: facets-before-children order, `NamingContainer` never descended into, `checkId` semantics, duplicate ids across facet and child, empty components (12)
- `createUniqueId`: seed returned verbatim, seeded call never advances the counter, seedless sequence contiguous, across all four `UniqueIdVendor`s (24)
- `convertToType`: non-declarers skipped, declarers consulted in registration order, first to set `propertyResolved` wins, declining declarer falls through, nested `CompositeELResolver` still walked (10)

Full Faces TCK was green for the equivalent changes on 5.0.

🤖 Generated with Claude Opus 4.8
