### PR TITLE
Do not destroy the @ViewScoped beans of a view map which is still in use

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/ViewScopeContext.java
+++ b/impl/src/main/java/com/sun/faces/application/view/ViewScopeContext.java
@@ -80,7 +80,13 @@ public class ViewScopeContext implements Context, Serializable {
     public <T> T get(Contextual<T> contextual) {
         FacesContext facesContext = getActiveFacesContext();
         ViewScopeManager manager = ViewScopeManager.getInstance(facesContext);
-        return manager != null ? manager.getContextManager().getBean(facesContext, contextual) : null;
+
+        if (manager == null) {
+            return null;
+        }
+
+        ViewScopeManager.acquireViewMap(facesContext);
+        return manager.getContextManager().getBean(facesContext, contextual);
     }
 
     /**
@@ -99,6 +105,8 @@ public class ViewScopeContext implements Context, Serializable {
         if (manager == null) {
             return null;
         }
+
+        ViewScopeManager.acquireViewMap(facesContext);
 
         T result = manager.getContextManager().getBean(facesContext, contextual);
         if (result == null) {

--- a/impl/src/main/java/com/sun/faces/application/view/ViewScopeContextManager.java
+++ b/impl/src/main/java/com/sun/faces/application/view/ViewScopeContextManager.java
@@ -336,16 +336,26 @@ public class ViewScopeContextManager {
         Map<Object, Map<String, ViewScopeContextObject>> activeViewScopeContexts = (Map<Object, Map<String, ViewScopeContextObject>>)
                 session.getAttribute(ACTIVE_VIEW_CONTEXTS);
         if (activeViewScopeContexts != null) {
-            Map<String, Object> activeViewMaps = (Map<String, Object>) session.getAttribute(ViewScopeManager.ACTIVE_VIEW_MAPS);
-            if (activeViewMaps != null) {
-                for (Map.Entry<String, Object> viewMapEntry : activeViewMaps.entrySet()) {
-                    Map<String, ViewScopeContextObject> contextMap = activeViewScopeContexts.get(viewMapEntry.getKey());
-                    destroyBeans((Map<String, Object>) viewMapEntry.getValue(), contextMap);
-                }
-            }
+            destroyAllBeans((Map<String, ?>) session.getAttribute(ViewScopeManager.ACTIVE_VIEW_MAPS), activeViewScopeContexts);
+            destroyAllBeans(ViewScopeManager.getEvictedViewMaps(session), activeViewScopeContexts);
 
             activeViewScopeContexts.clear();
             session.removeAttribute(ACTIVE_VIEW_CONTEXTS);
+        }
+    }
+
+    /**
+     * Destroy the view scoped beans of each of the given view maps.
+     *
+     * @param viewMaps the view maps, mapped by their id, or null when there are none.
+     * @param activeViewScopeContexts the context maps of all view maps.
+     */
+    @SuppressWarnings("unchecked")
+    private void destroyAllBeans(Map<String, ?> viewMaps, Map<Object, Map<String, ViewScopeContextObject>> activeViewScopeContexts) {
+        if (viewMaps != null) {
+            for (Map.Entry<String, ?> viewMapEntry : viewMaps.entrySet()) {
+                destroyBeans((Map<String, Object>) viewMapEntry.getValue(), activeViewScopeContexts.get(viewMapEntry.getKey()));
+            }
         }
     }
 

--- a/impl/src/main/java/com/sun/faces/application/view/ViewScopeManager.java
+++ b/impl/src/main/java/com/sun/faces/application/view/ViewScopeManager.java
@@ -21,9 +21,15 @@ import static com.sun.faces.config.WebConfiguration.WebContextInitParameter.Numb
 import static java.util.logging.Level.FINEST;
 import static java.util.logging.Level.WARNING;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Logger;
 
@@ -33,6 +39,7 @@ import com.sun.faces.util.LRUMap;
 
 import jakarta.faces.application.FacesMessage;
 import jakarta.faces.application.ProjectStage;
+import jakarta.faces.component.TransientStateHelper;
 import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.AbortProcessingException;
@@ -73,6 +80,14 @@ public class ViewScopeManager implements HttpSessionListener, ViewMapListener {
      * Stores the constant to keep track of the ViewScopeManager.
      */
     public static final String VIEW_SCOPE_MANAGER = "com.sun.faces.application.view.viewScopeManager";
+    /**
+     * Stores the constant to keep track of the view maps which are in use by unfinished requests.
+     */
+    private static final String VIEW_MAP_USAGES = "com.sun.faces.application.view.viewMapUsages";
+    /**
+     * Stores the constant to keep track of the view map ids which the current request has acquired.
+     */
+    private static final String ACQUIRED_VIEW_MAP_IDS = "com.sun.faces.application.view.acquiredViewMapIds";
     /**
      * Stores the CDI context manager.
      */
@@ -300,15 +315,13 @@ public class ViewScopeManager implements HttpSessionListener, ViewMapListener {
                     }
 
                     if (viewMaps.size() == size) {
-                        String eldestViewMapId = viewMaps.keySet().iterator().next();
-                        @SuppressWarnings("unchecked")
-                        Map<String, Object> eldestViewMap = (Map<String, Object>) viewMaps.remove(eldestViewMapId);
-                        removeEldestViewMap(facesContext, eldestViewMapId, eldestViewMap);
+                        evictEldestViewMap(facesContext, viewMaps);
                     }
 
                     viewMaps.put(viewMapId, viewMap);
                     viewRoot.getTransientStateHelper().putTransient(VIEW_MAP_ID, viewMapId);
                     viewRoot.getTransientStateHelper().putTransient(VIEW_MAP, viewMap);
+                    acquireViewMap(facesContext, viewMapId);
                     if (distributable) {
                         // If we are distributable, this will result in a dirtying of the
                         // session data, forcing replication. If we are not distributable,
@@ -389,22 +402,256 @@ public class ViewScopeManager implements HttpSessionListener, ViewMapListener {
             session.removeAttribute(ACTIVE_VIEW_MAPS);
             session.removeAttribute(ACTIVE_VIEW_MAPS_SIZE);
         }
+
+        session.removeAttribute(VIEW_MAP_USAGES);
     }
 
     /**
-     * Remove the eldest view map from the active view maps.
+     * Evict the eldest view map from the given active view maps. Its beans are destroyed immediately, unless an
+     * unfinished request is still using it, in which case the last request using it will destroy them.
+     *
+     * @param facesContext the Faces context.
+     * @param viewMaps the active view maps, whose monitor must be held by the caller.
+     */
+    private void evictEldestViewMap(FacesContext facesContext, Map<String, Object> viewMaps) {
+        String eldestViewMapId = viewMaps.keySet().iterator().next();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> eldestViewMap = (Map<String, Object>) viewMaps.remove(eldestViewMapId);
+
+        if (getViewMapUsages(facesContext).evict(eldestViewMapId, eldestViewMap)) {
+            LOGGER.log(FINEST, "Postponing destroy of eldest view map which is still in use: {0}", eldestViewMap);
+        } else {
+            destroyViewMap(facesContext, eldestViewMapId, eldestViewMap);
+        }
+    }
+
+    /**
+     * Registers that the current request is using the view map of the current view root, if any. This keeps its beans
+     * alive until the current request has finished, even when a concurrent request evicts the view map meanwhile. When
+     * it has meanwhile been evicted and destroyed by a concurrent request, then it is forgotten, so that the next
+     * {@link UIViewRoot#getViewMap(boolean)} creates and registers a new one.
+     *
+     * @param facesContext the Faces context.
+     */
+    public static void acquireViewMap(FacesContext facesContext) {
+        UIViewRoot viewRoot = facesContext.getViewRoot();
+
+        if (viewRoot == null) {
+            return;
+        }
+
+        TransientStateHelper transientStateHelper = viewRoot.getTransientStateHelper();
+        String viewMapId = (String) transientStateHelper.getTransient(VIEW_MAP_ID);
+
+        if (viewMapId != null && !acquireViewMap(facesContext, viewMapId)) {
+            transientStateHelper.putTransient(VIEW_MAP_ID, null);
+            transientStateHelper.putTransient(VIEW_MAP, null);
+        }
+    }
+
+    /**
+     * Registers that the current request is using the view map with the given id, so that a concurrent eviction of
+     * that view map will not destroy its beans before this request has finished. This is a no-op when the current
+     * request has already acquired it.
+     *
+     * @param facesContext the Faces context.
+     * @param viewMapId the view map id.
+     * @return false when the view map has meanwhile been evicted and destroyed by a concurrent request, in which case
+     * it must no longer be used.
+     */
+    private static boolean acquireViewMap(FacesContext facesContext, String viewMapId) {
+        Set<String> acquiredViewMapIds = getAcquiredViewMapIds(facesContext);
+
+        if (acquiredViewMapIds.contains(viewMapId)) {
+            return true;
+        }
+
+        Map<String, Object> viewMaps = getActiveViewMaps(facesContext);
+
+        if (viewMaps == null) {
+            return true; // The session holds no active view maps at all, hence there is nothing to protect.
+        }
+
+        synchronized (viewMaps) {
+            ViewMapUsages viewMapUsages = getViewMapUsages(facesContext);
+
+            if (!viewMaps.containsKey(viewMapId) && !viewMapUsages.isEvicted(viewMapId)) {
+                return false;
+            }
+
+            viewMapUsages.acquire(viewMapId);
+        }
+
+        acquiredViewMapIds.add(viewMapId);
+        return true;
+    }
+
+    /**
+     * Registers that the current request has finished using the view maps which it has acquired. Any of those which
+     * were meanwhile evicted while this was the last request using it will have their beans destroyed right now.
+     *
+     * @param facesContext the Faces context.
+     */
+    public static void releaseViewMaps(FacesContext facesContext) {
+        @SuppressWarnings("unchecked")
+        Set<String> acquiredViewMapIds = (Set<String>) facesContext.getAttributes().remove(ACQUIRED_VIEW_MAP_IDS);
+        Map<String, Object> viewMaps = acquiredViewMapIds != null ? getActiveViewMaps(facesContext) : null;
+
+        if (viewMaps == null) {
+            return;
+        }
+
+        for (String viewMapId : acquiredViewMapIds) {
+            Map<String, Object> evictedViewMap;
+
+            synchronized (viewMaps) {
+                evictedViewMap = getViewMapUsages(facesContext).release(viewMapId);
+            }
+
+            if (evictedViewMap != null) {
+                try {
+                    getInstance(facesContext).destroyViewMap(facesContext, viewMapId, evictedViewMap);
+                } catch (RuntimeException e) {
+                    LOGGER.log(WARNING, "Cannot destroy the @ViewScoped beans of the evicted view map: " + viewMapId, e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Destroy the given view map which has been removed from the active view maps.
      *
      * @param facesContext the context
      * @param viewMapId the view map id
-     * @param eldestViewMap the eldest view map.
+     * @param viewMap the view map.
      */
-    private void removeEldestViewMap(FacesContext facesContext, String viewMapId, Map<String, Object> eldestViewMap) {
-        LOGGER.log(FINEST, "Removing eldest view map: {0}", eldestViewMap);
+    private void destroyViewMap(FacesContext facesContext, String viewMapId, Map<String, Object> viewMap) {
+        LOGGER.log(FINEST, "Removing view map: {0}", viewMap);
 
         if (contextManager != null) {
-            contextManager.clear(facesContext, viewMapId, eldestViewMap);
+            contextManager.clear(facesContext, viewMapId, viewMap);
         }
 
-        destroyBeans(facesContext, eldestViewMap);
+        destroyBeans(facesContext, viewMap);
+    }
+
+    /**
+     * Get the active view maps of the current session, or null when there is no session or none have been registered.
+     *
+     * @param facesContext the Faces context.
+     * @return the active view maps, or null.
+     */
+    private static Map<String, Object> getActiveViewMaps(FacesContext facesContext) {
+        if (facesContext.getExternalContext().getSession(false) == null) {
+            return null;
+        }
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> viewMaps = (Map<String, Object>) facesContext.getExternalContext().getSessionMap().get(ACTIVE_VIEW_MAPS);
+        return viewMaps;
+    }
+
+    /**
+     * Get the usages of the view maps of the current session. The caller must hold the monitor of the active view maps.
+     *
+     * @param facesContext the Faces context.
+     * @return the usages of the view maps of the current session.
+     */
+    private static ViewMapUsages getViewMapUsages(FacesContext facesContext) {
+        return (ViewMapUsages) facesContext.getExternalContext().getSessionMap().computeIfAbsent(VIEW_MAP_USAGES, key -> new ViewMapUsages());
+    }
+
+    /**
+     * Get the view maps of the given session which have been evicted while an unfinished request was still using them,
+     * or null when there are none.
+     *
+     * @param session the HTTP session.
+     * @return the view maps which have been evicted while still in use, or null.
+     */
+    static Map<String, Map<String, Object>> getEvictedViewMaps(HttpSession session) {
+        ViewMapUsages viewMapUsages = (ViewMapUsages) session.getAttribute(VIEW_MAP_USAGES);
+        return viewMapUsages != null ? viewMapUsages.evictedViewMaps : null;
+    }
+
+    /**
+     * Get the ids of the view maps which the current request has acquired.
+     *
+     * @param facesContext the Faces context.
+     * @return the ids of the view maps which the current request has acquired.
+     */
+    private static Set<String> getAcquiredViewMapIds(FacesContext facesContext) {
+        @SuppressWarnings("unchecked")
+        Set<String> acquiredViewMapIds = (Set<String>) facesContext.getAttributes().computeIfAbsent(ACQUIRED_VIEW_MAP_IDS, key -> new HashSet<>());
+        return acquiredViewMapIds;
+    }
+
+    /**
+     * Keeps track of the amount of unfinished requests which are using each view map, and of the view maps which have
+     * been evicted from the active view maps while they were still in use, so that the last request using such a view
+     * map can destroy its beans. Guarded by the monitor of the active view maps.
+     * <p>
+     * The state is transient: unfinished requests do not survive a session passivation, so upon activation no view map
+     * is in use anymore and every evicted view map is beyond recovery.
+     */
+    private static final class ViewMapUsages implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private transient Map<String, Integer> activeRequests = new HashMap<>();
+        private transient Map<String, Map<String, Object>> evictedViewMaps = new HashMap<>();
+
+        /**
+         * Registers that one more request is using the view map with the given id.
+         */
+        private void acquire(String viewMapId) {
+            activeRequests.merge(viewMapId, 1, Integer::sum);
+        }
+
+        /**
+         * Registers that one less request is using the view map with the given id.
+         *
+         * @return the view map which has meanwhile been evicted and must now be destroyed, or null when other requests
+         * are still using it, or when it has not been evicted at all.
+         */
+        private Map<String, Object> release(String viewMapId) {
+            if (activeRequests.computeIfPresent(viewMapId, ViewMapUsages::decrement) != null) {
+                return null;
+            }
+
+            return evictedViewMaps.remove(viewMapId);
+        }
+
+        /**
+         * Registers that the view map with the given id has been evicted from the active view maps.
+         *
+         * @return true when an unfinished request is still using it, in which case its destroy must be postponed until
+         * that request releases it, and false when it can be destroyed right now.
+         */
+        private boolean evict(String viewMapId, Map<String, Object> viewMap) {
+            if (!activeRequests.containsKey(viewMapId)) {
+                return false;
+            }
+
+            evictedViewMaps.put(viewMapId, viewMap);
+            return true;
+        }
+
+        /**
+         * Returns whether the view map with the given id has been evicted while it was still in use, hence whether its
+         * beans are still alive.
+         */
+        private boolean isEvicted(String viewMapId) {
+            return evictedViewMaps.containsKey(viewMapId);
+        }
+
+        private static Integer decrement(String viewMapId, Integer activeRequests) {
+            return activeRequests > 1 ? activeRequests - 1 : null;
+        }
+
+        private void readObject(ObjectInputStream objectInputStream) throws IOException, ClassNotFoundException {
+            objectInputStream.defaultReadObject();
+            activeRequests = new HashMap<>();
+            evictedViewMaps = new HashMap<>();
+        }
     }
 }

--- a/impl/src/main/java/com/sun/faces/context/FacesContextImpl.java
+++ b/impl/src/main/java/com/sun/faces/context/FacesContextImpl.java
@@ -27,7 +27,7 @@ import java.util.NoSuchElementException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.sun.faces.cdi.CdiExtension;
+import com.sun.faces.application.view.ViewScopeManager;
 import com.sun.faces.cdi.CdiUtils;
 import com.sun.faces.el.ELContextImpl;
 import com.sun.faces.renderkit.RenderKitUtils;
@@ -512,6 +512,7 @@ public class FacesContextImpl extends FacesContext {
     @Override
     public void release() {
         BeanManager beanManager = Util.getCdiBeanManager(this);
+        ViewScopeManager.releaseViewMaps(this);
 
         released = true;
         if (externalContext != null) {

--- a/impl/src/main/java/com/sun/faces/lifecycle/RestoreViewPhase.java
+++ b/impl/src/main/java/com/sun/faces/lifecycle/RestoreViewPhase.java
@@ -66,6 +66,7 @@ import jakarta.faces.render.ResponseStateManager;
 import jakarta.faces.view.ViewDeclarationLanguage;
 import jakarta.faces.view.ViewMetadata;
 
+import com.sun.faces.application.view.ViewScopeManager;
 import com.sun.faces.util.FacesLogger;
 import com.sun.faces.util.MessageUtils;
 import com.sun.faces.util.Util;
@@ -169,6 +170,8 @@ public class RestoreViewPhase extends Phase {
 
                 facesContext.setViewRoot(viewRoot);
                 facesContext.setProcessingEvents(true);
+
+                ViewScopeManager.acquireViewMap(facesContext);
 
                 if (LOGGER.isLoggable(FINE)) {
                     LOGGER.fine("Postback: restored view for " + viewId);

--- a/test/issue5844/pom.xml
+++ b/test/issue5844/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.mojarra.test</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.0.19-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>issue5844</artifactId>
+    <packaging>war</packaging>
+
+    <name>Mojarra ${project.version} - INTEGRATION TESTS - ${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.mojarra.test</groupId>
+            <artifactId>base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/test/issue5844/src/main/java/org/eclipse/mojarra/test/issue5844/Issue5844Bean.java
+++ b/test/issue5844/src/main/java/org/eclipse/mojarra/test/issue5844/Issue5844Bean.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package org.eclipse.mojarra.test.issue5844;
+
+import java.io.Serializable;
+
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+@Named
+@ViewScoped
+public class Issue5844Bean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    private Issue5844Latch latch;
+
+    private String param;
+
+    public String getParam() {
+        return param;
+    }
+
+    /**
+     * Only wave A has an f:viewParam, so only wave A gets here. By now ViewScopeContextManager#createBean() has already
+     * registered this request's view map in the session, and this bean holds the value which must survive until render.
+     * So this is exactly where wave A must wait for wave B to come and evict it.
+     */
+    public void setParam(String param) {
+        this.param = param;
+
+        if (param != null) {
+            latch.awaitWaveB();
+        }
+    }
+}

--- a/test/issue5844/src/main/java/org/eclipse/mojarra/test/issue5844/Issue5844Gate.java
+++ b/test/issue5844/src/main/java/org/eclipse/mojarra/test/issue5844/Issue5844Gate.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package org.eclipse.mojarra.test.issue5844;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+/**
+ * Sequences wave B, which deliberately has no f:viewParam: an f:viewParam would already create the @ViewScoped bean
+ * during PROCESS_VALIDATIONS, when UIInput#validate() evaluates the value expression, and hence register the view map
+ * before any gate bound to UPDATE_MODEL could hold it back.
+ */
+@Named
+@RequestScoped
+public class Issue5844Gate {
+
+    @Inject
+    private Issue5844Latch latch;
+
+    /**
+     * Bound to f:viewAction, so it runs in INVOKE_APPLICATION, well before render creates the @ViewScoped bean.
+     */
+    public void awaitWaveA() {
+        latch.awaitWaveA();
+    }
+
+    /**
+     * Rendered after the @ViewScoped bean, hence after this request has registered its view map and thereby evicted
+     * wave A.
+     */
+    public String getSignal() {
+        latch.signalWaveBRegistered();
+        return "";
+    }
+}

--- a/test/issue5844/src/main/java/org/eclipse/mojarra/test/issue5844/Issue5844Latch.java
+++ b/test/issue5844/src/main/java/org/eclipse/mojarra/test/issue5844/Issue5844Latch.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package org.eclipse.mojarra.test.issue5844;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.util.concurrent.CountDownLatch;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Sequences two waves of concurrent requests so that the eviction is deterministic.
+ * <p>
+ * Wave A first registers its view maps and lets f:viewParam put a value in its @ViewScoped beans, and then waits. Only
+ * then does wave B register its view maps, which overflows the LRU map of active view maps and thereby evicts wave A's
+ * view maps while wave A is still in flight. Wave A is released once wave B has registered, and then renders.
+ * <p>
+ * Both waves must fit in GlassFish's default http-thread-pool size of 5, else they cannot be in flight at once.
+ */
+@ApplicationScoped
+public class Issue5844Latch {
+
+    /** The number of requests per wave, against a maximum of 2 active view maps. */
+    public static final int REQUESTS_PER_WAVE = 2;
+
+    private static final int TIMEOUT_IN_SECONDS = 30;
+
+    private final CountDownLatch waveAReady = new CountDownLatch(REQUESTS_PER_WAVE);
+    private final CountDownLatch waveBRegistered = new CountDownLatch(REQUESTS_PER_WAVE);
+
+    /**
+     * Invoked by wave A right after f:viewParam has put a value in its @ViewScoped bean. Signals that wave A holds its
+     * value and then waits until wave B has evicted it.
+     */
+    public void awaitWaveB() {
+        waveAReady.countDown();
+        await(waveBRegistered);
+    }
+
+    /**
+     * Invoked by wave B before it touches the @ViewScoped bean, hence before it registers its view map. Waits until
+     * wave A holds its value.
+     */
+    public void awaitWaveA() {
+        await(waveAReady);
+    }
+
+    /**
+     * Invoked by wave B right after it has registered its view map, which is what evicts wave A.
+     */
+    public void signalWaveBRegistered() {
+        waveBRegistered.countDown();
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await(TIMEOUT_IN_SECONDS, SECONDS);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/test/issue5844/src/main/webapp/WEB-INF/beans.xml
+++ b/test/issue5844/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/test/issue5844/src/main/webapp/WEB-INF/web.xml
+++ b/test/issue5844/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+    version="5.0"
+>
+    <!-- Artificially low so that the test needs only a handful of concurrent requests to overflow the LRU map of active view maps. -->
+    <context-param>
+        <param-name>com.sun.faces.numberOfActiveViewMaps</param-name>
+        <param-value>2</param-value>
+    </context-param>
+
+    <servlet>
+        <servlet-name>facesServlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>facesServlet</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/test/issue5844/src/main/webapp/wavea.xhtml
+++ b/test/issue5844/src/main/webapp/wavea.xhtml
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="en"
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:f="jakarta.faces.core"
+    xmlns:h="jakarta.faces.html"
+>
+    <f:metadata>
+        <f:viewParam name="param" value="#{issue5844Bean.param}" />
+    </f:metadata>
+
+    <h:head />
+
+    <h:body>
+        <span id="param">#{issue5844Bean.param}</span>
+    </h:body>
+</html>

--- a/test/issue5844/src/main/webapp/waveb.xhtml
+++ b/test/issue5844/src/main/webapp/waveb.xhtml
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="en"
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:f="jakarta.faces.core"
+    xmlns:h="jakarta.faces.html"
+>
+    <f:metadata>
+        <!-- Runs in INVOKE_APPLICATION, hence before render creates the view scoped bean. -->
+        <f:viewAction action="#{issue5844Gate.awaitWaveA}" />
+    </f:metadata>
+
+    <h:head />
+
+    <h:body>
+        <!-- Creating the view scoped bean registers this request's view map, which evicts wave A. -->
+        <span id="param">#{issue5844Bean.param}</span>
+        <span id="signal">#{issue5844Gate.signal}</span>
+    </h:body>
+</html>

--- a/test/issue5844/src/test/java/org/eclipse/mojarra/test/issue5844/Issue5844IT.java
+++ b/test/issue5844/src/test/java/org/eclipse/mojarra/test/issue5844/Issue5844IT.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package org.eclipse.mojarra.test.issue5844;
+
+import static java.net.URI.create;
+import static java.net.http.HttpRequest.newBuilder;
+import static java.net.http.HttpResponse.BodyHandlers.ofString;
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static org.eclipse.mojarra.test.issue5844.Issue5844Latch.REQUESTS_PER_WAVE;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.CookieManager;
+import java.net.http.HttpClient;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import org.eclipse.mojarra.test.base.BaseIT;
+import org.junit.jupiter.api.Test;
+
+class Issue5844IT extends BaseIT {
+
+    private static final String WAVE_A = "wavea.xhtml";
+    private static final String WAVE_B = "waveb.xhtml";
+    private static final String PARAM_VALUE = "foo";
+    private static final String EXPECTED_OUTPUT = "<span id=\"param\">" + PARAM_VALUE + "</span>";
+
+    /**
+     * When more requests are concurrently in flight within the same session than com.sun.faces.numberOfActiveViewMaps,
+     * then the LRU eviction of the eldest view map must not destroy its beans while the request owning it has not
+     * finished yet. That request keeps holding the very same view map, so when it were emptied, then it would during
+     * render silently re-create its @ViewScoped bean and thereby lose the value which f:viewParam had put in it.
+     * <p>
+     * Wave A is in flight and holds its value. Wave B then registers its own view maps, which overflows the LRU map of
+     * active view maps and evicts wave A. Wave A is released and renders. It must still hold its value.
+     *
+     * https://github.com/eclipse-ee4j/mojarra/issues/5844
+     */
+    @Test
+    void concurrentRequestsMustNotEvictEachOthersViewMap() throws Exception {
+        HttpClient client = HttpClient.newBuilder().cookieHandler(new CookieManager()).build(); // Shares the JSESSIONID.
+        getResponseBody(client, WAVE_A); // Creates the session. Deliberately without param, so it doesn't await.
+
+        ExecutorService executor = newFixedThreadPool(2 * REQUESTS_PER_WAVE);
+
+        try {
+            List<Future<String>> waveA = submit(executor, client, WAVE_A + "?param=" + PARAM_VALUE);
+            List<Future<String>> waveB = submit(executor, client, WAVE_B);
+
+            for (Future<String> response : waveB) {
+                response.get(); // Wave B only needs to register its view maps.
+            }
+
+            for (Future<String> response : waveA) {
+                String body = response.get();
+                assertTrue(body.contains(EXPECTED_OUTPUT), "@ViewScoped bean of wave A must still hold the view param, but rendered:\n" + body);
+            }
+        }
+        finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private List<Future<String>> submit(ExecutorService executor, HttpClient client, String resource) {
+        List<Future<String>> responses = new ArrayList<>();
+
+        for (int i = 0; i < REQUESTS_PER_WAVE; i++) {
+            responses.add(executor.submit(() -> getResponseBody(client, resource)));
+        }
+
+        return responses;
+    }
+
+    private String getResponseBody(HttpClient client, String resource) throws Exception {
+        return client.send(newBuilder(create(baseURL + resource)).build(), ofString()).body();
+    }
+}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -57,6 +57,7 @@
         <module>issue5750</module>
         <module>issue5772</module>
         <module>issue5837</module>
+        <module>issue5844</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Closes #5844

`ViewScopeManager.processPostConstructViewMap()` evicted the eldest view map on overflow and destroyed its `@ViewScoped` beans without checking whether the request owning it had finished. That request kept holding the very same, now emptied, view map, so it silently re-created its beans, losing whatever state they held, and those re-created beans were never destroyed. `@PreDestroy` was moreover invoked on beans of a request which was still executing.

## Fix

The usages of each view map are reference counted per session. On overflow the eldest view map is still removed from the LRU map right away, so the capacity is respected and a later postback still gets a fresh view scope, but its beans are destroyed only when no unfinished request is using it. Otherwise the last request releasing it destroys them.

A request acquires a view map:

- when it registers it, in `processPostConstructViewMap()`, atomically with the eviction because both run under the monitor of the active view maps;
- when it restores it, in `RestoreViewPhase`, which is the first moment a restored view root owns a view map;
- whenever it resolves a `@ViewScoped` bean, in `ViewScopeContext`.

and releases all of them in `FacesContextImpl.release()`.

When a view map turns out to have been evicted and destroyed already, the acquire fails and the view map is forgotten, so that the next `UIViewRoot#getViewMap(true)` creates and registers a new one instead of resurrecting a dead map. This also cleans up the case where `UIViewRoot#restoreState()` stores a `viewMapId` whose view map expired long ago.

Session destroy also destroys the beans of the view maps which were evicted while still in use, since those are no longer reachable through `ACTIVE_VIEW_MAPS`. The reference counts are transient: an unfinished request does not survive a session passivation.

## Test

`test/issue5844` runs two latched waves of concurrent requests within one HTTP session, against `com.sun.faces.numberOfActiveViewMaps=2`. Wave A parks in the `f:viewParam` setter, hence after its view maps are registered and while its `@ViewScoped` beans hold the param. Wave B then registers its own view maps, which overflows the LRU map and evicts wave A's. Wave A is released and must still render the param.

Red before the fix (wave A renders an empty param), green after. The full `test/` suite and the impl unit tests pass.

## Related

The same design, early registration into a capacity bounded session map combined with destroy on evict, produced the identical symptom in OmniFaces' own `@ViewScoped`, reported as omnifaces/omnifaces#966 and fixed there by the same reference counting.

🤖 Generated with Claude Opus 4.8
