### PR TITLE
Trim redundant per-node lookups from buildView and composite EL

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/facelets/el/ContextualCompositeValueExpression.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/el/ContextualCompositeValueExpression.java
@@ -106,13 +106,11 @@ public final class ContextualCompositeValueExpression extends ValueExpression {
     public <T> T getValue(ELContext elContext) {
 
         FacesContext ctx = (FacesContext) elContext.getContext(FacesContext.class);
-        boolean pushed = pushCompositeComponent(ctx);
+        CompositeComponentStackManager manager = pushCompositeComponent(ctx);
         try {
             return originalVE.getValue(elContext);
         } finally {
-            if (pushed) {
-                popCompositeComponent(ctx);
-            }
+            popCompositeComponent(manager);
         }
 
     }
@@ -121,13 +119,11 @@ public final class ContextualCompositeValueExpression extends ValueExpression {
     public void setValue(ELContext elContext, Object o) {
 
         FacesContext ctx = (FacesContext) elContext.getContext(FacesContext.class);
-        boolean pushed = pushCompositeComponent(ctx);
+        CompositeComponentStackManager manager = pushCompositeComponent(ctx);
         try {
             originalVE.setValue(elContext, o);
         } finally {
-            if (pushed) {
-                popCompositeComponent(ctx);
-            }
+            popCompositeComponent(manager);
         }
 
     }
@@ -136,13 +132,11 @@ public final class ContextualCompositeValueExpression extends ValueExpression {
     public boolean isReadOnly(ELContext elContext) {
 
         FacesContext ctx = (FacesContext) elContext.getContext(FacesContext.class);
-        boolean pushed = pushCompositeComponent(ctx);
+        CompositeComponentStackManager manager = pushCompositeComponent(ctx);
         try {
             return originalVE.isReadOnly(elContext);
         } finally {
-            if (pushed) {
-                popCompositeComponent(ctx);
-            }
+            popCompositeComponent(manager);
         }
 
     }
@@ -151,13 +145,11 @@ public final class ContextualCompositeValueExpression extends ValueExpression {
     public Class<?> getType(ELContext elContext) {
 
         FacesContext ctx = (FacesContext) elContext.getContext(FacesContext.class);
-        boolean pushed = pushCompositeComponent(ctx);
+        CompositeComponentStackManager manager = pushCompositeComponent(ctx);
         try {
             return originalVE.getType(elContext);
         } finally {
-            if (pushed) {
-                popCompositeComponent(ctx);
-            }
+            popCompositeComponent(manager);
         }
 
     }
@@ -166,13 +158,11 @@ public final class ContextualCompositeValueExpression extends ValueExpression {
     public Class<?> getExpectedType() {
 
         FacesContext ctx = FacesContext.getCurrentInstance();
-        boolean pushed = pushCompositeComponent(ctx);
+        CompositeComponentStackManager manager = pushCompositeComponent(ctx);
         try {
             return originalVE.getExpectedType();
         } finally {
-            if (pushed) {
-                popCompositeComponent(ctx);
-            }
+            popCompositeComponent(manager);
         }
     }
 
@@ -180,13 +170,11 @@ public final class ContextualCompositeValueExpression extends ValueExpression {
     public ValueReference getValueReference(ELContext elContext) {
 
         FacesContext ctx = (FacesContext) elContext.getContext(FacesContext.class);
-        boolean pushed = pushCompositeComponent(ctx);
+        CompositeComponentStackManager manager = pushCompositeComponent(ctx);
         try {
             return originalVE.getValueReference(elContext);
         } finally {
-            if (pushed) {
-                popCompositeComponent(ctx);
-            }
+            popCompositeComponent(manager);
         }
 
     }
@@ -229,18 +217,24 @@ public final class ContextualCompositeValueExpression extends ValueExpression {
 
     // ----------------------------------------------------- Private Methods
 
-    private boolean pushCompositeComponent(FacesContext ctx) {
+    /**
+     * @return the manager the composite component was pushed onto, or <code>null</code> when nothing was pushed. The
+     * manager is handed to {@link #popCompositeComponent(CompositeComponentStackManager)} so that the pop does not have
+     * to look it up again; every evaluation of this expression goes through this pair.
+     */
+    private CompositeComponentStackManager pushCompositeComponent(FacesContext ctx) {
 
         CompositeComponentStackManager manager = CompositeComponentStackManager.getManager(ctx);
         UIComponent cc = manager.findCompositeComponentUsingLocation(ctx, location);
-        return manager.push(cc);
+        return manager.push(cc) ? manager : null;
 
     }
 
-    private void popCompositeComponent(FacesContext ctx) {
+    private static void popCompositeComponent(CompositeComponentStackManager manager) {
 
-        CompositeComponentStackManager manager = CompositeComponentStackManager.getManager(ctx);
-        manager.pop();
+        if (manager != null) {
+            manager.pop();
+        }
 
     }
 

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/ComponentSupport.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/ComponentSupport.java
@@ -614,17 +614,28 @@ public final class ComponentSupport {
 
     public static boolean suppressViewModificationEvents(FacesContext ctx) {
 
+        String viewId = getViewIdForModificationEvents(ctx);
+        return viewId != null && StateContext.getStateContext(ctx).isPartialStateSaving(ctx, viewId);
+
+    }
+
+    /**
+     * Variant for callers that already hold the request's {@link StateContext}, so that a tree walk does not look it up
+     * once per component.
+     */
+    public static boolean suppressViewModificationEvents(FacesContext ctx, StateContext stateCtx) {
+
+        String viewId = getViewIdForModificationEvents(ctx);
+        return viewId != null && stateCtx.isPartialStateSaving(ctx, viewId);
+
+    }
+
+    private static String getViewIdForModificationEvents(FacesContext ctx) {
+
         // NO UIViewRoot means this was called during restore view -
         // no need to suppress events at that time
         UIViewRoot root = ctx.getViewRoot();
-        if (root != null) {
-            String viewId = root.getViewId();
-            if (viewId != null) {
-                StateContext stateCtx = StateContext.getStateContext(ctx);
-                return stateCtx.isPartialStateSaving(ctx, viewId);
-            }
-        }
-        return false;
+        return root != null ? root.getViewId() : null;
 
     }
 

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -161,6 +162,7 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
         }
 
         CompositeComponentStackManager ccStackManager = CompositeComponentStackManager.getManager(context);
+        StateContext stateContext = StateContext.getStateContext(context);
         boolean compcompPushed = pushComponentToEL(ctx, c, ccStackManager);
 
         if (ProjectStage.Development == context.getApplication().getProjectStage()) {
@@ -181,15 +183,22 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
         // children already attached) may contain components to reuse, so the scan stays active for its subtree.
         boolean freshSubtree = !componentFound && c.getChildCount() == 0;
         Map<Object, Object> contextAttributes = context.getAttributes();
-        Object previousFreshSubtree = contextAttributes.put(ComponentSupport.BUILDING_FRESH_SUBTREE, freshSubtree);
+        Object previousFreshSubtree = contextAttributes.get(ComponentSupport.BUILDING_FRESH_SUBTREE);
+        // The flag holds for a whole subtree, so it only has to be written when it actually flips.
+        boolean flipped = !Objects.equals(previousFreshSubtree, freshSubtree);
+        if (flipped) {
+            contextAttributes.put(ComponentSupport.BUILDING_FRESH_SUBTREE, freshSubtree);
+        }
         try {
             // first allow c to get populated
             owner.applyNextHandler(ctx, c);
         } finally {
-            if (previousFreshSubtree != null) {
-                contextAttributes.put(ComponentSupport.BUILDING_FRESH_SUBTREE, previousFreshSubtree);
-            } else {
-                contextAttributes.remove(ComponentSupport.BUILDING_FRESH_SUBTREE);
+            if (flipped) {
+                if (previousFreshSubtree != null) {
+                    contextAttributes.put(ComponentSupport.BUILDING_FRESH_SUBTREE, previousFreshSubtree);
+                } else {
+                    contextAttributes.remove(ComponentSupport.BUILDING_FRESH_SUBTREE);
+                }
             }
             if (isNaming) {
                 IterationIdManager.stopNamingContainer(ctx);
@@ -207,9 +216,9 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
         // add to the tree afterwards
         // this allows children to determine if it's
         // been part of the tree or not yet
-        addComponentToView(ctx, parent, c, componentFound, parentModified);
+        addComponentToView(ctx, parent, c, componentFound, parentModified, stateContext);
         ComponentSupport.copyPassthroughAttributes(ctx, c, owner.getTag());
-        adjustIndexOfDynamicChildren(context, c);
+        adjustIndexOfDynamicChildren(stateContext, c);
         popComponentFromEL(ctx, c, ccStackManager, compcompPushed);
     }
 
@@ -234,8 +243,7 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
         return parent.getAttributes().get(ComponentSupport.MARK_CHILDREN_MODIFIED) != null;
     }
 
-    private void adjustIndexOfDynamicChildren(FacesContext context, UIComponent parent) {
-        StateContext stateContext = StateContext.getStateContext(context);
+    private void adjustIndexOfDynamicChildren(StateContext stateContext, UIComponent parent) {
         if (!stateContext.hasOneOrMoreDynamicChild(parent)) {
             return;
         }
@@ -313,16 +321,17 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
 
     // ------------------------------------------------------- Protected Methods
 
-    private void addComponentToView(FaceletContext ctx, UIComponent parent, UIComponent c, boolean componentFound, boolean parentModified) {
+    private void addComponentToView(FaceletContext ctx, UIComponent parent, UIComponent c, boolean componentFound, boolean parentModified,
+            StateContext stateContext) {
         if (!componentFound || !parentModified) {
-            addComponentToView(ctx, parent, c, componentFound);
+            addComponentToView(ctx, parent, c, componentFound, stateContext);
         }
     }
 
-    protected void addComponentToView(FaceletContext ctx, UIComponent parent, UIComponent c, boolean componentFound) {
+    protected void addComponentToView(FaceletContext ctx, UIComponent parent, UIComponent c, boolean componentFound, StateContext stateContext) {
 
         FacesContext context = ctx.getFacesContext();
-        boolean suppressEvents = ComponentSupport.suppressViewModificationEvents(context);
+        boolean suppressEvents = ComponentSupport.suppressViewModificationEvents(context, stateContext);
         boolean compcomp = UIComponent.isCompositeComponent(c);
 
         if (suppressEvents && componentFound && !compcomp) {

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/html/ComponentResourceDelegate.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/html/ComponentResourceDelegate.java
@@ -28,6 +28,7 @@ import jakarta.faces.view.facelets.FaceletContext;
 import jakarta.faces.view.facelets.TagAttribute;
 import jakarta.faces.view.facelets.TagAttributes;
 
+import org.glassfish.mojarra.context.StateContext;
 import org.glassfish.mojarra.facelets.tag.faces.ComponentSupport;
 import org.glassfish.mojarra.facelets.tag.faces.ComponentTagHandlerDelegateImpl;
 
@@ -75,13 +76,13 @@ public abstract class ComponentResourceDelegate extends ComponentTagHandlerDeleg
     }
 
     @Override
-    protected void addComponentToView(FaceletContext ctx, UIComponent parent, UIComponent c, boolean componentFound) {
+    protected void addComponentToView(FaceletContext ctx, UIComponent parent, UIComponent c, boolean componentFound, StateContext stateContext) {
 
         if (!componentFound) {
             // default to the existing logic which will add the component
             // in-place. An event will be fired to move the component
             // as a UIViewRoot component resource
-            super.addComponentToView(ctx, parent, c, componentFound);
+            super.addComponentToView(ctx, parent, c, componentFound, stateContext);
         } else {
             // when re-applying we supress events for existing components,
             // so if we simply relied on the default logic, the resources
@@ -91,7 +92,7 @@ public abstract class ComponentResourceDelegate extends ComponentTagHandlerDeleg
                 final UIViewRoot root = ctx.getFacesContext().getViewRoot();
                 root.addComponentResource(ctx.getFacesContext(), c, target);
             } else {
-                super.addComponentToView(ctx, parent, c, componentFound);
+                super.addComponentToView(ctx, parent, c, componentFound, stateContext);
             }
         }
 

--- a/impl/src/test/java/jakarta/faces/component/UIInputTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIInputTestCase.java
@@ -23,6 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Iterator;
 
+import jakarta.el.ELContext;
+import jakarta.el.ValueExpression;
 import jakarta.faces.application.FacesMessage;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.PhaseId;
@@ -316,5 +318,98 @@ public class UIInputTestCase extends UIOutputTestCase {
             assertTrue(list1[i].getClass() == list2[i].getClass());
         }
         return true;
+    }
+
+    // The previous value only feeds the ValueChangeEvent, so validate() must not evaluate the value
+    // expression to obtain it when no ValueChangeListener could receive that event.
+    @Test
+    public void testValidateSkipsPreviousValueWhenNobodyListens() {
+        CountingValueExpression valueExpression = new CountingValueExpression();
+        UIInput input = newInputWithValueExpression(valueExpression);
+
+        input.validate(facesContext);
+
+        // Guard against a vacuous assertion: the read only happens on the valid branch, so prove it ran.
+        assertTrue(input.isValid());
+        assertTrue(input.isLocalValueSet());
+        assertEquals(0, valueExpression.reads, "value expression must not be evaluated");
+    }
+
+    @Test
+    public void testValidateReadsPreviousValueWhenObserved() {
+        CountingValueExpression valueExpression = new CountingValueExpression();
+        UIInput input = newInputWithValueExpression(valueExpression);
+        input.addValueChangeListener(new ValueChangeListenerTestImpl("VCL"));
+
+        input.validate(facesContext);
+
+        assertTrue(input.isValid());
+        assertTrue(input.isLocalValueSet());
+        assertEquals(1, valueExpression.reads, "value expression must be evaluated once");
+    }
+
+    // Submitting the value the expression already holds keeps compareValues() false, so no
+    // ValueChangeEvent is queued and the component needs no parent to queue it onto.
+    private static UIInput newInputWithValueExpression(CountingValueExpression valueExpression) {
+        UIInput input = new UIInput();
+        input.setRendererType(null);
+        input.setValueExpression("value", valueExpression);
+        input.setSubmittedValue(CountingValueExpression.VALUE);
+        return input;
+    }
+
+    private static final class CountingValueExpression extends ValueExpression {
+
+        private static final long serialVersionUID = 1L;
+
+        static final String VALUE = "unchanged";
+
+        int reads;
+
+        @Override
+        public Object getValue(ELContext context) {
+            reads++;
+            return VALUE;
+        }
+
+        @Override
+        public void setValue(ELContext context, Object value) {
+            // no-op
+        }
+
+        @Override
+        public boolean isReadOnly(ELContext context) {
+            return false;
+        }
+
+        @Override
+        public Class<?> getType(ELContext context) {
+            return String.class;
+        }
+
+        @Override
+        public Class<?> getExpectedType() {
+            return String.class;
+        }
+
+        @Override
+        public String getExpressionString() {
+            return "#{test.value}";
+        }
+
+        @Override
+        public boolean isLiteralText() {
+            return false;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other;
+        }
+
+        @Override
+        public int hashCode() {
+            return System.identityHashCode(this);
+        }
     }
 }


### PR DESCRIPTION
## Trim redundant per-node lookups from buildView and composite EL

Three behaviour-neutral cleanups on the hot Facelets build and composite-EL paths, plus the RI test for the paired jakarta.faces validation change.

### `ContextualCompositeValueExpression`

Every EL evaluation of a `#{cc.attrs.*}` expression looked the `CompositeComponentStackManager` up twice — once to push the composite component, once to pop it. Push now returns the manager it pushed onto (or null when nothing was pushed) and pop takes it; the null return gates the pop exactly as the previous boolean did.

### `ComponentTagHandlerDelegateImpl` (+ `ComponentSupport`, `ComponentResourceDelegate`)

`apply()` runs for every component of every buildView. It fetched the request `StateContext` twice; it is now fetched once and threaded through both callers, the way `ccStackManager` already is. And `BUILDING_FRESH_SUBTREE` was put and restored on every component — since the flag holds for a whole subtree, it is now written only when it actually flips.

### Test

`UIInputTestCase` locks in the `jakarta.faces` `UIInput.validate()` optimisation from jakartaee/faces#2208: with no `ValueChangeListener` the value expression must not be evaluated, with one it must be evaluated once. It reaches the valid branch first so the count cannot pass vacuously. As this optimisation is not explicitly mandated by the Faces spec, the test stays in the Mojarra repo rather than the Faces repo.

### Notes

These are redundancy removals, not measurable speedups on their own — standalone timing sits within bench noise (micro-optimisation); they are committed as hygiene. The real validation win lives in the API change above. Full Faces TCK is green.

**Depends on** jakartaee/faces#2208: the test goes green once the faces submodule pins an api build carrying the `UIInput.validate()` change.

Part of #5753.

🤖 Generated with Claude Opus 4.8
