### PR TITLE
4.0 backport: validation EL resolution + buildView performance

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/el/ContextualCompositeValueExpression.java
+++ b/impl/src/main/java/com/sun/faces/facelets/el/ContextualCompositeValueExpression.java
@@ -106,13 +106,11 @@ public final class ContextualCompositeValueExpression extends ValueExpression {
     public Object getValue(ELContext elContext) {
 
         FacesContext ctx = (FacesContext) elContext.getContext(FacesContext.class);
-        boolean pushed = pushCompositeComponent(ctx);
+        CompositeComponentStackManager manager = pushCompositeComponent(ctx);
         try {
             return originalVE.getValue(elContext);
         } finally {
-            if (pushed) {
-                popCompositeComponent(ctx);
-            }
+            popCompositeComponent(manager);
         }
 
     }
@@ -121,13 +119,11 @@ public final class ContextualCompositeValueExpression extends ValueExpression {
     public void setValue(ELContext elContext, Object o) {
 
         FacesContext ctx = (FacesContext) elContext.getContext(FacesContext.class);
-        boolean pushed = pushCompositeComponent(ctx);
+        CompositeComponentStackManager manager = pushCompositeComponent(ctx);
         try {
             originalVE.setValue(elContext, o);
         } finally {
-            if (pushed) {
-                popCompositeComponent(ctx);
-            }
+            popCompositeComponent(manager);
         }
 
     }
@@ -136,13 +132,11 @@ public final class ContextualCompositeValueExpression extends ValueExpression {
     public boolean isReadOnly(ELContext elContext) {
 
         FacesContext ctx = (FacesContext) elContext.getContext(FacesContext.class);
-        boolean pushed = pushCompositeComponent(ctx);
+        CompositeComponentStackManager manager = pushCompositeComponent(ctx);
         try {
             return originalVE.isReadOnly(elContext);
         } finally {
-            if (pushed) {
-                popCompositeComponent(ctx);
-            }
+            popCompositeComponent(manager);
         }
 
     }
@@ -151,13 +145,11 @@ public final class ContextualCompositeValueExpression extends ValueExpression {
     public Class<?> getType(ELContext elContext) {
 
         FacesContext ctx = (FacesContext) elContext.getContext(FacesContext.class);
-        boolean pushed = pushCompositeComponent(ctx);
+        CompositeComponentStackManager manager = pushCompositeComponent(ctx);
         try {
             return originalVE.getType(elContext);
         } finally {
-            if (pushed) {
-                popCompositeComponent(ctx);
-            }
+            popCompositeComponent(manager);
         }
 
     }
@@ -166,13 +158,11 @@ public final class ContextualCompositeValueExpression extends ValueExpression {
     public Class<?> getExpectedType() {
 
         FacesContext ctx = FacesContext.getCurrentInstance();
-        boolean pushed = pushCompositeComponent(ctx);
+        CompositeComponentStackManager manager = pushCompositeComponent(ctx);
         try {
             return originalVE.getExpectedType();
         } finally {
-            if (pushed) {
-                popCompositeComponent(ctx);
-            }
+            popCompositeComponent(manager);
         }
     }
 
@@ -180,13 +170,11 @@ public final class ContextualCompositeValueExpression extends ValueExpression {
     public ValueReference getValueReference(ELContext elContext) {
 
         FacesContext ctx = (FacesContext) elContext.getContext(FacesContext.class);
-        boolean pushed = pushCompositeComponent(ctx);
+        CompositeComponentStackManager manager = pushCompositeComponent(ctx);
         try {
             return originalVE.getValueReference(elContext);
         } finally {
-            if (pushed) {
-                popCompositeComponent(ctx);
-            }
+            popCompositeComponent(manager);
         }
 
     }
@@ -230,18 +218,24 @@ public final class ContextualCompositeValueExpression extends ValueExpression {
 
     // ----------------------------------------------------- Private Methods
 
-    private boolean pushCompositeComponent(FacesContext ctx) {
+    /**
+     * @return the manager the composite component was pushed onto, or <code>null</code> when nothing was pushed. The
+     * manager is handed to {@link #popCompositeComponent(CompositeComponentStackManager)} so that the pop does not have
+     * to look it up again; every evaluation of this expression goes through this pair.
+     */
+    private CompositeComponentStackManager pushCompositeComponent(FacesContext ctx) {
 
         CompositeComponentStackManager manager = CompositeComponentStackManager.getManager(ctx);
         UIComponent cc = manager.findCompositeComponentUsingLocation(ctx, location);
-        return manager.push(cc);
+        return manager.push(cc) ? manager : null;
 
     }
 
-    private void popCompositeComponent(FacesContext ctx) {
+    private static void popCompositeComponent(CompositeComponentStackManager manager) {
 
-        CompositeComponentStackManager manager = CompositeComponentStackManager.getManager(ctx);
-        manager.pop();
+        if (manager != null) {
+            manager.pop();
+        }
 
     }
 

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentSupport.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentSupport.java
@@ -603,17 +603,28 @@ public final class ComponentSupport {
 
     public static boolean suppressViewModificationEvents(FacesContext ctx) {
 
+        String viewId = getViewIdForModificationEvents(ctx);
+        return viewId != null && StateContext.getStateContext(ctx).isPartialStateSaving(ctx, viewId);
+
+    }
+
+    /**
+     * Variant for callers that already hold the request's {@link StateContext}, so that a tree walk does not look it up
+     * once per component.
+     */
+    public static boolean suppressViewModificationEvents(FacesContext ctx, StateContext stateCtx) {
+
+        String viewId = getViewIdForModificationEvents(ctx);
+        return viewId != null && stateCtx.isPartialStateSaving(ctx, viewId);
+
+    }
+
+    private static String getViewIdForModificationEvents(FacesContext ctx) {
+
         // NO UIViewRoot means this was called during restore view -
         // no need to suppress events at that time
         UIViewRoot root = ctx.getViewRoot();
-        if (root != null) {
-            String viewId = root.getViewId();
-            if (viewId != null) {
-                StateContext stateCtx = StateContext.getStateContext(ctx);
-                return stateCtx.isPartialStateSaving(ctx, viewId);
-            }
-        }
-        return false;
+        return root != null ? root.getViewId() : null;
 
     }
 

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -161,6 +162,7 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
         }
 
         CompositeComponentStackManager ccStackManager = CompositeComponentStackManager.getManager(context);
+        StateContext stateContext = StateContext.getStateContext(context);
         boolean compcompPushed = pushComponentToEL(ctx, c, ccStackManager);
 
         if (ProjectStage.Development == context.getApplication().getProjectStage()) {
@@ -181,15 +183,22 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
         // children already attached) may contain components to reuse, so the scan stays active for its subtree.
         boolean freshSubtree = !componentFound && c.getChildCount() == 0;
         Map<Object, Object> contextAttributes = context.getAttributes();
-        Object previousFreshSubtree = contextAttributes.put(ComponentSupport.BUILDING_FRESH_SUBTREE, freshSubtree);
+        Object previousFreshSubtree = contextAttributes.get(ComponentSupport.BUILDING_FRESH_SUBTREE);
+        // The flag holds for a whole subtree, so it only has to be written when it actually flips.
+        boolean flipped = !Objects.equals(previousFreshSubtree, freshSubtree);
+        if (flipped) {
+            contextAttributes.put(ComponentSupport.BUILDING_FRESH_SUBTREE, freshSubtree);
+        }
         try {
             // first allow c to get populated
             owner.applyNextHandler(ctx, c);
         } finally {
-            if (previousFreshSubtree != null) {
-                contextAttributes.put(ComponentSupport.BUILDING_FRESH_SUBTREE, previousFreshSubtree);
-            } else {
-                contextAttributes.remove(ComponentSupport.BUILDING_FRESH_SUBTREE);
+            if (flipped) {
+                if (previousFreshSubtree != null) {
+                    contextAttributes.put(ComponentSupport.BUILDING_FRESH_SUBTREE, previousFreshSubtree);
+                } else {
+                    contextAttributes.remove(ComponentSupport.BUILDING_FRESH_SUBTREE);
+                }
             }
             if (isNaming) {
                 IterationIdManager.stopNamingContainer(ctx);
@@ -207,9 +216,9 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
         // add to the tree afterwards
         // this allows children to determine if it's
         // been part of the tree or not yet
-        addComponentToView(ctx, parent, c, componentFound, parentModified);
+        addComponentToView(ctx, parent, c, componentFound, parentModified, stateContext);
         ComponentSupport.copyPassthroughAttributes(ctx, c, owner.getTag());
-        adjustIndexOfDynamicChildren(context, c);
+        adjustIndexOfDynamicChildren(stateContext, c);
         popComponentFromEL(ctx, c, ccStackManager, compcompPushed);
     }
 
@@ -233,8 +242,7 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
         return parent.getAttributes().get(ComponentSupport.MARK_CHILDREN_MODIFIED) != null;
     }
 
-    private void adjustIndexOfDynamicChildren(FacesContext context, UIComponent parent) {
-        StateContext stateContext = StateContext.getStateContext(context);
+    private void adjustIndexOfDynamicChildren(StateContext stateContext, UIComponent parent) {
         if (!stateContext.hasOneOrMoreDynamicChild(parent)) {
             return;
         }
@@ -312,16 +320,17 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
 
     // ------------------------------------------------------- Protected Methods
 
-    private void addComponentToView(FaceletContext ctx, UIComponent parent, UIComponent c, boolean componentFound, boolean parentModified) {
+    private void addComponentToView(FaceletContext ctx, UIComponent parent, UIComponent c, boolean componentFound, boolean parentModified,
+            StateContext stateContext) {
         if (!componentFound || !parentModified) {
-            addComponentToView(ctx, parent, c, componentFound);
+            addComponentToView(ctx, parent, c, componentFound, stateContext);
         }
     }
 
-    protected void addComponentToView(FaceletContext ctx, UIComponent parent, UIComponent c, boolean componentFound) {
+    protected void addComponentToView(FaceletContext ctx, UIComponent parent, UIComponent c, boolean componentFound, StateContext stateContext) {
 
         FacesContext context = ctx.getFacesContext();
-        boolean suppressEvents = ComponentSupport.suppressViewModificationEvents(context);
+        boolean suppressEvents = ComponentSupport.suppressViewModificationEvents(context, stateContext);
         boolean compcomp = UIComponent.isCompositeComponent(c);
 
         if (suppressEvents && componentFound && !compcomp) {

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/html/ComponentResourceDelegate.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/html/ComponentResourceDelegate.java
@@ -20,6 +20,7 @@ import static com.sun.faces.facelets.tag.faces.ComponentSupport.MARK_CREATED;
 
 import java.util.List;
 
+import com.sun.faces.context.StateContext;
 import com.sun.faces.facelets.tag.faces.ComponentSupport;
 import com.sun.faces.facelets.tag.faces.ComponentTagHandlerDelegateImpl;
 
@@ -75,13 +76,13 @@ public abstract class ComponentResourceDelegate extends ComponentTagHandlerDeleg
     }
 
     @Override
-    protected void addComponentToView(FaceletContext ctx, UIComponent parent, UIComponent c, boolean componentFound) {
+    protected void addComponentToView(FaceletContext ctx, UIComponent parent, UIComponent c, boolean componentFound, StateContext stateContext) {
 
         if (!componentFound) {
             // default to the existing logic which will add the component
             // in-place. An event will be fired to move the component
             // as a UIViewRoot component resource
-            super.addComponentToView(ctx, parent, c, componentFound);
+            super.addComponentToView(ctx, parent, c, componentFound, stateContext);
         } else {
             // when re-applying we supress events for existing components,
             // so if we simply relied on the default logic, the resources
@@ -91,7 +92,7 @@ public abstract class ComponentResourceDelegate extends ComponentTagHandlerDeleg
                 final UIViewRoot root = ctx.getFacesContext().getViewRoot();
                 root.addComponentResource(ctx.getFacesContext(), c, target);
             } else {
-                super.addComponentToView(ctx, parent, c, componentFound);
+                super.addComponentToView(ctx, parent, c, componentFound, stateContext);
             }
         }
 

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -764,6 +764,28 @@ public abstract class UIComponentBase extends UIComponent {
     }
 
     /**
+     * Whether at least one listener of the given type would receive an event broadcast by this component. Reads the
+     * same list {@link #broadcast} does, without building the arrays {@link #getFacesListeners} has to allocate.
+     *
+     * @param clazz the listener type to look for
+     * @return true if such a listener is attached
+     */
+    boolean hasFacesListener(Class<? extends FacesListener> clazz) {
+
+        if (listeners == null) {
+            return false;
+        }
+
+        for (Iterator<FacesListener> i = listeners.iterator(); i.hasNext();) {
+            if (clazz.isAssignableFrom(i.next().getClass())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @throws IllegalArgumentException {@inheritDoc}
      * @throws NullPointerException {@inheritDoc}
      */

--- a/impl/src/main/java/jakarta/faces/component/UIInput.java
+++ b/impl/src/main/java/jakarta/faces/component/UIInput.java
@@ -849,10 +849,16 @@ public class UIInput extends UIOutput implements EditableValueHolder {
         // If our value is valid, store the new value, erase the
         // "submitted" value, and emit a ValueChangeEvent if appropriate
         if (isValid()) {
-            Object previous = getValue();
+            // Reading the previous value evaluates the value expression, which walks the whole ELResolver chain and,
+            // with CDI in that chain, resolves the bean afresh. It only feeds the ValueChangeEvent, and a queued event
+            // is discarded at broadcast when nothing is listening for it, so skip the read in that case.
+            boolean valueChangeObserved = hasFacesListener(ValueChangeListener.class);
+            Object previous = valueChangeObserved ? getValue() : null;
+
             setValue(newValue);
             setSubmittedValue(null);
-            if (compareValues(previous, newValue)) {
+
+            if (valueChangeObserved && compareValues(previous, newValue)) {
                 queueEvent(new ValueChangeEvent(context, this, previous, newValue));
             }
         }

--- a/impl/src/main/java/jakarta/faces/validator/BeanValidator.java
+++ b/impl/src/main/java/jakarta/faces/validator/BeanValidator.java
@@ -35,6 +35,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
+import jakarta.el.ELContext;
 import jakarta.el.PropertyNotFoundException;
 import jakarta.el.ValueExpression;
 import jakarta.el.ValueReference;
@@ -313,17 +314,19 @@ public class BeanValidator implements Validator, PartialStateHolder {
             return;
         }
 
-        ValueReference valueReference = getValueReference(context, component, valueExpression);
+        ResolvedValueReference resolvedValueReference = resolveValueReference(context, component, valueExpression);
+        ValueReference valueReference = resolvedValueReference.getReference();
 
         if (valueReference == null || valueReference.getBase() == null) {
             return;
         }
 
         Class<?>[] validationGroupsArray = parseValidationGroups(getValidationGroups());
-        
+
         if (isResolvable(valueReference, valueExpression)) {
             jakarta.validation.Validator beanValidator = getBeanValidator(context);
-            Object coercedValue = value == null ? null : context.getApplication().getExpressionFactory().coerceToType(value, valueExpression.getType(context.getELContext()));
+            Object coercedValue = value == null ? null
+                    : context.getApplication().getExpressionFactory().coerceToType(value, getPropertyType(context, valueExpression, resolvedValueReference));
 
             @SuppressWarnings("rawtypes")
             Set violationsRaw = null;
@@ -368,7 +371,32 @@ public class BeanValidator implements Validator, PartialStateHolder {
         }
     }
 
-    private static ValueReference getValueReference(FacesContext context, UIComponent component, ValueExpression valueExpression) {
+    /**
+     * A {@link ValueReference}, plus whether it had to be unwrapped out of a composite component's
+     * <code>#{cc.attrs.x}</code> indirection. Once unwrapped it points at the backing bean property rather than at
+     * what the original expression's own {@link ValueExpression#getType} would report, which
+     * {@link #getPropertyType} has to account for.
+     */
+    private static final class ResolvedValueReference {
+
+        private final ValueReference reference;
+        private final boolean unwrappedFromCompositeComponent;
+
+        ResolvedValueReference(ValueReference reference, boolean unwrappedFromCompositeComponent) {
+            this.reference = reference;
+            this.unwrappedFromCompositeComponent = unwrappedFromCompositeComponent;
+        }
+
+        ValueReference getReference() {
+            return reference;
+        }
+
+        boolean isUnwrappedFromCompositeComponent() {
+            return unwrappedFromCompositeComponent;
+        }
+    }
+
+    private static ResolvedValueReference resolveValueReference(FacesContext context, UIComponent component, ValueExpression valueExpression) {
         try {
             ValueReference reference = valueExpression.getValueReference(context.getELContext());
             if (reference != null) {
@@ -376,11 +404,11 @@ public class BeanValidator implements Validator, PartialStateHolder {
                 if (base instanceof CompositeComponentExpressionHolder) {
                     ValueExpression ve = ((CompositeComponentExpressionHolder) base).getExpression(String.valueOf(reference.getProperty()));
                     if (ve != null) {
-                        reference = getValueReference(context, component, ve);
+                        return new ResolvedValueReference(resolveValueReference(context, component, ve).getReference(), true);
                     }
                 }
             }
-            return reference;
+            return new ResolvedValueReference(reference, false);
         }
         catch (PropertyNotFoundException e) {
             if (component instanceof UIInput && ((UIInput) component).getSubmittedValue() == null) {
@@ -391,11 +419,40 @@ public class BeanValidator implements Validator, PartialStateHolder {
                                        valueExpression.getExpressionString(),
                                        component.getId() });
                 }
-                return null;
+                return new ResolvedValueReference(null, false);
             } else {
                 throw e;
             }
         }
+    }
+
+    /**
+     * The type of the property the value expression points at.
+     * <p>
+     * {@link ValueExpression#getType} re-resolves the expression from its root and then asks the resolver about the
+     * base and property it arrives at. That base and property are exactly what the {@link ValueReference} already
+     * holds, so the resolver can be asked directly and the walk skipped -- which matters because with CDI in the
+     * resolver chain the root resolution is a bean lookup, once per input per request.
+     * <p>
+     * A reference unwrapped out of a composite component no longer describes the original expression's own target, so
+     * that case keeps the full walk.
+     */
+    private static Class<?> getPropertyType(FacesContext context, ValueExpression valueExpression, ResolvedValueReference resolvedValueReference) {
+        ELContext elContext = context.getELContext();
+
+        if (resolvedValueReference.isUnwrappedFromCompositeComponent()) {
+            return valueExpression.getType(elContext);
+        }
+
+        ValueReference valueReference = resolvedValueReference.getReference();
+        elContext.setPropertyResolved(false);
+        Class<?> type = elContext.getELResolver().getType(elContext, valueReference.getBase(), valueReference.getProperty());
+
+        if (!elContext.isPropertyResolved()) {
+            throw new PropertyNotFoundException(valueExpression.getExpressionString());
+        }
+
+        return type;
     }
 
     private boolean isResolvable(jakarta.el.ValueReference valueReference, ValueExpression valueExpression) {

--- a/impl/src/test/java/jakarta/faces/component/UIInputTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIInputTestCase.java
@@ -26,6 +26,8 @@ import java.util.Iterator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import jakarta.el.ELContext;
+import jakarta.el.ValueExpression;
 import jakarta.faces.application.FacesMessage;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.PhaseId;
@@ -314,5 +316,98 @@ public class UIInputTestCase extends UIOutputTestCase {
             assertTrue(list1[i].getClass() == list2[i].getClass());
         }
         return true;
+    }
+
+    // The previous value only feeds the ValueChangeEvent, so validate() must not evaluate the value
+    // expression to obtain it when no ValueChangeListener could receive that event.
+    @Test
+    public void testValidateSkipsPreviousValueWhenNobodyListens() {
+        CountingValueExpression valueExpression = new CountingValueExpression();
+        UIInput input = newInputWithValueExpression(valueExpression);
+
+        input.validate(facesContext);
+
+        // Guard against a vacuous assertion: the read only happens on the valid branch, so prove it ran.
+        assertTrue(input.isValid());
+        assertTrue(input.isLocalValueSet());
+        assertEquals(0, valueExpression.reads, "value expression must not be evaluated");
+    }
+
+    @Test
+    public void testValidateReadsPreviousValueWhenObserved() {
+        CountingValueExpression valueExpression = new CountingValueExpression();
+        UIInput input = newInputWithValueExpression(valueExpression);
+        input.addValueChangeListener(new ValueChangeListenerTestImpl("VCL"));
+
+        input.validate(facesContext);
+
+        assertTrue(input.isValid());
+        assertTrue(input.isLocalValueSet());
+        assertEquals(1, valueExpression.reads, "value expression must be evaluated once");
+    }
+
+    // Submitting the value the expression already holds keeps compareValues() false, so no
+    // ValueChangeEvent is queued and the component needs no parent to queue it onto.
+    private static UIInput newInputWithValueExpression(CountingValueExpression valueExpression) {
+        UIInput input = new UIInput();
+        input.setRendererType(null);
+        input.setValueExpression("value", valueExpression);
+        input.setSubmittedValue(CountingValueExpression.VALUE);
+        return input;
+    }
+
+    private static final class CountingValueExpression extends ValueExpression {
+
+        private static final long serialVersionUID = 1L;
+
+        static final String VALUE = "unchanged";
+
+        int reads;
+
+        @Override
+        public Object getValue(ELContext context) {
+            reads++;
+            return VALUE;
+        }
+
+        @Override
+        public void setValue(ELContext context, Object value) {
+            // no-op
+        }
+
+        @Override
+        public boolean isReadOnly(ELContext context) {
+            return false;
+        }
+
+        @Override
+        public Class<?> getType(ELContext context) {
+            return String.class;
+        }
+
+        @Override
+        public Class<?> getExpectedType() {
+            return String.class;
+        }
+
+        @Override
+        public String getExpressionString() {
+            return "#{test.value}";
+        }
+
+        @Override
+        public boolean isLiteralText() {
+            return false;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other;
+        }
+
+        @Override
+        public int hashCode() {
+            return System.identityHashCode(this);
+        }
     }
 }


### PR DESCRIPTION
## 4.0 backport: validation EL resolution + buildView performance

Backports jakartaee/faces#2208 and eclipse-ee4j/mojarra#5846 to 4.0. On 4.0 the `jakarta.faces.*` API still lives in `impl` (no faces submodule) on `com.sun.faces` and Java 11, so both PRs land as one branch; `ResolvedValueReference` is a plain class, so Java 11 is fine.

### Validation: two redundant EL resolver walks per input removed (jakartaee/faces#2208)

During PROCESS_VALIDATIONS each input resolved its value expression from the root more times than it needed to. Every root-identifier resolution walks the full `ELResolver` chain, and with a CDI `ELResolver` in that chain each walk is a bean lookup (a fresh `CreationalContext` per call). 
- `UIInput.validate()` read the previous value with `getValue()` only to feed a `ValueChangeEvent` that is discarded at broadcast when nobody listens; it is now guarded by a new package-private `UIComponentBase.hasFacesListener()`. 
- `BeanValidator.validate()` called `ValueExpression.getType()` — re-resolving the expression from its root — right after `resolveValueReference()` had already resolved the base and property; it now asks the resolver for the type of the base and property the `ValueReference` already holds, keeping the full walk only for a reference unwrapped out of a composite component's `#{cc.attrs.x}`.

### buildView + composite EL: redundant per-node lookups trimmed (eclipse-ee4j/mojarra#5846)

- `ContextualCompositeValueExpression` looked the `CompositeComponentStackManager` up twice per `#{cc.attrs.*}` evaluation (push and pop); push now returns the manager and pop takes it. 
- `ComponentTagHandlerDelegateImpl.apply()`, which runs for every component of every buildView, fetched the request `StateContext` twice — now once, threaded through — and rewrote `BUILDING_FRESH_SUBTREE` on every component, now only when the flag actually flips.

### Measured (validation change)

Tomcat, order-balanced interleaved A/B, warm single-thread bench, four validation-heavy scenarios.

| scenario | PROCESS_VALIDATIONS | scenario total |
|---|--:|--:|
| composite-inputs | −39.8% | −13.0% |
| form-inputs | −31.1% | −2.7% |
| table-inputs | −42.9% | −14.6% |
| repeat-inputs | −34.5% | −9.8% |

−9.9% across those four scenarios. The buildView cleanups are behaviour-neutral hygiene, within bench noise on their own. Both changes are observationally identical; the full Faces TCK passed on the merged 5.0 PRs, and this backport builds clean with `UIInputTestCase` green (52 tests) on Java 11.

Part of #5753.

🤖 Generated with Claude Opus 4.8
