### PR TITLE
Improve dynamic component add/remove performance (INVOKE_APPLICATION)

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/RIConstants.java
+++ b/impl/src/main/java/org/glassfish/mojarra/RIConstants.java
@@ -100,11 +100,6 @@ public class RIConstants {
      */
     public static final String DYNAMIC_CHILD_COUNT = RI_PREFIX + "DynamicChildCount";
 
-    /**
-     * Present in the attrs of UIViewRoot iff the tree has one or more dynamic modifications
-     */
-    public static final String TREE_HAS_DYNAMIC_COMPONENTS = RI_PREFIX + "TreeHasDynamicComponents";
-
     public static final String FLOW_DEFINITION_ID_SUFFIX = "-flow.xml";
 
     public static final int FLOW_DEFINITION_ID_SUFFIX_LENGTH = FLOW_DEFINITION_ID_SUFFIX.length();

--- a/impl/src/main/java/org/glassfish/mojarra/context/StateContext.java
+++ b/impl/src/main/java/org/glassfish/mojarra/context/StateContext.java
@@ -224,33 +224,16 @@ public class StateContext {
         return parent.getAttributes().containsKey(DYNAMIC_CHILD_COUNT);
     }
 
-    private int incrementDynamicChildCount(UIComponent parent) {
-        int result;
+    /**
+     * Mark {@code parent} as having a dynamically added child. Read back by {@link #hasOneOrMoreDynamicChild} to gate
+     * the dynamic-child reorder during Facelets re-apply, which tests only for the key's presence -- so this is a
+     * set-once marker, not a count.
+     */
+    private void markHasDynamicChild(UIComponent parent) {
         Map<String, Object> attrs = parent.getAttributes();
-        Integer cur = (Integer) attrs.get(DYNAMIC_CHILD_COUNT);
-        if (null != cur) {
-            result = cur++;
-        } else {
-            result = 1;
+        if (!attrs.containsKey(DYNAMIC_CHILD_COUNT)) {
+            attrs.put(DYNAMIC_CHILD_COUNT, 1);
         }
-        attrs.put(DYNAMIC_CHILD_COUNT, result);
-
-        return result;
-    }
-
-    private int decrementDynamicChildCount(UIComponent parent) {
-        int result = 0;
-        Map<String, Object> attrs = parent.getAttributes();
-        Integer cur = (Integer) attrs.get(DYNAMIC_CHILD_COUNT);
-        if (null != cur) {
-            result = 0 < cur ? cur-- : 0;
-
-        }
-        if (0 == result && null != cur) {
-            attrs.remove(DYNAMIC_CHILD_COUNT);
-        }
-
-        return result;
     }
 
     /**
@@ -655,7 +638,6 @@ public class StateContext {
         @Override
         protected void handleRemove(FacesContext context, UIComponent component) {
             if (component.isInView()) {
-                decrementDynamicChildCount(component.getParent());
                 recordDynamicAction(
                     component, 
                     new ComponentStruct(REMOVE, findFacetNameForComponent(component), component.getClientId(context), component.getId())
@@ -676,7 +658,7 @@ public class StateContext {
                 // UIComponentBase.setParent, which runs before this event, so no setId is needed here.
                 String facetName = findFacetNameForComponent(component);
                 if (facetName != null) {
-                    incrementDynamicChildCount(component.getParent());
+                    markHasDynamicChild(component.getParent());
                     component.clearInitialState();
                     component.getAttributes().put(DYNAMIC_COMPONENT, indexInParent(component));
 
@@ -685,7 +667,7 @@ public class StateContext {
 
                     recordDynamicAction(component, struct);
                 } else {
-                    incrementDynamicChildCount(component.getParent());
+                    markHasDynamicChild(component.getParent());
                     component.clearInitialState();
                     component.getAttributes().put(DYNAMIC_COMPONENT, indexInParent(component));
 

--- a/impl/src/main/java/org/glassfish/mojarra/context/StateContext.java
+++ b/impl/src/main/java/org/glassfish/mojarra/context/StateContext.java
@@ -224,7 +224,7 @@ public class StateContext {
         return parent.getAttributes().containsKey(DYNAMIC_CHILD_COUNT);
     }
 
-    private int incrementDynamicChildCount(FacesContext context, UIComponent parent) {
+    private int incrementDynamicChildCount(UIComponent parent) {
         int result;
         Map<String, Object> attrs = parent.getAttributes();
         Integer cur = (Integer) attrs.get(DYNAMIC_CHILD_COUNT);
@@ -234,12 +234,11 @@ public class StateContext {
             result = 1;
         }
         attrs.put(DYNAMIC_CHILD_COUNT, result);
-        context.getViewRoot().getAttributes().put(RIConstants.TREE_HAS_DYNAMIC_COMPONENTS, Boolean.TRUE);
 
         return result;
     }
 
-    private int decrementDynamicChildCount(FacesContext context, UIComponent parent) {
+    private int decrementDynamicChildCount(UIComponent parent) {
         int result = 0;
         Map<String, Object> attrs = parent.getAttributes();
         Integer cur = (Integer) attrs.get(DYNAMIC_CHILD_COUNT);
@@ -250,7 +249,6 @@ public class StateContext {
         if (0 == result && null != cur) {
             attrs.remove(DYNAMIC_CHILD_COUNT);
         }
-        context.getViewRoot().getAttributes().put(RIConstants.TREE_HAS_DYNAMIC_COMPONENTS, Boolean.TRUE);
 
         return result;
     }
@@ -381,12 +379,10 @@ public class StateContext {
             if (event instanceof PreRemoveFromViewEvent) {
                 if (stateCtx.trackViewModifications()) {
                     handleRemove(ctx, ((PreRemoveFromViewEvent) event).getComponent());
-                    ctx.getViewRoot().getAttributes().put(RIConstants.TREE_HAS_DYNAMIC_COMPONENTS, Boolean.TRUE);
                 }
             } else {
                 if (stateCtx.trackViewModifications()) {
                     handleAdd(ctx, ((PostAddToViewEvent) event).getComponent());
-                    ctx.getViewRoot().getAttributes().put(RIConstants.TREE_HAS_DYNAMIC_COMPONENTS, Boolean.TRUE);
                 }
             }
         }
@@ -659,7 +655,7 @@ public class StateContext {
         @Override
         protected void handleRemove(FacesContext context, UIComponent component) {
             if (component.isInView()) {
-                decrementDynamicChildCount(context, component.getParent());
+                decrementDynamicChildCount(component.getParent());
                 recordDynamicAction(
                     component, 
                     new ComponentStruct(REMOVE, findFacetNameForComponent(component), component.getClientId(context), component.getId())
@@ -680,7 +676,7 @@ public class StateContext {
                 // UIComponentBase.setParent, which runs before this event, so no setId is needed here.
                 String facetName = findFacetNameForComponent(component);
                 if (facetName != null) {
-                    incrementDynamicChildCount(context, component.getParent());
+                    incrementDynamicChildCount(component.getParent());
                     component.clearInitialState();
                     component.getAttributes().put(DYNAMIC_COMPONENT, indexInParent(component));
 
@@ -689,7 +685,7 @@ public class StateContext {
 
                     recordDynamicAction(component, struct);
                 } else {
-                    incrementDynamicChildCount(context, component.getParent());
+                    incrementDynamicChildCount(component.getParent());
                     component.clearInitialState();
                     component.getAttributes().put(DYNAMIC_COMPONENT, indexInParent(component));
 

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/CompositeComponentTagHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/CompositeComponentTagHandler.java
@@ -61,7 +61,6 @@ import jakarta.faces.view.facelets.MetadataTarget;
 import jakarta.faces.view.facelets.Tag;
 import jakarta.faces.view.facelets.TagAttribute;
 
-import org.glassfish.mojarra.RIConstants;
 import org.glassfish.mojarra.context.StateContext;
 import org.glassfish.mojarra.el.CompositeComponentELResolver;
 import org.glassfish.mojarra.facelets.el.VariableMapperWrapper;
@@ -121,7 +120,6 @@ public class CompositeComponentTagHandler extends ComponentHandler implements Cr
         } else {
             cc = context.getApplication().createComponent(context, ccResource);
         }
-        context.getViewRoot().getAttributes().put(RIConstants.TREE_HAS_DYNAMIC_COMPONENTS, Boolean.TRUE);
         setCompositeComponent(context, cc);
 
         return cc;


### PR DESCRIPTION
Two behaviour-neutral cleanups on the dynamic component add/remove path (`StateContext`), each deleting dead or redundant per-component work from `INVOKE_APPLICATION`. Part of the #5753 perf campaign; found while profiling the `dynamic-toggle-ajax` perf scenario against MyFaces.

## 1. Remove the dead `TREE_HAS_DYNAMIC_COMPONENTS` view-root flag (9204168334)

A request-scoped boolean written to the view root's attribute map on every dynamic add/remove (twice per add — once in `processEvent`, once in `increment/decrementDynamicChildCount`) and on every composite-component creation. Its only reader — a `containsKey` in `ComponentSupport.findChildByTagIdFullStateSaving` — was dropped by #5761 when that cache became a direct scan, leaving the writes orphaned and write-only. A 500-child toggle did ~1000 redundant reflective view-root map writes per postback.

## 2. Collapse the `DYNAMIC_CHILD_COUNT` counter to a set-once marker (21255b0e17)

`hasOneOrMoreDynamicChild` — the only reader, gating the dynamic-child reorder in Facelets re-apply — tests only for the key's presence, never the value. Yet every dynamic add/remove did a reflective parent-attribute get+put to maintain a running count. The count was already inert (an `increment`/`decrement` off-by-one stored the pre-mutation value, so it was always written as 1 and the remove-at-zero branch never fired — effectively set-once already). Replaced both with a set-once `markHasDynamicChild` (put iff absent) and dropped the decrement call.

## Measurements

Isolated `dynamic-toggle-ajax` (500-child toggle), Tomcat, warmup 200, 30k runs, same-session before/after A/B:

| | `INVOKE_APPLICATION` |
|---|--:|
| baseline (master) | 301 µs |
| after #1 | 271 µs (−10%) |
| after #2 (cumulative) | **248 µs (−18%)** |

Other lifecycle phases flat. Full TCK green on each commit.

The residual `INVOKE_APPLICATION` cost vs MyFaces (`getClientId` + `recordDynamicAction`) is the deliberate defer trade — Mojarra records dynamic actions keyed by clientId at INVOKE and defers the subtree populate to RENDER, which is why its `RESTORE_VIEW` is ~45% faster on this scenario; the scenario nets Mojarra-favourable overall. That is left untouched.

🤖 Generated with Claude Opus 4.8
