### PR TITLE
Add AI-assisted contributions section to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,34 @@ Contributor Agreement (ECA) on file.
 For more information, please see the Eclipse Committer Handbook:
 https://www.eclipse.org/projects/handbook/#resources-commit
 
+## AI-assisted contributions
+
+Use of AI coding assistants is welcome. If an AI tool materially contributed to a
+change, it is appreciated (but not required) to credit it in the commit message
+with a `Co-authored-by` trailer. Always include the model name and version so the
+attribution stays meaningful over time (model versions differ in behaviour). Here
+are some examples:
+
+- `Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>`
+- `Co-authored-by: GitHub Copilot (GPT-5) <copilot@github.com>`
+- `Co-authored-by: Cursor (Claude Sonnet 4.5) <cursoragent@cursor.com>`
+- `Co-authored-by: Devin AI 2.0 <158243242+devin-ai-integration[bot]@users.noreply.github.com>`
+- `Co-authored-by: OpenAI Codex (GPT-5-Codex) <codex@openai.com>`
+- `Co-authored-by: Gemini 2.5 Pro <gemini@google.com>`
+- `Co-authored-by: Grok 4 <grok@x.ai>`
+
+Use whatever model and version your tool actually reports.
+
+Why we ask for this:
+
+- **Traceability** — makes it clear which parts of the history were AI-assisted,
+  which helps when auditing a regression or a licensing question later.
+- **Accountability** — ties the change to the tool and model that produced it, not
+  just a vague "AI" label; model versions differ in behaviour and matter.
+- **Responsibility** — the human contributor remains the author of record. The
+  `Signed-off-by` and ECA requirements above apply unchanged, and you are expected
+  to review, understand, and stand behind any AI-generated code you submit.
+
 ## Contact
 
 Contact the project developers via the project's "dev" list.


### PR DESCRIPTION
## Summary

Adds an **AI-assisted contributions** section to `CONTRIBUTING.md`, documenting that AI coding assistants are welcome and that, when a tool materially contributed to a change, it is appreciated (not required) to credit it with a `Co-authored-by` trailer naming the model and version.

The section:

- Gives concrete trailer examples (Claude, Copilot, Cursor, Devin, Codex, Gemini, Grok).
- Explains the rationale: **traceability**, **accountability**, and **responsibility**.
- Reaffirms that the human contributor remains the author of record and that the `Signed-off-by` / ECA requirements are unchanged — the AI trailer is attribution, not legal authorship.

Docs-only change; no code impact. Applied to `master` (5.0); can be cherry-picked to `4.1`/`4.0` if wanted.

🤖 Generated with Claude Opus 4.8
