### PR TITLE
Drop the RESTORE_VIEW_SCOPE_ONLY context-attribute hack

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/view/FaceletViewHandlingStrategy.java
@@ -248,9 +248,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
                         String clientId = viewRoot.getClientId(context);
                         Object stateObj = state.get(clientId);
                         if (stateObj != null) {
-                            context.getAttributes().put(ViewScopeManager.RESTORE_VIEW_SCOPE_ONLY, true);
-                            viewRoot.restoreState(context, stateObj);
-                            context.getAttributes().remove(ViewScopeManager.RESTORE_VIEW_SCOPE_ONLY);
+                            viewRoot.restoreViewScopeState(context, stateObj);
                         }
                     }
                 }

--- a/impl/src/main/java/org/glassfish/mojarra/application/view/ViewScopeManager.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/view/ViewScopeManager.java
@@ -73,10 +73,6 @@ public class ViewScopeManager implements HttpSessionListener, ViewMapListener {
      */
     public static final String VIEW_MAP_ID = "org.glassfish.mojarra.application.view.viewMapId";
     /**
-     * Stores the constant indicating that only the view scope must be restored.
-     */
-    public static final String RESTORE_VIEW_SCOPE_ONLY = "org.glassfish.mojarra.application.view.restoreViewScopeOnly";
-    /**
      * Stores the constant to keep track of the ViewScopeManager.
      */
     public static final String VIEW_SCOPE_MANAGER = "org.glassfish.mojarra.application.view.viewScopeManager";

--- a/impl/src/test/java/org/glassfish/mojarra/component/UIViewRootTest.java
+++ b/impl/src/test/java/org/glassfish/mojarra/component/UIViewRootTest.java
@@ -18,6 +18,7 @@ package org.glassfish.mojarra.component;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
@@ -37,6 +38,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class UIViewRootTest {
+
+    private static final String SAVED_VIEW_MAP_ID = "savedViewMapId";
+    private static final String REPLACEMENT_VIEW_MAP_ID = "replacementViewMapId";
 
     @Test
     public void testViewMapPostConstructViewMapEvent() {
@@ -127,6 +131,89 @@ public class UIViewRootTest {
         viewRoot2.restoreState(facesContext, saved);
         viewMap = viewRoot2.getViewMap();
         assertEquals("one", viewMap.get("one"));
+
+        setFacesContext(null);
+    }
+
+    @Test
+    public void testViewMapRestoreViewScopeState() {
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        Application application = Mockito.mock(Application.class);
+        ExternalContext externalContext = Mockito.mock(ExternalContext.class);
+        HashMap<Object, Object> attributes = new HashMap<>();
+        HashMap<String, Object> sessionMap = new HashMap<>();
+
+        setFacesContext(facesContext);
+
+        when(facesContext.getAttributes()).thenReturn(attributes);
+        when(facesContext.getApplication()).thenReturn(application);
+        when(application.getProjectStage()).thenReturn(ProjectStage.UnitTest);
+        when(facesContext.getExternalContext()).thenReturn(externalContext);
+        when(externalContext.getApplicationMap()).thenReturn(null);
+        when(externalContext.getSessionMap()).thenReturn(sessionMap);
+
+        UIViewRoot viewRoot1 = new UIViewRoot();
+        viewRoot1.setRenderKitId("HTML_BASIC_TEST");
+        viewRoot1.getTransientStateHelper().putTransient(ViewScopeManager.VIEW_MAP_ID, SAVED_VIEW_MAP_ID);
+        viewRoot1.getViewMap().put("one", "one");
+        Object saved = viewRoot1.saveState(facesContext);
+
+        Map<String, Object> viewMaps = new HashMap<>();
+        viewMaps.put(SAVED_VIEW_MAP_ID, viewRoot1.getViewMap());
+        sessionMap.put(ViewScopeManager.ACTIVE_VIEW_MAPS, viewMaps);
+
+        UIViewRoot viewRoot2 = new UIViewRoot();
+        viewRoot2.restoreViewScopeState(facesContext, saved);
+
+        assertEquals("one", viewRoot2.getViewMap().get("one"));
+        assertNull(viewRoot2.getRenderKitId());
+
+        setFacesContext(null);
+    }
+
+    @Test
+    public void testViewMapRestoreStateAfterRestoreViewScopeState() {
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        Application application = Mockito.mock(Application.class);
+        ExternalContext externalContext = Mockito.mock(ExternalContext.class);
+        HashMap<Object, Object> attributes = new HashMap<>();
+        HashMap<String, Object> sessionMap = new HashMap<>();
+
+        setFacesContext(facesContext);
+
+        when(facesContext.getAttributes()).thenReturn(attributes);
+        when(facesContext.getApplication()).thenReturn(application);
+        when(application.getProjectStage()).thenReturn(ProjectStage.UnitTest);
+        when(facesContext.getExternalContext()).thenReturn(externalContext);
+        when(externalContext.getApplicationMap()).thenReturn(null);
+        when(externalContext.getSessionMap()).thenReturn(sessionMap);
+
+        UIViewRoot viewRoot1 = new UIViewRoot();
+        viewRoot1.getTransientStateHelper().putTransient(ViewScopeManager.VIEW_MAP_ID, SAVED_VIEW_MAP_ID);
+        viewRoot1.getViewMap().put("one", "one");
+        Object saved = viewRoot1.saveState(facesContext);
+
+        /*
+         * The saved view map is no longer among the active view maps, e.g. LRU-evicted or gone with an expired session.
+         */
+        Map<String, Object> viewMaps = new HashMap<>();
+        sessionMap.put(ViewScopeManager.ACTIVE_VIEW_MAPS, viewMaps);
+
+        UIViewRoot viewRoot2 = new UIViewRoot();
+        viewRoot2.restoreViewScopeState(facesContext, saved);
+
+        /*
+         * Simulate our ViewScopeManager minting a replacement view map while the view is being built.
+         */
+        Map<String, Object> replacementViewMap = viewRoot2.getViewMap();
+        replacementViewMap.put("two", "two");
+        viewMaps.put(REPLACEMENT_VIEW_MAP_ID, replacementViewMap);
+        viewRoot2.getTransientStateHelper().putTransient(ViewScopeManager.VIEW_MAP_ID, REPLACEMENT_VIEW_MAP_ID);
+
+        viewRoot2.restoreState(facesContext, saved);
+
+        assertEquals(REPLACEMENT_VIEW_MAP_ID, viewRoot2.getTransientStateHelper().getTransient(ViewScopeManager.VIEW_MAP_ID));
+        assertEquals("two", viewRoot2.getViewMap().get("two"));
 
         setFacesContext(null);
     }


### PR DESCRIPTION
Closes #5787. API side merged as jakartaee/faces#2212; the faces submodule is bumped to 321e6fae1.

`FaceletViewHandlingStrategy` now calls `UIViewRoot.restoreViewScopeState()` on the `createMetadataView` restore path, as prescribed by `StateManagementStrategy.restoreView()`'s javadoc, instead of putting a `RESTORE_VIEW_SCOPE_ONLY` context attribute around a full `restoreState()` call. `ViewScopeManager.RESTORE_VIEW_SCOPE_ONLY` goes with it, so the string contract between the spec class and the impl is gone from both sides.

**Tests.** The unit tests for the API change live here rather than in the faces repo, which has no `UIViewRoot` test, and they reference `ViewScopeManager`'s key constants anyway. `testViewMapRestoreViewScopeState` pins that `restoreViewScopeState()` restores the view map and not the component state — the inversion the old stub had. `testViewMapRestoreStateAfterRestoreViewScopeState` pins that a subsequent `restoreState()` does not rewire the view map over a replacement minted during `buildView()`. Against the pre-2212 API they fail with `expected: <one> but was: <null>` and `expected: <replacementViewMapId> but was: <savedViewMapId>`; with only 2212's guard removed, exactly the second one fails.

**Testing.** Full Faces TCK green. `mvn clean install` in `impl` green, including the pre-existing `UIViewRootTestCase` (60) and `UIViewRootTest` (5).

🤖 Generated with Claude Opus 4.8
