### PR TITLE
Read resource content in bulk while scanning for EL expressions

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/application/resource/ResourceHelper.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/resource/ResourceHelper.java
@@ -541,6 +541,12 @@ public abstract class ResourceHelper {
         private boolean expressionEvaluated;
         private boolean endOfStreamReached;
 
+        // Pull from inner in bulk; it is read one byte at a time while scanning for '#{', and inner.read() is typically
+        // synchronized (e.g. ByteArrayInputStream), so a per-byte call to it costs a monitor on every byte of the resource.
+        private final byte[] innerBuf = new byte[8192];
+        private int innerPos;
+        private int innerLimit;
+
         // ---------------------------------------------------- Constructors
 
         public ELEvaluatingInputStream(FacesContext ctx, ClientResourceInfo info, InputStream inner) {
@@ -571,16 +577,16 @@ public abstract class ResourceHelper {
                     i = buf.remove(0);
                 } else {
                     writingExpression = false;
-                    i = inner.read();
+                    i = readInner();
                 }
             } else {
                 // Read a character.
-                i = inner.read();
+                i = readInner();
                 c = (char) i;
                 // If it *might* be an expression...
                 if (c == '#') {
                     // read another character.
-                    i = inner.read();
+                    i = readInner();
                     c = (char) i;
                     // If it's '{', assume we have an expression.
                     if (c == '{') {
@@ -610,13 +616,89 @@ public abstract class ResourceHelper {
             return i;
         }
 
+        /**
+         * Copies through the bytes up to the next '#', which only the single byte state machine may interpret. Bytes are
+         * copied straight out of the buffer that {@link #readInner} fills, so a run without any '#' costs one bulk read on
+         * inner instead of one call per byte.
+         */
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            if (null == inner) {
+                return -1;
+            }
+
+            if (len == 0) {
+                return 0;
+            }
+
+            // An expression is being written out, or a '#' which turned out not to start one is pending; both are states
+            // which only the single byte read can unwind.
+            if (failedExpressionTest || writingExpression) {
+                return readSingleByteInto(b, off);
+            }
+
+            if (innerPos >= innerLimit && !fillInnerBuf()) {
+                endOfStreamReached = true;
+                return -1;
+            }
+
+            int start = innerPos;
+            int stop = Math.min(innerLimit, start + len);
+            int end = start;
+
+            while (end < stop && innerBuf[end] != '#') {
+                end++;
+            }
+
+            if (end == start) {
+                // Next byte is '#', so it may start an expression; let the single byte read decide.
+                return readSingleByteInto(b, off);
+            }
+
+            int count = end - start;
+            System.arraycopy(innerBuf, start, b, off, count);
+            innerPos = end;
+            return count;
+        }
+
+        private int readSingleByteInto(byte[] b, int off) throws IOException {
+            int i = read();
+
+            if (i == -1) {
+                return -1;
+            }
+
+            b[off] = (byte) i;
+            return 1;
+        }
+
+        private int readInner() throws IOException {
+            if (innerPos >= innerLimit && !fillInnerBuf()) {
+                return -1;
+            }
+
+            return innerBuf[innerPos++] & 0xFF;
+        }
+
+        private boolean fillInnerBuf() throws IOException {
+            int read = inner.read(innerBuf, 0, innerBuf.length);
+
+            if (read <= 0) {
+                return false;
+            }
+
+            innerPos = 0;
+            innerLimit = read;
+            return true;
+        }
+
         private int nextRead = -1;
 
         private void readExpressionIntoBufferAndEvaluateIntoBuffer() throws IOException {
             int i;
             char c;
             do {
-                i = inner.read();
+                i = readInner();
                 c = (char) i;
                 if (c == '}') {
                     evaluateExpressionIntoBuffer();

--- a/impl/src/main/java/org/glassfish/mojarra/application/resource/ResourceHelper.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/resource/ResourceHelper.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -623,12 +624,14 @@ public abstract class ResourceHelper {
          */
         @Override
         public int read(byte[] b, int off, int len) throws IOException {
-            if (null == inner) {
-                return -1;
-            }
+            Objects.checkFromIndexSize(off, len, b.length);
 
             if (len == 0) {
                 return 0;
+            }
+
+            if (null == inner) {
+                return -1;
             }
 
             // An expression is being written out, or a '#' which turned out not to start one is pending; both are states
@@ -681,9 +684,16 @@ public abstract class ResourceHelper {
         }
 
         private boolean fillInnerBuf() throws IOException {
-            int read = inner.read(innerBuf, 0, innerBuf.length);
+            int read;
 
-            if (read <= 0) {
+            // Only a negative return means end of stream. A zero return must not be mistaken for it: it would truncate the
+            // resource, and close() would then disableEL() on the cached ClientResourceInfo, permanently dropping EL
+            // evaluation for it.
+            do {
+                read = inner.read(innerBuf, 0, innerBuf.length);
+            } while (read == 0);
+
+            if (read < 0) {
                 return false;
             }
 


### PR DESCRIPTION
Fixes #5858.

`ELEvaluatingInputStream` implemented only `read()`, so it inherited `InputStream`'s default `read(byte[],int,int)`, which loops calling `read()` once per byte. The inner stream's `read()` is typically `synchronized` (`ByteArrayInputStream`), so every byte of a served resource cost a monitor acquire/release plus two virtual calls. The surrounding `new BufferedInputStream(new ELEvaluatingInputStream(...))` could not help, because the bulk read lands on the inherited default, which loops per byte anyway:

```
java.io.ByteArrayInputStream.read()                          line: 146   <- single-byte, synchronized
...ResourceHelper$ELEvaluatingInputStream.read()             line: 578
java.io.InputStream.read(byte[], int, int)                   line: 296   <- default impl, loops per byte
java.io.BufferedInputStream.read1(byte[], int, int)          line: 345
```

## Change

Buffer `inner` in 8K chunks, and add a `read(byte[],int,int)` override which copies the run of bytes up to the next `'#'` straight out of that buffer, leaving every `'#'` to the existing single byte state machine. Scanning and expression evaluation semantics are unchanged — a `'#'` is still the only thing that can start an expression, and it is still the original code that decides.

## Who pays this today

`resourceSupportsEL()` is true for `text/css` and for `jakarta.faces:faces.js`. EL-free CSS takes the `disableEL()` shortcut in `close()` after its first full read, so it self-corrects. What does not self-correct:

- **faces.js** — it ships 6 EL expressions (`#{applicationScope["com.sun.faces.mojarraVersion"].specversion}`, `#{facesContext.namingContainerSeparatorChar}`, ...), so `expressionEvaluated` is always set and it is re-scanned byte-by-byte on **every** fetch, in every Faces application.
- **CSS containing EL** (e.g. `#{resource['image:background.png']}`) — same.

## Measurement

Tomcat 11.0.22, JFR `settings=profile` with `-XX:+DebugNonSafepoints`, 20000 requests at concurrency 8 against a single ~50K resource containing faces.js:

| | before | after |
|---|---|---|
| throughput | 5780 req/s | **9992 req/s** (1.73x) |
| latency | 1.384 ms | **0.801 ms** (-42%) |
| `ByteArrayInputStream.read` | **75.6%** of execution samples | gone from the profile |
| failed requests | 0 | 0 |

For reference, before the change ~82-86% of the CPU spent serving that resource was byte-at-a-time plumbing, while actual EL evaluation (`readExpressionIntoBufferAndEvaluateIntoBuffer` + `evaluateExpressionIntoBuffer`) was ~0.8% — i.e. nearly all of it was *looking for* `#{`, not evaluating it.

## Correctness

- **faces.js** (EL evaluated): output **byte-identical** before vs after, 51259 bytes, same build compared both ways.
- **EL-free CSS** (the `disableEL()` path): output **byte-identical**, and the second fetch — after `disableEL()` has fired — is identical too.
- No unevaluated `#{` left in the served output.
- Full 5.0 TCK green with this change.

The measurement above was taken with this same change applied to the 4.1 line (identical apart from the package rename), since the harness driving it is wired for Faces 4.1.

🤖 Generated with Claude Opus 4.8
