### PR TITLE
Backport bulk resource read while scanning for EL expressions to 4.0 (#5858)

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceHelper.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceHelper.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -542,6 +543,12 @@ public abstract class ResourceHelper {
         private boolean expressionEvaluated;
         private boolean endOfStreamReached;
 
+        // Pull from inner in bulk; it is read one byte at a time while scanning for '#{', and inner.read() is typically
+        // synchronized (e.g. ByteArrayInputStream), so a per-byte call to it costs a monitor on every byte of the resource.
+        private final byte[] innerBuf = new byte[8192];
+        private int innerPos;
+        private int innerLimit;
+
         // ---------------------------------------------------- Constructors
 
         public ELEvaluatingInputStream(FacesContext ctx, ClientResourceInfo info, InputStream inner) {
@@ -572,16 +579,16 @@ public abstract class ResourceHelper {
                     i = buf.remove(0);
                 } else {
                     writingExpression = false;
-                    i = inner.read();
+                    i = readInner();
                 }
             } else {
                 // Read a character.
-                i = inner.read();
+                i = readInner();
                 c = (char) i;
                 // If it *might* be an expression...
                 if (c == '#') {
                     // read another character.
-                    i = inner.read();
+                    i = readInner();
                     c = (char) i;
                     // If it's '{', assume we have an expression.
                     if (c == '{') {
@@ -611,13 +618,98 @@ public abstract class ResourceHelper {
             return i;
         }
 
+        /**
+         * Copies through the bytes up to the next '#', which only the single byte state machine may interpret. Bytes are
+         * copied straight out of the buffer that {@link #readInner} fills, so a run without any '#' costs one bulk read on
+         * inner instead of one call per byte.
+         */
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            Objects.checkFromIndexSize(off, len, b.length);
+
+            if (len == 0) {
+                return 0;
+            }
+
+            if (null == inner) {
+                return -1;
+            }
+
+            // An expression is being written out, or a '#' which turned out not to start one is pending; both are states
+            // which only the single byte read can unwind.
+            if (failedExpressionTest || writingExpression) {
+                return readSingleByteInto(b, off);
+            }
+
+            if (innerPos >= innerLimit && !fillInnerBuf()) {
+                endOfStreamReached = true;
+                return -1;
+            }
+
+            int start = innerPos;
+            int stop = Math.min(innerLimit, start + len);
+            int end = start;
+
+            while (end < stop && innerBuf[end] != '#') {
+                end++;
+            }
+
+            if (end == start) {
+                // Next byte is '#', so it may start an expression; let the single byte read decide.
+                return readSingleByteInto(b, off);
+            }
+
+            int count = end - start;
+            System.arraycopy(innerBuf, start, b, off, count);
+            innerPos = end;
+            return count;
+        }
+
+        private int readSingleByteInto(byte[] b, int off) throws IOException {
+            int i = read();
+
+            if (i == -1) {
+                return -1;
+            }
+
+            b[off] = (byte) i;
+            return 1;
+        }
+
+        private int readInner() throws IOException {
+            if (innerPos >= innerLimit && !fillInnerBuf()) {
+                return -1;
+            }
+
+            return innerBuf[innerPos++] & 0xFF;
+        }
+
+        private boolean fillInnerBuf() throws IOException {
+            int read;
+
+            // Only a negative return means end of stream. A zero return must not be mistaken for it: it would truncate the
+            // resource, and close() would then disableEL() on the cached ClientResourceInfo, permanently dropping EL
+            // evaluation for it.
+            do {
+                read = inner.read(innerBuf, 0, innerBuf.length);
+            } while (read == 0);
+
+            if (read < 0) {
+                return false;
+            }
+
+            innerPos = 0;
+            innerLimit = read;
+            return true;
+        }
+
         private int nextRead = -1;
 
         private void readExpressionIntoBufferAndEvaluateIntoBuffer() throws IOException {
             int i;
             char c;
             do {
-                i = inner.read();
+                i = readInner();
                 c = (char) i;
                 if (c == '}') {
                     evaluateExpressionIntoBuffer();


### PR DESCRIPTION
4.0 backport of #5858 / #5859.

`ELEvaluatingInputStream` implemented only `read()`, so it inherited `InputStream`'s default `read(byte[],int,int)`, which loops calling `read()` once per byte. The inner stream's `read()` is typically `synchronized` (`ByteArrayInputStream`), so every byte of a served resource cost a monitor acquire/release plus two virtual calls. The surrounding `new BufferedInputStream(new ELEvaluatingInputStream(...))` could not help, because the bulk read lands on the inherited default, which loops per byte anyway.

Buffer `inner` in 8K chunks, and add a `read(byte[],int,int)` override which copies the run of bytes up to the next `'#'` straight out of that buffer, leaving every `'#'` to the existing single byte state machine. Scanning and expression evaluation semantics are unchanged.

This is paid by faces.js and by any CSS containing EL, as those never reach the `disableEL()` shortcut in `close()` and are therefore re-scanned on every fetch. EL-free CSS self-corrects after its first full read and is unaffected.

## Relation to master

The changed class is **textually identical** to the version merged into master (ea3deacafb), including the post-review fixes in a2b9231fa6 (`Objects.checkFromIndexSize` validation ordering, and treating only a negative `inner.read()` as end of stream rather than zero). The only differences between this file and master's are pre-existing on 4.0 and unrelated to this change: the fields here are not `final`, and `char chars[]` uses the older array syntax.

## Measurement

Measured on the 4.1 line (identical code apart from the package rename) with Tomcat 11.0.22, JFR `settings=profile` with `-XX:+DebugNonSafepoints`, 20000 requests at concurrency 8 against a single ~50K resource containing faces.js:

| | before | after |
|---|---|---|
| throughput | 5780 req/s | **9992-10842 req/s** (~1.7-1.9x) |
| latency | 1.384 ms | **0.801 ms** |
| `ByteArrayInputStream.read` | **75.6%** of execution samples | gone from the profile |
| failed requests | 0 | 0 |

Before the change, ~82-86% of the CPU spent serving that resource was byte-at-a-time plumbing, while actual EL evaluation was ~0.8% — nearly all of it was *looking for* `#{`, not evaluating it.

## Verification

On the 4.1 line, output was byte-identical before vs after for both paths: faces.js (EL evaluated, 51259 bytes) and an EL-free CSS resource, including the second fetch after `disableEL()` has fired.

🤖 Generated with Claude Opus 4.8
