### PR TITLE
Fix #5861: carry the dynamic add index on the action instead of on the component

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/application/view/FaceletPartialStateManagementStrategy.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/view/FaceletPartialStateManagementStrategy.java
@@ -164,6 +164,26 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
     }
 
     /**
+     * Returns the index the given action's child must be restored at. The action carries it, as the component
+     * does not necessarily survive to hold it: a facelet-created child which was dynamically moved to another
+     * parent is deleted and recreated by the facelet refresh, losing its marker. The marker on the component
+     * is only consulted for state saved before the action carried the index.
+     *
+     * @param struct the component struct.
+     * @param child the child being restored.
+     * @return the index within the parent's children, or {@link ComponentStruct#APPEND} to append.
+     */
+    private static int indexOf(ComponentStruct struct, UIComponent child) {
+        if (struct.getIndex() != ComponentStruct.APPEND) {
+            return struct.getIndex();
+        }
+        if (child.getAttributes().get(DYNAMIC_COMPONENT) instanceof Integer index) {
+            return index;
+        }
+        return ComponentStruct.APPEND;
+    }
+
+    /**
      * Method that takes care of restoring a dynamic add.
      *
      * @param context the Faces context.
@@ -231,10 +251,7 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
                     parent.getFacets().put(struct.getFacetName(), child);
                     child.getAttributes().put(DYNAMIC_COMPONENT, child.getParent().getChildren().indexOf(child));
                 } else {
-                    int childIndex = -1;
-                    if (child.getAttributes().containsKey(DYNAMIC_COMPONENT)) {
-                        childIndex = (Integer) child.getAttributes().get(DYNAMIC_COMPONENT);
-                    }
+                    int childIndex = indexOf(struct, child);
                     child.setId(struct.getId());
                     int storedIndex;
                     if (childIndex >= parent.getChildCount() || childIndex == -1) {
@@ -426,6 +443,11 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
                             action.getClientId());
                 }
                 if (component != null) {
+                    // The tree walk above has just stamped each dynamically added component with the index it
+                    // actually ended up at, which supersedes the one recorded when the action was fired.
+                    if (ADD.equals(action.getAction()) && component.getAttributes().get(DYNAMIC_COMPONENT) instanceof Integer index) {
+                        action.setIndex(index);
+                    }
                     savedActions.add(action.saveState(context));
                 }
             }

--- a/impl/src/main/java/org/glassfish/mojarra/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/view/FaceletViewHandlingStrategy.java
@@ -1792,6 +1792,26 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
     }
 
     /**
+     * Returns the index the given action's child must be reapplied at. The action carries it, as the component
+     * does not necessarily survive to hold it: a facelet-created child which was dynamically moved to another
+     * parent is deleted and recreated by this very refresh, losing its marker. The marker on the component is
+     * only consulted for state saved before the action carried the index.
+     *
+     * @param struct the component struct.
+     * @param child the child being reapplied.
+     * @return the index within the parent's children, or {@link ComponentStruct#APPEND} to append.
+     */
+    private static int indexOf(ComponentStruct struct, UIComponent child) {
+        if (struct.getIndex() != ComponentStruct.APPEND) {
+            return struct.getIndex();
+        }
+        if (child.getAttributes().get(DYNAMIC_COMPONENT) instanceof Integer index) {
+            return index;
+        }
+        return ComponentStruct.APPEND;
+    }
+
+    /**
      * Reapply the dynamic add after Facelets reapply.
      *
      * @param context the Faces context.
@@ -1815,10 +1835,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
                     parent.getFacets().put(struct.getFacetName(), child);
                     child.getClientId();
                 } else if (child.getParent() != parent) {
-                    int childIndex = -1;
-                    if (child.getAttributes().containsKey(DYNAMIC_COMPONENT)) {
-                        childIndex = (Integer) child.getAttributes().get(DYNAMIC_COMPONENT);
-                    }
+                    int childIndex = indexOf(struct, child);
                     child.setId(struct.getId());
                     int storedIndex;
                     if (childIndex >= parent.getChildCount() || childIndex == -1) {

--- a/impl/src/main/java/org/glassfish/mojarra/context/StateContext.java
+++ b/impl/src/main/java/org/glassfish/mojarra/context/StateContext.java
@@ -657,25 +657,16 @@ public class StateContext {
                 // The stale clientId that a reparent could leave behind is already invalidated by
                 // UIComponentBase.setParent, which runs before this event, so no setId is needed here.
                 String facetName = findFacetNameForComponent(component);
-                if (facetName != null) {
-                    markHasDynamicChild(component.getParent());
-                    component.clearInitialState();
-                    component.getAttributes().put(DYNAMIC_COMPONENT, indexInParent(component));
+                int index = indexInParent(component);
+                markHasDynamicChild(component.getParent());
+                component.clearInitialState();
+                component.getAttributes().put(DYNAMIC_COMPONENT, index);
 
-                    ComponentStruct struct = new ComponentStruct(ADD, facetName, component.getParent().getClientId(context), component.getClientId(context),
-                            component.getId());
+                ComponentStruct struct = new ComponentStruct(ADD, facetName, component.getParent().getClientId(context), component.getClientId(context),
+                        component.getId());
+                struct.setIndex(index);
 
-                    recordDynamicAction(component, struct);
-                } else {
-                    markHasDynamicChild(component.getParent());
-                    component.clearInitialState();
-                    component.getAttributes().put(DYNAMIC_COMPONENT, indexInParent(component));
-
-                    ComponentStruct struct = new ComponentStruct(ADD, null, component.getParent().getClientId(context), component.getClientId(context),
-                            component.getId());
-
-                    recordDynamicAction(component, struct);
-                }
+                recordDynamicAction(component, struct);
             }
         }
 

--- a/impl/src/main/java/org/glassfish/mojarra/util/ComponentStruct.java
+++ b/impl/src/main/java/org/glassfish/mojarra/util/ComponentStruct.java
@@ -34,11 +34,17 @@ public class ComponentStruct implements StateHolder {
      */
     public static final String REMOVE = "REMOVE";
 
+    /**
+     * Index which an ADD must restore its child at, or -1 when it must be appended.
+     */
+    public static final int APPEND = -1;
+
     private String action;
     private String facetName;
     private String parentClientId;
     private String clientId;
     private String id;
+    private int index = APPEND;
 
     public ComponentStruct() {
     }
@@ -79,6 +85,7 @@ public class ComponentStruct implements StateHolder {
         clientId = (String) s[2];
         id = (String) s[3];
         facetName = (String) s[4];
+        index = (Integer) s[5];
     }
 
     @Override
@@ -87,12 +94,13 @@ public class ComponentStruct implements StateHolder {
             throw new NullPointerException();
         }
 
-        Object[] state = new Object[5];
+        Object[] state = new Object[6];
         state[0] = action;
         state[1] = parentClientId;
         state[2] = clientId;
         state[3] = id;
         state[4] = facetName;
+        state[5] = index;
 
         return state;
     }
@@ -143,6 +151,26 @@ public class ComponentStruct implements StateHolder {
 
     public String getId() {
         return id;
+    }
+
+    /**
+     * Returns the index within the parent's children which this action's child must be restored at, or
+     * {@link #APPEND} when it must be appended.
+     *
+     * <p>
+     * The index travels with the action rather than with the component, because the component itself does
+     * not necessarily survive: a facelet-created child which was dynamically moved to another parent is
+     * deleted and recreated by the facelet refresh, which loses any marker held in its attribute map.
+     * </p>
+     *
+     * @return the index within the parent's children, or {@link #APPEND}.
+     */
+    public int getIndex() {
+        return index;
+    }
+
+    public void setIndex(int index) {
+        this.index = index;
     }
 
 }


### PR DESCRIPTION
Fixes #5861, which has the analysis. In short: the insertion index lived on the component instance, which a moved facelet-created child does not survive, as the refresh deletes and recreates it.

Carry the index on `ComponentStruct` (the action) instead, which outlives both the state and the facelet refresh:

- `StateContext#handleAdd` records it on the action (and its two identical facet/non-facet branches are folded into one).
- The save refreshes it from the index which the save time tree walk already stamps on the component.
- Both replay paths read it off the action, keeping the component attribute as a fallback for state saved before the action carried it.

The optimizations of #5753 are preserved: the index is read in O(1) off the action, the save reuses the index it already stamps rather than scanning with `getChildren().indexOf`, and the view wide component index stays. The cost is one `int` per dynamic action.

The Jakarta Faces TCK is green in full with this change, including `Issue2892IT` in `faces23/dynamic-components`, which fails without it.

Note that `ComponentStruct` now saves a 6 element state array, so state saved by an earlier version would fail to restore. That is only reachable with client side state saving across a mid session upgrade.

🤖 Generated with Claude Opus 4.8
