### PR TITLE
Fix #5864: index the view without iterating rows when replaying dynamic actions

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/view/FaceletViewHandlingStrategy.java
@@ -70,6 +70,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
@@ -178,6 +179,9 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
     private Map<String, List<String>> contractMappings;
 
     private static final String NONCE_EXPRESSION = "#{nonce}";
+
+    private static final Set<VisitHint> SKIP_ITERATION_HINT = EnumSet.of(VisitHint.SKIP_ITERATION);
+
     private String cspHeader;
     private boolean dynamicCspHeader;
 
@@ -1747,12 +1751,27 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
      * dynamically added component nested under another) resolves against the live tree rather than restoring a
      * duplicate.
      *
+     * <p>
+     * The visit skips iteration, as the same lookup in {@link FaceletPartialStateManagementStrategy} always has.
+     * Iterating is not free of consequence: it sets the row index on every iterating component in the view, which a
+     * component can act on -- a data table backed by a lazily loaded model fetches a page of data per iteration --
+     * and replay must not provoke that merely to find components by client id.
+     * </p>
+     *
+     * <p>
+     * The index therefore holds no row-scoped client id, and an action recorded against one (an add performed while
+     * a row index was set) does not resolve here. That costs nothing: a component inside a row is a single instance
+     * shared by every row, so such an action denotes no position the index is missing, and the request which
+     * recorded it has the component attached already. Later requests never see it either way, as
+     * {@link FaceletPartialStateManagementStrategy} resolves against an equally row-free index when restoring.
+     * </p>
+     *
      * @param context the Faces context.
      * @param root the subtree to index.
      * @param index the index to populate.
      */
     private void indexSubtree(FacesContext context, UIComponent root, Map<String, UIComponent> index) {
-        VisitContext visitContext = VisitContext.createVisitContext(context);
+        VisitContext visitContext = VisitContext.createVisitContext(context, null, SKIP_ITERATION_HINT);
         root.visitTree(visitContext, (visitContext1, component) -> {
             index.put(component.getClientId(visitContext1.getFacesContext()), component);
             return VisitResult.ACCEPT;
@@ -1925,7 +1944,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
             return false;
         }
         boolean[] found = { false };
-        VisitContext visitContext = VisitContext.createVisitContext(context, null, EnumSet.of(VisitHint.SKIP_ITERATION));
+        VisitContext visitContext = VisitContext.createVisitContext(context, null, SKIP_ITERATION_HINT);
         viewRoot.visitTree(visitContext, (vc, target) -> {
             if (target instanceof UIForm) {
                 found[0] = true;

--- a/impl/src/test/java/org/glassfish/mojarra/application/view/FaceletViewHandlingStrategyTest.java
+++ b/impl/src/test/java/org/glassfish/mojarra/application/view/FaceletViewHandlingStrategyTest.java
@@ -16,6 +16,7 @@
 package org.glassfish.mojarra.application.view;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -23,10 +24,14 @@ import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
 
 import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.component.visit.VisitCallback;
 import jakarta.faces.component.visit.VisitContext;
+import jakarta.faces.component.visit.VisitHint;
 import jakarta.faces.context.FacesContext;
 
 import org.glassfish.mojarra.context.StateContext;
@@ -36,14 +41,19 @@ import org.mockito.MockedStatic;
 
 class FaceletViewHandlingStrategyTest {
 
-    /** A view root that records whether its subtree was walked. */
+    /**
+     * A view root that records whether its subtree was walked, and how the visit was configured. It does not walk:
+     * these tests turn on whether a walk happens and how it is set up, not on what it finds.
+     */
     private static final class RecordingViewRoot extends UIViewRoot {
         boolean visited;
+        Set<VisitHint> hints;
 
         @Override
         public boolean visitTree(VisitContext context, VisitCallback callback) {
             visited = true;
-            return super.visitTree(context, callback);
+            hints = context.getHints();
+            return false;
         }
     }
 
@@ -80,5 +90,69 @@ class FaceletViewHandlingStrategyTest {
         }
 
         assertFalse(viewRoot.visited, "reapplyDynamicActions walked the view despite having no dynamic actions");
+    }
+
+    /**
+     * Regression guard for #5864. When there are dynamic actions to replay the view does get indexed, and that
+     * walk must skip iteration.
+     *
+     * <p>A visit without {@link VisitHint#SKIP_ITERATION} sets the row index on every iterating component it
+     * passes, which components observe: a data table backed by a lazily loaded model fetches a page of data per
+     * iteration, so the walk provokes a duplicate query on every postback which renders one. Indexing exists to
+     * find components by client id and has no business iterating anything to do it.
+     *
+     * <p>The guard above is not a substitute for this one: it only holds when the view has no dynamic actions at
+     * all, and every view relocates its component resources to the head, so in practice there is always an action
+     * to replay and this walk always runs.
+     *
+     * <p>This lives here rather than in the TCK because the spec does not mandate it. The spec defines what
+     * {@code SKIP_ITERATION} means for a visit, but says nothing about how the runtime may go looking for a
+     * component by client id, and dynamic-action replay is entirely an implementation concern -- no spec type is
+     * involved. The invariant is nonetheless real and cross-implementation: a component which loads data per row
+     * cannot defend itself against a walk it never asked for, and both implementations honoured this until
+     * PR #5783 stopped honouring it here. A TCK test would have to assert a row-access count, which the spec
+     * leaves free, so it belongs to the implementation which made the promise.
+     */
+    @Test
+    void reapplyDynamicActionsIndexesTheViewWithoutIteratingRows() throws Exception {
+        RecordingViewRoot viewRoot = new RecordingViewRoot();
+        FacesContext context = mock(FacesContext.class);
+        when(context.getViewRoot()).thenReturn(viewRoot);
+
+        ComponentStruct action = new ComponentStruct(ComponentStruct.ADD, null, "form", "form:added", "added");
+
+        StateContext stateContext = mock(StateContext.class);
+        when(stateContext.getDynamicActions()).thenReturn(new ArrayList<>(List.of(action)));
+        when(stateContext.getDynamicComponents()).thenReturn(new HashMap<>());
+
+        FaceletViewHandlingStrategy strategy = mock(FaceletViewHandlingStrategy.class);
+        Method reapplyDynamicActions = FaceletViewHandlingStrategy.class
+                .getDeclaredMethod("reapplyDynamicActions", FacesContext.class);
+        reapplyDynamicActions.setAccessible(true);
+
+        try (MockedStatic<StateContext> mocked = mockStatic(StateContext.class);
+                MockedStatic<VisitContext> visitContexts = mockStatic(VisitContext.class)) {
+            mocked.when(() -> StateContext.getStateContext(context)).thenReturn(stateContext);
+            mocked.when(() -> StateContext.pruneDynamicActions(any())).thenCallRealMethod();
+            // Hand back the hints the caller asked for: the real factory would need a CDI-backed FactoryFinder,
+            // and the assertion is about what the visit is asked for, not about what the factory makes of it.
+            visitContexts.when(() -> VisitContext.createVisitContext(any(), any(), any())).thenAnswer(invocation -> {
+                VisitContext visitContext = mock(VisitContext.class);
+                when(visitContext.getHints()).thenReturn(invocation.getArgument(2));
+                return visitContext;
+            });
+            // The hintless overload, so that indexing via it fails this test on its assertion rather than on a NPE.
+            visitContexts.when(() -> VisitContext.createVisitContext(any())).thenAnswer(invocation -> {
+                VisitContext visitContext = mock(VisitContext.class);
+                when(visitContext.getHints()).thenReturn(Set.of());
+                return visitContext;
+            });
+
+            reapplyDynamicActions.invoke(strategy, context);
+        }
+
+        assertTrue(viewRoot.visited, "reapplyDynamicActions did not index the view despite having a dynamic action");
+        assertTrue(viewRoot.hints.contains(VisitHint.SKIP_ITERATION),
+                "reapplyDynamicActions indexed the view with a visit which iterates rows");
     }
 }


### PR DESCRIPTION
Closes #5864

`reapplyDynamicActions` indexes the whole view so each action resolves its parent and child by client id. The visit did not set `SKIP_ITERATION`, so it iterated the rows of every `UIData`/`UIRepeat` on the way — which a component can act on. PrimeFaces `DataTable` overrides `visitRows()` to load its `LazyDataModel`, so every postback rendering a lazy table ran its backing query twice.

The same lookup in `FaceletPartialStateManagementStrategy` has always skipped iteration. Only this path did not.

### Why no fallback for row-scoped client ids

A row-free index holds no row-scoped client id, so an action recorded while a row index was set no longer resolves here. That costs nothing:

- a component inside a row is a single instance shared by every row, so such an id denotes no position the index is missing — one add inside a row renders in every row
- the request which recorded the action has the component attached already, so replay is a no-op there: the facelet refresh deletes only facelet-created children, never programmatic ones
- later requests never see it either way, as restore resolves against an equally row-free index (that is #5865, which predates this and is fixed separately)

Resolving one would need an `invokeOnComponent`, which sets the row index and so touches the very `DataModel` this fixes.

### Testing

`FaceletViewHandlingStrategyTest.reapplyDynamicActionsIndexesTheViewWithoutIteratingRows` asserts the walk carries the hint, and fails on its own assertion without the fix. It sits beside the existing guard for the `!isEmpty(actions)` check — which does not cover this, as every view relocates component resources to the head, so there is always an action to replay and the walk always runs.

Green: Mojarra unit suite 1072/1072, `faces23/dynamic-components` TCK 9/9, PrimeFaces integration suite 933 tests with no regression (`DataTable006Test` 15/15, was 8 failures).

🤖 Generated with Claude Opus 4.8
