### PR TITLE
Fix #5865: record dynamic actions against a row-free client id

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/context/StateContext.java
+++ b/impl/src/main/java/org/glassfish/mojarra/context/StateContext.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.logging.Logger;
 
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UINamingContainer;
 import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.AbortProcessingException;
@@ -639,8 +640,8 @@ public class StateContext {
         protected void handleRemove(FacesContext context, UIComponent component) {
             if (component.isInView()) {
                 recordDynamicAction(
-                    component, 
-                    new ComponentStruct(REMOVE, findFacetNameForComponent(component), component.getClientId(context), component.getId())
+                    component,
+                    new ComponentStruct(REMOVE, findFacetNameForComponent(component), stripIterationIndex(context, component.getClientId(context)), component.getId())
                 );
            }
         }
@@ -662,12 +663,76 @@ public class StateContext {
                 component.clearInitialState();
                 component.getAttributes().put(DYNAMIC_COMPONENT, index);
 
-                ComponentStruct struct = new ComponentStruct(ADD, facetName, component.getParent().getClientId(context), component.getClientId(context),
+                ComponentStruct struct = new ComponentStruct(ADD, facetName,
+                        stripIterationIndex(context, component.getParent().getClientId(context)),
+                        stripIterationIndex(context, component.getClientId(context)),
                         component.getId());
                 struct.setIndex(index);
 
                 recordDynamicAction(component, struct);
             }
+        }
+
+        /**
+         * Drops the iteration index of every iterating ancestor from the given client id, e.g.
+         * {@code form:table:1:group} becomes {@code form:table:group}.
+         *
+         * <p>
+         * An action is recorded whenever the tree is modified, which can be while an iterating component has a row
+         * index set -- an add performed by a command button inside a row, for instance, as {@link UIData#broadcast}
+         * sets the row index before the action runs. The client id then carries that row, but the component does
+         * not: a component inside an iterating one is a single instance shared by every row, so the modification
+         * belongs to all of them and the row says only when it happened. Recording it would key the action to a
+         * position which does not exist, which nothing can resolve it against afterwards.
+         * </p>
+         *
+         * <p>
+         * A numeric segment is unambiguous: a component id cannot be one, as {@link UIComponent#setId} requires the
+         * first character to be a letter or an underscore. Only an iterating component contributes one.
+         * </p>
+         *
+         * @param context the Faces context.
+         * @param clientId the client id to strip.
+         * @return the given client id without the iteration index of any iterating ancestor.
+         */
+        private String stripIterationIndex(FacesContext context, String clientId) {
+            char separatorChar = UINamingContainer.getSeparatorChar(context);
+            StringBuilder builder = new StringBuilder(clientId.length());
+            boolean stripped = false;
+            int segmentStart = 0;
+
+            for (int i = 0; i <= clientId.length(); i++) {
+                if (i < clientId.length() && clientId.charAt(i) != separatorChar) {
+                    continue;
+                }
+
+                if (isIterationIndex(clientId, segmentStart, i)) {
+                    stripped = true;
+                } else {
+                    if (builder.length() > 0) {
+                        builder.append(separatorChar);
+                    }
+                    builder.append(clientId, segmentStart, i);
+                }
+
+                segmentStart = i + 1;
+            }
+
+            return stripped ? builder.toString() : clientId;
+        }
+
+        private boolean isIterationIndex(String clientId, int start, int end) {
+            if (start >= end) {
+                return false;
+            }
+
+            for (int i = start; i < end; i++) {
+                if (!Character.isDigit(clientId.charAt(i))) {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         /**


### PR DESCRIPTION
Closes #5865

An action is recorded whenever the tree is modified, which can happen while an iterating component has a row index set: `UIData.broadcast` sets it before an action runs, so an add performed by a command button inside a row was recorded against a parent like `form:table:1:group`.

The component does not carry that row. A component inside an iterating one is a single instance shared by every row, so the modification belongs to all of them and the row says only when it happened. The id therefore named a position which does not exist, and `FaceletPartialStateManagementStrategy` could not resolve it when restoring, as it indexes row-free and always has — back to 2.3.9, the oldest tag in this repository. The add rendered in the request which created it and then vanished on the next postback, while the dropped action stayed in the list to be re-saved and replayed, for nothing, on every postback after that.

This strips the iteration index when recording instead, so the action names what it actually denotes.

### Why a numeric segment is unambiguous

A component id cannot be one: `UIComponent.setId` requires the first character to be a letter or an underscore. Only an iterating component contributes a numeric segment. The same reasoning already underpins `PackageUtils.extractFirstNumericSegment`, which `UIData.invokeOnComponent` uses to read a row out of a client id — this is that idea in reverse. It is package-private in `jakarta.faces.component`, hence a local helper here.

Alternatives considered and rejected: resolving the row-scoped id at restore via `invokeOnComponent` (a tree scan per action, and it sets the row index, touching the `DataModel` — see #5864), and clearing the row index on iterating ancestors to compute a row-free id (touches per-row state and the model).

### Note for reviewers

This changes what goes into saved state: a view serialised by an older Mojarra and restored by a newer one carries un-stripped ids, which then will not resolve. Worth a view on whether that matters for backports.

### Testing

`Issue5865IT` in `faces23/dynamic-components` (jakartaee/faces#2213) asserts a component added to a container inside a data table row renders in the proper place and survives a postback. Red before, green after. Verified on this branch standalone: TCK 9/9, Mojarra unit suite 1072/1072.

The helper was checked against nested tables (`form:outer:3:inner:12:input`), multi-digit rows, leading and trailing indices (`form:table:1` must not leave a dangling separator), and ids which must not be stripped (`_1`, `a1`).

🤖 Generated with Claude Opus 4.8
