### PR TITLE
Backport #5864 and #5865 into 4.0

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -75,6 +75,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
@@ -183,6 +184,9 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
     private Map<String, List<String>> contractMappings;
 
     private static final String NONCE_EXPRESSION = "#{nonce}";
+
+    private static final Set<VisitHint> SKIP_ITERATION_HINT = EnumSet.of(VisitHint.SKIP_ITERATION);
+
     private String cspHeader;
     private boolean dynamicCspHeader;
 
@@ -1765,12 +1769,27 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
      * dynamically added component nested under another) resolves against the live tree rather than restoring a
      * duplicate.
      *
+     * <p>
+     * The visit skips iteration, as the same lookup in {@link FaceletPartialStateManagementStrategy} always has.
+     * Iterating is not free of consequence: it sets the row index on every iterating component in the view, which a
+     * component can act on -- a data table backed by a lazily loaded model fetches a page of data per iteration --
+     * and replay must not provoke that merely to find components by client id.
+     * </p>
+     *
+     * <p>
+     * The index therefore holds no row-scoped client id, and an action recorded against one (an add performed while
+     * a row index was set) does not resolve here. That costs nothing: a component inside a row is a single instance
+     * shared by every row, so such an action denotes no position the index is missing, and the request which
+     * recorded it has the component attached already. Later requests never see it either way, as
+     * {@link FaceletPartialStateManagementStrategy} resolves against an equally row-free index when restoring.
+     * </p>
+     *
      * @param context the Faces context.
      * @param root the subtree to index.
      * @param index the index to populate.
      */
     private void indexSubtree(FacesContext context, UIComponent root, Map<String, UIComponent> index) {
-        VisitContext visitContext = VisitContext.createVisitContext(context);
+        VisitContext visitContext = VisitContext.createVisitContext(context, null, SKIP_ITERATION_HINT);
         root.visitTree(visitContext, (visitContext1, component) -> {
             index.put(component.getClientId(visitContext1.getFacesContext()), component);
             return VisitResult.ACCEPT;
@@ -1940,7 +1959,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
             return false;
         }
         boolean[] found = { false };
-        VisitContext visitContext = VisitContext.createVisitContext(context, null, EnumSet.of(VisitHint.SKIP_ITERATION));
+        VisitContext visitContext = VisitContext.createVisitContext(context, null, SKIP_ITERATION_HINT);
         viewRoot.visitTree(visitContext, (vc, target) -> {
             if (target instanceof UIForm) {
                 found[0] = true;

--- a/impl/src/main/java/com/sun/faces/context/StateContext.java
+++ b/impl/src/main/java/com/sun/faces/context/StateContext.java
@@ -44,6 +44,7 @@ import com.sun.faces.util.FacesLogger;
 import com.sun.faces.util.MostlySingletonSet;
 
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UINamingContainer;
 import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.AbortProcessingException;
@@ -636,8 +637,8 @@ public class StateContext {
         protected void handleRemove(FacesContext context, UIComponent component) {
             if (component.isInView()) {
                 recordDynamicAction(
-                    component, 
-                    new ComponentStruct(REMOVE, findFacetNameForComponent(component), component.getClientId(context), component.getId())
+                    component,
+                    new ComponentStruct(REMOVE, findFacetNameForComponent(component), stripIterationIndex(context, component.getClientId(context)), component.getId())
                 );
            }
         }
@@ -659,12 +660,76 @@ public class StateContext {
                 component.clearInitialState();
                 component.getAttributes().put(DYNAMIC_COMPONENT, index);
 
-                ComponentStruct struct = new ComponentStruct(ADD, facetName, component.getParent().getClientId(context), component.getClientId(context),
+                ComponentStruct struct = new ComponentStruct(ADD, facetName,
+                        stripIterationIndex(context, component.getParent().getClientId(context)),
+                        stripIterationIndex(context, component.getClientId(context)),
                         component.getId());
                 struct.setIndex(index);
 
                 recordDynamicAction(component, struct);
             }
+        }
+
+        /**
+         * Drops the iteration index of every iterating ancestor from the given client id, e.g.
+         * {@code form:table:1:group} becomes {@code form:table:group}.
+         *
+         * <p>
+         * An action is recorded whenever the tree is modified, which can be while an iterating component has a row
+         * index set -- an add performed by a command button inside a row, for instance, as {@link UIData#broadcast}
+         * sets the row index before the action runs. The client id then carries that row, but the component does
+         * not: a component inside an iterating one is a single instance shared by every row, so the modification
+         * belongs to all of them and the row says only when it happened. Recording it would key the action to a
+         * position which does not exist, which nothing can resolve it against afterwards.
+         * </p>
+         *
+         * <p>
+         * A numeric segment is unambiguous: a component id cannot be one, as {@link UIComponent#setId} requires the
+         * first character to be a letter or an underscore. Only an iterating component contributes one.
+         * </p>
+         *
+         * @param context the Faces context.
+         * @param clientId the client id to strip.
+         * @return the given client id without the iteration index of any iterating ancestor.
+         */
+        private String stripIterationIndex(FacesContext context, String clientId) {
+            char separatorChar = UINamingContainer.getSeparatorChar(context);
+            StringBuilder builder = new StringBuilder(clientId.length());
+            boolean stripped = false;
+            int segmentStart = 0;
+
+            for (int i = 0; i <= clientId.length(); i++) {
+                if (i < clientId.length() && clientId.charAt(i) != separatorChar) {
+                    continue;
+                }
+
+                if (isIterationIndex(clientId, segmentStart, i)) {
+                    stripped = true;
+                } else {
+                    if (builder.length() > 0) {
+                        builder.append(separatorChar);
+                    }
+                    builder.append(clientId, segmentStart, i);
+                }
+
+                segmentStart = i + 1;
+            }
+
+            return stripped ? builder.toString() : clientId;
+        }
+
+        private boolean isIterationIndex(String clientId, int start, int end) {
+            if (start >= end) {
+                return false;
+            }
+
+            for (int i = start; i < end; i++) {
+                if (!Character.isDigit(clientId.charAt(i))) {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         /**

--- a/impl/src/test/java/com/sun/faces/application/view/FaceletViewHandlingStrategyTest.java
+++ b/impl/src/test/java/com/sun/faces/application/view/FaceletViewHandlingStrategyTest.java
@@ -16,6 +16,7 @@
 package com.sun.faces.application.view;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -23,6 +24,9 @@ import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -33,18 +37,24 @@ import com.sun.faces.util.ComponentStruct;
 import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.component.visit.VisitCallback;
 import jakarta.faces.component.visit.VisitContext;
+import jakarta.faces.component.visit.VisitHint;
 import jakarta.faces.context.FacesContext;
 
 class FaceletViewHandlingStrategyTest {
 
-    /** A view root that records whether its subtree was walked. */
+    /**
+     * A view root that records whether its subtree was walked, and how the visit was configured. It does not walk:
+     * these tests turn on whether a walk happens and how it is set up, not on what it finds.
+     */
     private static final class RecordingViewRoot extends UIViewRoot {
         boolean visited;
+        Set<VisitHint> hints;
 
         @Override
         public boolean visitTree(VisitContext context, VisitCallback callback) {
             visited = true;
-            return super.visitTree(context, callback);
+            hints = context.getHints();
+            return false;
         }
     }
 
@@ -81,5 +91,69 @@ class FaceletViewHandlingStrategyTest {
         }
 
         assertFalse(viewRoot.visited, "reapplyDynamicActions walked the view despite having no dynamic actions");
+    }
+
+    /**
+     * Regression guard for #5864. When there are dynamic actions to replay the view does get indexed, and that
+     * walk must skip iteration.
+     *
+     * <p>A visit without {@link VisitHint#SKIP_ITERATION} sets the row index on every iterating component it
+     * passes, which components observe: a data table backed by a lazily loaded model fetches a page of data per
+     * iteration, so the walk provokes a duplicate query on every postback which renders one. Indexing exists to
+     * find components by client id and has no business iterating anything to do it.
+     *
+     * <p>The guard above is not a substitute for this one: it only holds when the view has no dynamic actions at
+     * all, and every view relocates its component resources to the head, so in practice there is always an action
+     * to replay and this walk always runs.
+     *
+     * <p>This lives here rather than in the TCK because the spec does not mandate it. The spec defines what
+     * {@code SKIP_ITERATION} means for a visit, but says nothing about how the runtime may go looking for a
+     * component by client id, and dynamic-action replay is entirely an implementation concern -- no spec type is
+     * involved. The invariant is nonetheless real and cross-implementation: a component which loads data per row
+     * cannot defend itself against a walk it never asked for, and both implementations honoured this until
+     * PR #5783 stopped honouring it here. A TCK test would have to assert a row-access count, which the spec
+     * leaves free, so it belongs to the implementation which made the promise.
+     */
+    @Test
+    void reapplyDynamicActionsIndexesTheViewWithoutIteratingRows() throws Exception {
+        RecordingViewRoot viewRoot = new RecordingViewRoot();
+        FacesContext context = mock(FacesContext.class);
+        when(context.getViewRoot()).thenReturn(viewRoot);
+
+        ComponentStruct action = new ComponentStruct(ComponentStruct.ADD, null, "form", "form:added", "added");
+
+        StateContext stateContext = mock(StateContext.class);
+        when(stateContext.getDynamicActions()).thenReturn(new ArrayList<>(List.of(action)));
+        when(stateContext.getDynamicComponents()).thenReturn(new HashMap<>());
+
+        FaceletViewHandlingStrategy strategy = mock(FaceletViewHandlingStrategy.class);
+        Method reapplyDynamicActions = FaceletViewHandlingStrategy.class
+                .getDeclaredMethod("reapplyDynamicActions", FacesContext.class);
+        reapplyDynamicActions.setAccessible(true);
+
+        try (MockedStatic<StateContext> mocked = mockStatic(StateContext.class);
+                MockedStatic<VisitContext> visitContexts = mockStatic(VisitContext.class)) {
+            mocked.when(() -> StateContext.getStateContext(context)).thenReturn(stateContext);
+            mocked.when(() -> StateContext.pruneDynamicActions(any())).thenCallRealMethod();
+            // Hand back the hints the caller asked for: the real factory would need a CDI-backed FactoryFinder,
+            // and the assertion is about what the visit is asked for, not about what the factory makes of it.
+            visitContexts.when(() -> VisitContext.createVisitContext(any(), any(), any())).thenAnswer(invocation -> {
+                VisitContext visitContext = mock(VisitContext.class);
+                when(visitContext.getHints()).thenReturn(invocation.getArgument(2));
+                return visitContext;
+            });
+            // The hintless overload, so that indexing via it fails this test on its assertion rather than on a NPE.
+            visitContexts.when(() -> VisitContext.createVisitContext(any())).thenAnswer(invocation -> {
+                VisitContext visitContext = mock(VisitContext.class);
+                when(visitContext.getHints()).thenReturn(Set.of());
+                return visitContext;
+            });
+
+            reapplyDynamicActions.invoke(strategy, context);
+        }
+
+        assertTrue(viewRoot.visited, "reapplyDynamicActions did not index the view despite having a dynamic action");
+        assertTrue(viewRoot.hints.contains(VisitHint.SKIP_ITERATION),
+                "reapplyDynamicActions indexed the view with a visit which iterates rows");
     }
 }


### PR DESCRIPTION
Backports #5864 and #5865 from master (5.0) into 4.0.

Both defects are present on 4.0 exactly as on master. The `#5865` change is byte-identical to the merged 5.0 commit (only the package differs, `com.sun.faces` vs `org.glassfish.mojarra`); the `#5864` change applied from 4.1 without conflict.

- **#5864** — `reapplyDynamicActions` indexed the view without `SKIP_ITERATION`, iterating the rows of every `UIData`/`UIRepeat` and causing a data table backed by a lazily loaded model to fetch a page per postback that renders one.
- **#5865** — a dynamic add recorded while a row index was set carried a row-scoped parent client id (`form:table:1:group`), which the row-free restore index could not resolve, so the add vanished on the next postback.

### Testing

4.0 unit suite 1188/1188, including `FaceletViewHandlingStrategyTest`'s guard for #5864. The #5865 IT (jakartaee/faces#2213) targets the 5.0 TCK; #5865's change here is byte-identical to the version that IT covers on master.

### Not a state-format change

`#5865` alters the value recorded in `ComponentStruct` (a row-free client id), not its saved shape — `saveState` is unchanged. A view serialised by 4.0.19 and restored by 4.0.20 with a dynamic add recorded inside a row would fail to resolve that stale id, which is exactly what 4.0.19 already did with it. No regression.

🤖 Generated with Claude Opus 4.8
