### PR TITLE
Fix #5871: discard buffered render output on reset instead of dropping the writer

### DIFF
--- a/impl/src/main/java/com/sun/faces/context/ExternalContextImpl.java
+++ b/impl/src/main/java/com/sun/faces/context/ExternalContextImpl.java
@@ -86,12 +86,12 @@ public class ExternalContextImpl extends ExternalContext {
     private ServletContext servletContext = null;
     private ServletRequest request = null;
     private ServletResponse response = null;
-    // Cached response writer (lazily created). A BufferedWriter so the many small render-time writes --
+    // Cached response writer (lazily created). A buffering writer so the many small render-time writes --
     // and any writes by render-view listeners that obtain this same writer -- coalesce into larger chunks
     // before the container's writer (some servlet writers, e.g. undertow, pay a per-write encode cost).
     // Caching means every caller shares one buffer, preserving write order; flushed in release() and
-    // responseFlushBuffer().
-    private Writer responseOutputWriter;
+    // responseFlushBuffer(), and emptied in responseReset() and responseSendError().
+    private ResponseOutputWriter responseOutputWriter;
     private ClientWindow clientWindow = null;
 
     private Map<String, Object> applicationMap = null;
@@ -837,19 +837,22 @@ public class ExternalContextImpl extends ExternalContext {
     @Override
     public Writer getResponseOutputWriter() throws IOException {
         if (responseOutputWriter == null) {
-            responseOutputWriter = new BufferedWriter(response.getWriter());
+            responseOutputWriter = new ResponseOutputWriter(response.getWriter());
         }
         return responseOutputWriter;
     }
 
     /**
-     * Drop the cached {@link BufferedWriter} without flushing it. Both {@code response.reset()} and
+     * Empty the cached {@link ResponseOutputWriter} without flushing it. Both {@code response.reset()} and
      * {@code response.sendError()} only clear the container buffer, so output still buffered in the wrapping
      * writer would survive and get flushed at {@link #release()}, re-committing the aborted response and
-     * defeating the container's error page. A subsequent write lazily re-creates a fresh writer.
+     * defeating the container's error page. The writer itself is deliberately kept, as the response writer
+     * created earlier in the request holds on to it and keeps writing into it after the reset.
      */
     private void discardResponseOutputWriter() {
-        responseOutputWriter = null;
+        if (responseOutputWriter != null) {
+            responseOutputWriter.discard();
+        }
     }
 
     /**
@@ -1248,6 +1251,87 @@ public class ExternalContextImpl extends ExternalContext {
         @Override
         public void remove() {
             throw new UnsupportedOperationException();
+        }
+
+    }
+
+    /**
+     * Buffering writer which coalesces the many small render-time writes into larger chunks before handing them to the
+     * container's writer, and which can additionally discard whatever is still buffered.
+     * <p>
+     * The discard is what {@link BufferedWriter} cannot offer: aborting a partially rendered response requires
+     * dropping the output that has not reached the container yet, as {@code response.reset()} only clears the
+     * container's own buffer. Output already drained to the container's writer is beyond reach, which matches the
+     * container's own semantics -- once it is committed it can no longer be taken back.
+     */
+    private static class ResponseOutputWriter extends Writer {
+
+        private static final int BUFFER_SIZE = 8192;
+
+        private final Writer wrapped;
+        private final char[] buffer = new char[BUFFER_SIZE];
+        private int count;
+
+        private ResponseOutputWriter(Writer wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public void write(char[] chars, int offset, int length) throws IOException {
+            if (length >= BUFFER_SIZE) {
+                drain();
+                wrapped.write(chars, offset, length);
+                return;
+            }
+
+            if (count + length > BUFFER_SIZE) {
+                drain();
+            }
+
+            System.arraycopy(chars, offset, buffer, count, length);
+            count += length;
+        }
+
+        @Override
+        public void write(String string, int offset, int length) throws IOException {
+            if (length >= BUFFER_SIZE) {
+                drain();
+                wrapped.write(string, offset, length);
+                return;
+            }
+
+            if (count + length > BUFFER_SIZE) {
+                drain();
+            }
+
+            string.getChars(offset, offset + length, buffer, count);
+            count += length;
+        }
+
+        @Override
+        public void flush() throws IOException {
+            drain();
+            wrapped.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            drain();
+            wrapped.close();
+        }
+
+        /**
+         * Drop what is still buffered, so that it never reaches the container's writer.
+         */
+        private void discard() {
+            count = 0;
+        }
+
+        private void drain() throws IOException {
+            if (count > 0) {
+                wrapped.write(buffer, 0, count);
+                count = 0;
+            }
         }
 
     }

--- a/impl/src/test/java/com/sun/faces/context/ExternalContextImplTest.java
+++ b/impl/src/test/java/com/sun/faces/context/ExternalContextImplTest.java
@@ -16,11 +16,16 @@
 
 package com.sun.faces.context;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -171,6 +176,67 @@ public class ExternalContextImplTest {
         verifySupplier(() -> requestCookieMap.put("foot", "bar"));
         verifyConsumer(m -> requestCookieMap.putAll((Map<? extends String, ? extends Object>) m), new HashMap<>());
         verifySupplier(() -> requestCookieMap.remove("foo"));
+    }
+
+    /**
+     * Test that responseReset discards render output which is still buffered in the response output writer. The writer
+     * is deliberately held on to across the reset, as that is what the response writer created earlier in the request
+     * does.
+     */
+    @Test
+    public void testResponseResetDiscardsBufferedOutput() throws IOException {
+        StringWriter container = new StringWriter();
+        ExternalContextImpl externalContext = createExternalContext(container);
+        Writer writer = externalContext.getResponseOutputWriter();
+
+        writer.write("aborted");
+        externalContext.responseReset();
+        writer.write("replacement");
+        writer.flush();
+
+        assertEquals("replacement", container.toString());
+    }
+
+    /**
+     * Test that responseSendError discards render output which is still buffered in the response output writer.
+     */
+    @Test
+    public void testResponseSendErrorDiscardsBufferedOutput() throws IOException {
+        StringWriter container = new StringWriter();
+        ExternalContextImpl externalContext = createExternalContext(container);
+        Writer writer = externalContext.getResponseOutputWriter();
+
+        writer.write("aborted");
+        externalContext.responseSendError(500, null);
+        writer.flush();
+
+        assertEquals("", container.toString());
+    }
+
+    /**
+     * Test that render output which has already been drained to the container's writer is beyond the reach of
+     * responseReset, which matches the container's own semantics.
+     */
+    @Test
+    public void testResponseResetDoesNotDiscardAlreadyDrainedOutput() throws IOException {
+        StringWriter container = new StringWriter();
+        ExternalContextImpl externalContext = createExternalContext(container);
+        Writer writer = externalContext.getResponseOutputWriter();
+        String drained = "x".repeat(8192);
+
+        writer.write(drained);
+        externalContext.responseReset();
+        writer.flush();
+
+        assertEquals(drained, container.toString());
+    }
+
+    private ExternalContextImpl createExternalContext(StringWriter container) throws IOException {
+        ServletContext servletContext = Mockito.mock(ServletContext.class);
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        when(response.getWriter()).thenReturn(new PrintWriter(container));
+        return new ExternalContextImpl(servletContext, request, response);
     }
 
     /**


### PR DESCRIPTION
Closes #5871

`discardResponseOutputWriter()` set the cached field to `null`, which does not empty the `BufferedWriter` it was pointing at. The response writer created earlier in the request holds on to that same instance and keeps writing into it after the reset, so the aborted output survived and got flushed together with whatever was rendered afterwards.

An `ExceptionHandler` which resets the response and renders a replacement view therefore produced two concatenated documents. On ajax that is two `<partial-response>` documents, of which the browser parses only the first, so the replacement view never applies.

## Change

Replace the `BufferedWriter` with a `ResponseOutputWriter` which offers the missing discard, and keep the instance on reset so the live response writer keeps writing into the now empty buffer. Coalescing behaviour is unchanged: same 8K buffer, same straight-through path for oversized writes.

Output already drained to the container's writer is beyond reach, which matches the container's own semantics — once committed it can no longer be taken back. This also restores the meaning of `isResponseCommitted()`: buffered but undrained output is retractable again, so `false` once more means the response can still be replaced.

## Tests

Three tests in `ExternalContextImplTest`, all holding on to the writer across the reset as the real response writer does:

- `testResponseResetDiscardsBufferedOutput` — without the fix: `expected: <replacement> but was: <abortedreplacement>`
- `testResponseSendErrorDiscardsBufferedOutput` — without the fix: `expected: <> but was: <aborted>`
- `testResponseResetDoesNotDiscardAlreadyDrainedOutput` — pins the deliberate limitation

Full `impl` test suite is green.

## Not verified here

The originating real-world reproducer is OmniFaces' `FullAjaxExceptionHandler` on Faces 5, which cannot run on this branch. The fix targets the code path that a write-level trace implicated, but the end-to-end scenario should be re-checked after upmerge to master.

🤖 Generated with Claude Opus 4.8
