### PR TITLE
Fix #5871: drain instead of flush the buffered render output on release

### DIFF
--- a/impl/src/main/java/com/sun/faces/context/ExternalContextImpl.java
+++ b/impl/src/main/java/com/sun/faces/context/ExternalContextImpl.java
@@ -1060,7 +1060,10 @@ public class ExternalContextImpl extends ExternalContext {
         // covers output written after renderView -- e.g. by PostRenderViewEvent listeners.
         if (responseOutputWriter != null) {
             try {
-                responseOutputWriter.flush();
+                // Deliberately only drain, not flush: flushing the container's writer would commit the response, even
+                // when nothing is left to write, and thereby defeat the error page of a request which is being aborted.
+                // The container flushes its own buffer when the request ends.
+                responseOutputWriter.drain();
             } catch (IOException ignored) {
                 // Best-effort at teardown; a genuine write failure surfaces via the container.
             }

--- a/impl/src/test/java/com/sun/faces/context/ExternalContextImplTest.java
+++ b/impl/src/test/java/com/sun/faces/context/ExternalContextImplTest.java
@@ -17,6 +17,7 @@
 package com.sun.faces.context;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -229,6 +230,35 @@ public class ExternalContextImplTest {
         writer.flush();
 
         assertEquals(drained, container.toString());
+    }
+
+    /**
+     * Test that release drains buffered render output to the container's writer without flushing it. Flushing would
+     * commit the response, even when nothing is left to write, and thereby defeat the error page of a request which is
+     * being aborted.
+     */
+    @Test
+    public void testReleaseDrainsWithoutFlushing() throws IOException {
+        FlushRecordingWriter container = new FlushRecordingWriter();
+        ExternalContextImpl externalContext = createExternalContext(container);
+
+        externalContext.getResponseOutputWriter().write("rendered");
+        externalContext.release();
+
+        assertEquals("rendered", container.toString());
+        assertFalse(container.flushed, "container writer must not be flushed by release()");
+    }
+
+    private static class FlushRecordingWriter extends StringWriter {
+
+        private boolean flushed;
+
+        @Override
+        public void flush() {
+            flushed = true;
+            super.flush();
+        }
+
     }
 
     private ExternalContextImpl createExternalContext(StringWriter container) throws IOException {


### PR DESCRIPTION
Follow-up to #5872, same ticket.

`ExternalContextImpl#release()` flushed the cached response output writer, which flushes the container's writer in turn, and that commits the response even when nothing is left to write. A request being aborted therefore ended up with a committed response before the container could serve its error page, leaving the client with a truncated response (`ERR_INCOMPLETE_CHUNKED_ENCODING`).

This defeated the discard added in #5872 on the non-ajax path: an `ExceptionHandler` which lets the exception through to the container relies on the response still being replaceable, but `release()` runs in the `FacesServlet` finally — after the exception escaped, before the container handles it. Traced:

```
[CATCH] ServletException committed=false   <- exception escapes, response still clean
[CATCH] after reset:     committed=false   <- discard works
[BUF]   POST after chain committed=true    <- release() committed it
```

## Change

Only drain the buffer in `release()`, so the remaining output still reaches the container's writer but the response is not committed by doing so. The container flushes its own buffer when the request ends.

## Tests

`ExternalContextImplTest.testReleaseDrainsWithoutFlushing` asserts both halves: the output *is* drained through (a normal request loses nothing) and the container writer is *not* flushed. Without the fix it reports `container writer must not be flushed by release() ==> expected: <false> but was: <true>`.

Full `impl` suite green (1192 tests).

## End-to-end

With this plus #5872, OmniFaces' `FullAjaxExceptionHandlerIT` passes 14/14 on Faces 5 — previously 7 failures. That end-to-end run was done on master (Faces 4.0 cannot run OmniFaces 5.x); this branch carries the identical change.

🤖 Generated with Claude Opus 4.8
