### PR TITLE
Fix #5874: key UIData/UIRepeat per-row child state by clientId, not row index

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/component/UIRepeat.java
+++ b/impl/src/main/java/com/sun/faces/facelets/component/UIRepeat.java
@@ -40,6 +40,8 @@ import jakarta.faces.application.FacesMessage;
 import jakarta.faces.component.ContextCallback;
 import jakarta.faces.component.EditableValueHolder;
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.NamingContainer;
+import jakarta.faces.component.UIForm;
 import jakarta.faces.component.UINamingContainer;
 import jakarta.faces.component.visit.VisitCallback;
 import jakarta.faces.component.visit.VisitContext;
@@ -340,11 +342,15 @@ public class UIRepeat extends UINamingContainer {
         }
     }
 
-    // Per-row transient state of the stateful descendants, keyed by row index. The value array is positionally
-    // aligned to iterationStatefulList (the EditableValueHolder descendants in deterministic tree order), so save and
-    // restore index by position instead of recomputing a clientId and hashing it per child per row. The array length
-    // is guarded on restore so a tree-shape change between requests degrades to NULL_STATE rather than misaligning.
-    private Map<Integer, SavedState[]> childState;
+    // Per-row transient state of the stateful descendants, keyed by this repeat's own row-scoped clientId. The value
+    // array is positionally aligned to iterationStatefulList (the EditableValueHolder descendants in deterministic
+    // tree order), so save and restore index by position instead of recomputing a clientId and hashing it per child
+    // per row. The array length is guarded on restore so a tree-shape change between requests degrades to NULL_STATE
+    // rather than misaligning. The key must be the clientId rather than the bare index: a nested repeat is one
+    // component instance reused across the enclosing iteration's rows, so an index alone identifies the same key
+    // under every enclosing row and the rows would overwrite each other's state. This repeat's own clientId already
+    // carries the enclosing rows' indices, and is computed once per index change rather than once per child per row.
+    private Map<String, SavedState[]> childState;
 
     /**
      * Per-iteration cache of the descendants the per-row save/restore walks act on, collected by
@@ -358,11 +364,24 @@ public class UIRepeat extends UINamingContainer {
     private transient List<UIComponent> iterationResetList;
     private transient List<UIComponent> iterationStatefulList;
 
-    private Map<Integer, SavedState[]> getChildState() {
+    private Map<String, SavedState[]> getChildState() {
         if (childState == null) {
             childState = new HashMap<>();
         }
         return childState;
+    }
+
+    /**
+     * The key this repeat's per-row child state is stored under: its own clientId, which carries the row indices of
+     * any enclosing iterating components, plus its current index. Nesting therefore yields distinct keys where the
+     * bare index would collide.
+     */
+    private String getRowStateKey(FacesContext ctx) {
+        // Deliberately super.getClientId(): this repeat's own getClientId() appends the index and
+        // rebuilds the id through a buffer on every call. The inherited one is cached in the clientId
+        // field and invalidated by the iterationResetList walk whenever an enclosing row changes, so
+        // it yields the enclosing rows' indices without rebuilding them per row.
+        return super.getClientId(ctx) + NamingContainer.SEPARATOR_CHAR + index;
     }
 
     private void clearChildState() {
@@ -393,7 +412,10 @@ public class UIRepeat extends UINamingContainer {
 
     private void collectIterationState(UIComponent component, List<UIComponent> reset, List<UIComponent> stateful) {
         reset.add(component);
-        if (component instanceof EditableValueHolder) {
+        if (component instanceof EditableValueHolder || component instanceof UIForm) {
+            // UIForm carries per-row state too: with one form per row only the submitted one may
+            // validate and update its model, so its submitted flag must be restored per row rather
+            // than leaking whichever row was decoded last. Mirrors UIData#collectIterationState.
             stateful.add(component);
         }
         Iterator<UIComponent> itr = component.getFacetsAndChildren();
@@ -408,10 +430,11 @@ public class UIRepeat extends UINamingContainer {
         if (count == 0) {
             return;
         }
-        SavedState[] rowState = getChildState().get(index);
+        String rowStateKey = getRowStateKey(ctx);
+        SavedState[] rowState = getChildState().get(rowStateKey);
         if (rowState == null || rowState.length != count) {
             rowState = new SavedState[count];
-            getChildState().put(index, rowState);
+            getChildState().put(rowStateKey, rowState);
         }
         for (int i = 0; i < count; i++) {
             UIComponent c = iterationStatefulList.get(i);
@@ -421,14 +444,18 @@ public class UIRepeat extends UINamingContainer {
                     ss = new SavedState();
                     rowState[i] = ss;
                 }
-                ss.populate((EditableValueHolder) c);
+                if (c instanceof UIForm) {
+                    ss.populate((UIForm) c);
+                } else {
+                    ss.populate((EditableValueHolder) c);
+                }
             }
         }
     }
 
     private void removeChildState(FacesContext ctx) {
         if (childState != null) {
-            childState.remove(index);
+            childState.remove(getRowStateKey(ctx));
         }
     }
 
@@ -446,11 +473,15 @@ public class UIRepeat extends UINamingContainer {
         }
         // Positional restore: index into this row's saved-state array rather than rebuilding/hashing a clientId per
         // child. A null array (row never saved) or short array (tree shape changed) falls back to NULL_STATE per slot.
-        SavedState[] rowState = childState == null ? null : childState.get(index);
+        SavedState[] rowState = childState == null ? null : childState.get(getRowStateKey(ctx));
         for (int i = 0; i < count; i++) {
-            EditableValueHolder evh = (EditableValueHolder) iterationStatefulList.get(i);
+            UIComponent c = iterationStatefulList.get(i);
             SavedState ss = rowState != null && i < rowState.length ? rowState[i] : null;
-            (ss != null ? ss : NULL_STATE).apply(evh);
+            if (c instanceof UIForm) {
+                (ss != null ? ss : NULL_STATE).apply((UIForm) c);
+            } else {
+                (ss != null ? ss : NULL_STATE).apply((EditableValueHolder) c);
+            }
         }
     }
 
@@ -903,6 +934,16 @@ public class UIRepeat extends UINamingContainer {
             localValueSet = evh.isLocalValueSet();
         }
 
+        private boolean submitted;
+
+        public void populate(UIForm form) {
+            submitted = form.isSubmitted();
+        }
+
+        public void apply(UIForm form) {
+            form.setSubmitted(submitted);
+        }
+
         public void apply(EditableValueHolder evh) {
             evh.setValue(value);
             evh.setValid(valid);
@@ -1032,7 +1073,7 @@ public class UIRepeat extends UINamingContainer {
         Object[] state = (Object[]) object;
         super.restoreState(faces, state[0]);
         // noinspection unchecked
-        childState = (Map<Integer, SavedState[]>) state[1];
+        childState = (Map<String, SavedState[]>) state[1];
         begin = (Integer) state[2];
         end = (Integer) state[3];
         step = (Integer) state[4];

--- a/impl/src/main/java/jakarta/faces/component/UIData.java
+++ b/impl/src/main/java/jakarta/faces/component/UIData.java
@@ -229,10 +229,14 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
      */
     private Boolean isNested = null;
 
-    // Per-row transient state of the stateful descendants, keyed by row index. The value array is positionally
-    // aligned to iterationStatefulList, so save/restore index by position instead of recomputing a clientId and
-    // hashing it per descendant per row. Mirrors UIRepeat#childState; saved/restored explicitly in saveState below.
-    private Map<Integer, SavedState[]> childState;
+    // Per-row transient state of the stateful descendants, keyed by this table's own row-scoped clientId. The value
+    // array is positionally aligned to iterationStatefulList, so save/restore index by position instead of recomputing
+    // a clientId and hashing it per descendant per row. The key must be the clientId rather than the bare row index:
+    // a nested table is one component instance reused across the enclosing table's rows, so a row index alone
+    // identifies the same key under every enclosing row and the rows would overwrite each other's state. This
+    // table's own clientId already carries the enclosing rows' indices, and is computed once per row change rather
+    // than once per descendant per row. Mirrors UIRepeat#childState; saved/restored explicitly in saveState below.
+    private Map<String, SavedState[]> childState;
 
     private Map<String, Object> _rowDeltaStates = new HashMap<>();
     private Map<String, Object> _rowTransientStates = new HashMap<>();
@@ -495,8 +499,12 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
             return;
         }
 
+        // Resolved once and threaded through: getFacesContext() is a ThreadLocal lookup, and the
+        // per-row save/restore below needs a context for the row state key either way.
+        FacesContext context = getFacesContext();
+
         // Save current state for the previous row index
-        saveDescendantState();
+        saveDescendantState(context);
 
         // Update to the new row index
         // this.rowIndex = rowIndex;
@@ -512,7 +520,7 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
         // Clear or expose the current row data as a request scope attribute
         String var = (String) getStateHelper().get(PropertyKeys.var);
         if (var != null) {
-            Map<String, Object> requestMap = getFacesContext().getExternalContext().getRequestMap();
+            Map<String, Object> requestMap = context.getExternalContext().getRequestMap();
             if (rowIndex == -1) {
                 oldVar = requestMap.remove(var);
             } else if (isRowAvailable()) {
@@ -527,7 +535,7 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
         }
 
         // Reset current state information for the new row index
-        restoreDescendantState();
+        restoreDescendantState(context);
 
         // Iteration ended: clear the per-iteration stateful-descendants cache so the next
         // iteration re-evaluates the tree shape (children can change between iterations).
@@ -1667,7 +1675,7 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
         } else {
             _rowDeltaStates = (Map<String, Object>) restoredRowStates;
         }
-        childState = (Map<Integer, SavedState[]>) values[2];
+        childState = (Map<String, SavedState[]>) values[2];
     }
 
     private void resetClientIds(UIComponent component) {
@@ -2153,7 +2161,7 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
      * Restore state information for all descendant components, as described for <code>setRowIndex()</code>.
      * </p>
      */
-    private void restoreDescendantState() {
+    private void restoreDescendantState(FacesContext context) {
 
         // The clientId reset must run for every descendant (not just the stateful ones): each row
         // needs a row-specific clientId (e.g. data:N:foo), else rows render duplicate id="...". The
@@ -2169,7 +2177,7 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
         }
         // Positional restore: index this row's saved-state array rather than rebuilding/hashing a clientId per
         // child. A null array (row never saved) or short array (tree shape changed) falls back to a reset per slot.
-        SavedState[] rowState = childState == null ? null : childState.get(getRowIndex());
+        SavedState[] rowState = childState == null ? null : childState.get(getRowStateKey(context));
         for (int i = 0; i < count; i++) {
             SavedState state = rowState != null && i < rowState.length ? rowState[i] : null;
             restoreComponentState(iterationStatefulList.get(i), state);
@@ -2207,7 +2215,7 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
      * Save state information for all descendant components, as described for <code>setRowIndex()</code>.
      * </p>
      */
-    private void saveDescendantState() {
+    private void saveDescendantState(FacesContext context) {
         ensureIterationLists();
         int count = iterationStatefulList.size();
         if (count == 0) {
@@ -2216,7 +2224,7 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
         }
         // Capture per position; only slots with delta state hold a SavedState. Persist the row array only when some
         // slot carries delta, else drop the row entry — keeping the saved state minimal.
-        int row = getRowIndex();
+        String row = getRowStateKey(context);
         SavedState[] rowState = new SavedState[count];
         boolean anyDelta = false;
         for (int i = 0; i < count; i++) {
@@ -2233,11 +2241,24 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
         }
     }
 
-    private Map<Integer, SavedState[]> getChildState() {
+    private Map<String, SavedState[]> getChildState() {
         if (childState == null) {
             childState = new HashMap<>();
         }
         return childState;
+    }
+
+    /**
+     * The key this table's per-row child state is stored under: its own clientId, which carries the row indices of
+     * any enclosing iterating components, plus its current row index. Nesting therefore yields distinct keys where
+     * the bare row index would collide.
+     */
+    private String getRowStateKey(FacesContext context) {
+        // Deliberately super.getClientId(): this table's own getClientId() appends the row index and,
+        // when nested, rebuilds the whole id on every call. The inherited one is cached in the
+        // clientId field and invalidated by the iterationResetList walk whenever an enclosing row
+        // changes, so it yields the enclosing rows' indices without rebuilding them per row.
+        return super.getClientId(context) + NamingContainer.SEPARATOR_CHAR + getRowIndex();
     }
 
     private SavedState captureComponentState(UIComponent component) {


### PR DESCRIPTION
Fixes #5874 on 4.0.

A nested iterating component is one instance reused across the enclosing component's rows, so keying its per-row child state by the bare row index made every enclosing row map to the same key and overwrite the others' state. Affects all four combinations of `h:dataTable`/`ui:repeat` nesting.

Keys on the iterator's own row-scoped clientId instead, which already carries the enclosing rows' indices:

```java
private String getRowStateKey(FacesContext context) {
    return super.getClientId(context) + NamingContainer.SEPARATOR_CHAR + getRowIndex();
}
```

`super.getClientId()` deliberately: the overridden one appends the row index itself and rebuilds the whole id per call when nested, whereas the inherited one is cached in the `clientId` field and invalidated by the existing `iterationResetList` walk, so the enclosing indices come along without per-row string building.

`rowStatePreserved="true"` was never affected — it goes through `_rowDeltaStates`/`preservedRowStates`, already keyed by `getContainerClientId()`.

### Also included

`UIRepeat` gains per-row `UIForm` state, mirroring what `UIData` already does (`collectIterationState` collects `UIForm`; `SavedState` carries `submitted`). With one form per row only the submitted form may validate and update its model, and without per-row state that flag leaked from whichever row decoded last — so an `h:form` nested inside a `ui:repeat` lost *every* submitted value, while the `h:dataTable` equivalent worked. That is a pre-existing gap rather than part of the #5874 regression, and can be split out if preferred.

### Performance

Measured with `test/perf` on the 5.0 equivalent of this change (GlassFish, 1000 runs). On flat iteration pages — where fixed and unfixed do identical work — the result is indistinguishable from the index-keyed version: mean −2.4% across `table-inputs`/`repeat-inputs` phases, inside the ±5% run-to-run noise floor of the harness.

Nested pages show large positive deltas, but those are not comparable: the unfixed build *skips* work there (collided rows never get validated or updated), so the difference is the fix doing the correct amount.

### Verification

Behaviour was verified against Faces 5.0 on GlassFish 9, where a TCK grid covering the four nesting pairs × form position is being added: unfixed 0/6 cells correct on all four pairings, fixed 6/6, plus `h:form` inside `ui:repeat` round-tripping at both nesting levels.

**This 4.0 branch is compile-verified only** — the TCK grid targets 5.0 and the test pool ships the 5.0 API, so it could not be deployed here. 4.0 has the identical regression in both classes and the identical `UIForm` gap, and the `UIData` patch applied cleanly from 5.0; `UIRepeat` was hand-ported because the package path differs, so that one is equivalent-by-construction rather than proven identical and is worth a read-through. Compiles to class file version 55 (Java 11).

🤖 Generated with Claude Opus 4.8
