### PR TITLE
Fix #5878: match resource exclusions with endsWith, not a regex

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
@@ -30,7 +30,6 @@ import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static jakarta.servlet.http.HttpServletResponse.SC_NOT_MODIFIED;
 import static jakarta.servlet.http.MappingMatch.EXTENSION;
 import static java.lang.Boolean.FALSE;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.WARNING;
 
@@ -40,16 +39,19 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.List;
-import java.util.Map;
 import java.security.SecureRandom;
-import java.util.UUID;
+import java.util.Base64;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
+
+import jakarta.faces.application.Resource;
+import jakarta.faces.application.ResourceHandler;
+import jakarta.faces.application.ResourceHandlerWrapper;
+import jakarta.faces.application.ResourceVisitOption;
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.FacesContext;
 
 import com.sun.faces.application.ApplicationAssociate;
 import com.sun.faces.config.WebConfiguration;
@@ -58,13 +60,6 @@ import com.sun.faces.renderkit.html_basic.StylesheetRenderer;
 import com.sun.faces.util.FacesLogger;
 import com.sun.faces.util.RequestStateManager;
 import com.sun.faces.util.Util;
-
-import jakarta.faces.application.Resource;
-import jakarta.faces.application.ResourceHandler;
-import jakarta.faces.application.ResourceHandlerWrapper;
-import jakarta.faces.application.ResourceVisitOption;
-import jakarta.faces.context.ExternalContext;
-import jakarta.faces.context.FacesContext;
 
 /**
  * This is the default implementation of {@link ResourceHandler}.
@@ -94,7 +89,7 @@ public class ResourceHandlerImpl extends ResourceHandler {
     public static final String DEFAULT_CSP_POLICY = "script-src 'self' 'nonce-#{nonce}' 'strict-dynamic'";
 
     ResourceManager manager;
-    List<Pattern> excludePatterns;
+    private String[] excludedExtensions;
     private long creationTime;
     private long maxAge;
     private boolean cspEnabled;
@@ -296,7 +291,7 @@ public class ResourceHandlerImpl extends ResourceHandler {
 
         ExternalContext extContext = context.getExternalContext();
 
-        if (isExcluded(resourceId)) {
+        if (isExcluded(excludedExtensions, resourceId)) {
             extContext.setResponseStatus(SC_NOT_FOUND);
             return;
         }
@@ -613,13 +608,14 @@ public class ResourceHandlerImpl extends ResourceHandler {
     }
 
     /**
+     * @param excludedExtensions the excluded file extensions as returned by {@link #parseExcludedExtensions(Map, String)}
      * @param resourceId the normalized request path as returned by
      * {@link #normalizeResourceRequest(jakarta.faces.context.FacesContext)}
      * @return <code>true</code> if the request matces an excluded resource, otherwise <code>false</code>
      */
-    private boolean isExcluded(String resourceId) {
-        for (Pattern pattern : excludePatterns) {
-            if (pattern.matcher(resourceId).matches()) {
+    static boolean isExcluded(String[] excludedExtensions, String resourceId) {
+        for (String excludedExtension : excludedExtensions) {
+            if (resourceId.endsWith(excludedExtension)) {
                 return true;
             }
         }
@@ -629,21 +625,19 @@ public class ResourceHandlerImpl extends ResourceHandler {
 
     /**
      * Initialize the exclusions for this application. If no explicit exclusions are configured, the defaults of
-     * <ul>
-     * <li>.class</li>
-     * <li>.properties</li>
-     * <li>.xhtml</li>
-     * <ul>
-     * will be used.
+     * {@link ResourceHandler#RESOURCE_EXCLUDES_DEFAULT_VALUE} will be used.
      */
     private void initExclusions(Map<String, Object> appMap) {
-        String excludesParam = webconfig.getOptionValue(ResourceExcludes);
-        String[] patterns = Util.split(appMap, excludesParam, " ");
+        excludedExtensions = parseExcludedExtensions(appMap, webconfig.getOptionValue(ResourceExcludes));
+    }
 
-        excludePatterns = new ArrayList<>(patterns.length);
-        for (String pattern : patterns) {
-            excludePatterns.add(Pattern.compile(".*\\" + pattern));
-        }
+    /**
+     * @param appMap the application map, used to cache the split pattern
+     * @param excludesParam the space separated list of file extensions, including the leading '.' character
+     * @return the excluded file extensions, without empty entries, as an empty entry would exclude every resource
+     */
+    static String[] parseExcludedExtensions(Map<String, Object> appMap, String excludesParam) {
+        return Stream.of(Util.split(appMap, excludesParam, " ")).filter(extension -> !extension.isEmpty()).toArray(String[]::new);
     }
 
     private void initMaxAge() {

--- a/impl/src/test/java/com/sun/faces/application/resource/ResourceHandlerImplExcludesTest.java
+++ b/impl/src/test/java/com/sun/faces/application/resource/ResourceHandlerImplExcludesTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.faces.application.resource;
+
+import static com.sun.faces.application.resource.ResourceHandlerImpl.isExcluded;
+import static com.sun.faces.application.resource.ResourceHandlerImpl.parseExcludedExtensions;
+import static jakarta.faces.application.ResourceHandler.RESOURCE_EXCLUDES_DEFAULT_VALUE;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the parsing and matching of the {@link jakarta.faces.application.ResourceHandler#RESOURCE_EXCLUDES_PARAM_NAME}
+ * init parameter, which is a space separated list of plain file extension suffixes.
+ */
+class ResourceHandlerImplExcludesTest {
+
+    private final Map<String, Object> appMap = new HashMap<>();
+
+    private String[] parse(String excludesParam) {
+        return parseExcludedExtensions(appMap, excludesParam);
+    }
+
+    // --- parseExcludedExtensions ---
+
+    @Test
+    void parsesDefaultValue() {
+        assertArrayEquals(new String[] { ".class", ".jsp", ".jspx", ".properties", ".xhtml", ".groovy" },
+                parse(RESOURCE_EXCLUDES_DEFAULT_VALUE));
+    }
+
+    /**
+     * A leading, trailing or repeated space must not yield an empty suffix, as that would match every resource id and
+     * thus exclude the whole application.
+     */
+    @Test
+    void skipsEmptyTokens() {
+        assertArrayEquals(new String[] { ".class", ".xhtml" }, parse("  .class   .xhtml  "));
+        assertArrayEquals(new String[0], parse(""));
+        assertArrayEquals(new String[0], parse("   "));
+    }
+
+    // --- isExcluded ---
+
+    @Test
+    void excludesConfiguredSuffixes() {
+        String[] excludes = parse(RESOURCE_EXCLUDES_DEFAULT_VALUE);
+
+        assertTrue(isExcluded(excludes, "/jakarta.faces.resource/foo.xhtml"));
+        assertTrue(isExcluded(excludes, "/jakarta.faces.resource/com/example/Foo.class"));
+        assertTrue(isExcluded(excludes, "/jakarta.faces.resource/messages.properties"));
+        assertTrue(isExcluded(excludes, "/jakarta.faces.resource/foo.groovy"));
+    }
+
+    @Test
+    void doesNotExcludeOtherSuffixes() {
+        String[] excludes = parse(RESOURCE_EXCLUDES_DEFAULT_VALUE);
+
+        assertFalse(isExcluded(excludes, "/jakarta.faces.resource/foo.js"));
+        assertFalse(isExcluded(excludes, "/jakarta.faces.resource/foo.css"));
+        assertFalse(isExcluded(excludes, "/jakarta.faces.resource/foo.png"));
+    }
+
+    /**
+     * The suffix must be matched at the end only, not anywhere in the resource id.
+     */
+    @Test
+    void doesNotExcludeSuffixOccurringAsInfix() {
+        String[] excludes = parse(RESOURCE_EXCLUDES_DEFAULT_VALUE);
+
+        assertFalse(isExcluded(excludes, "/jakarta.faces.resource/foo.xhtml.js"));
+        assertFalse(isExcluded(excludes, "/jakarta.faces.resource/.class/foo.png"));
+    }
+
+    /**
+     * A line terminator in the resource id must not let it escape the exclusion.
+     */
+    @Test
+    void excludesResourceIdContainingLineTerminator() {
+        String[] excludes = parse(RESOURCE_EXCLUDES_DEFAULT_VALUE);
+
+        assertTrue(isExcluded(excludes, "/jakarta.faces.resource/foo\nbar.class"));
+        assertTrue(isExcluded(excludes, "/jakarta.faces.resource/foo\r\nbar.properties"));
+    }
+
+    @Test
+    void excludesNothingWhenNoneConfigured() {
+        String[] excludes = parse("");
+
+        assertFalse(isExcluded(excludes, "/jakarta.faces.resource/foo.xhtml"));
+        assertFalse(isExcluded(excludes, ""));
+    }
+
+    @Test
+    void honoursCustomExcludes() {
+        String[] excludes = parse(".md .txt");
+
+        assertTrue(isExcluded(excludes, "/jakarta.faces.resource/README.md"));
+        assertTrue(isExcluded(excludes, "/jakarta.faces.resource/notes.txt"));
+        assertFalse(isExcluded(excludes, "/jakarta.faces.resource/foo.xhtml"));
+    }
+}


### PR DESCRIPTION
Closes #5878.

`ResourceHandlerImpl` compiled one `".*\<ext>"` pattern per configured exclusion and ran `matches()` over all of them on every resource request. Each pattern leads with a greedy `.*` that consumes the whole resource id and then backtracks to find the literal. Profiling OmniFaces `o:graphicImage` at ~19k req/s attributed **7.1%** of samples to `isExcluded`, split over `Pattern$CharPropertyGreedy.match` and `Pattern$Slice.match`.

The exclusions are plain file extension suffixes, so `".*\.ext"` matched with `matches()` is equivalent to `String#endsWith`. The regex goes away entirely:

```java
static boolean isExcluded(String[] excludedExtensions, String resourceId) {
    for (String excludedExtension : excludedExtensions) {
        if (resourceId.endsWith(excludedExtension)) {
            return true;
        }
    }

    return false;
}
```

`endsWith` is also the more faithful reading of the spec, which defines the parameter as "a single space separated list of file extensions, including the leading '.' character".

### Behaviour changes

Verdicts are identical for every well-formed configuration. Two edge cases differ, both for the better:

- `.` does not match line terminators by default, so a resource id containing one previously escaped the exclusion and got served. `endsWith` has no such hole.
- Empty entries are now skipped. A configured value with a leading or repeated space split into an empty token, which compiled to a dangling-escape pattern and threw `PatternSyntaxException` at startup. Under `endsWith` an empty suffix would instead match every resource id and 404 the whole application, so `parseExcludedExtensions` filters them out.

Also worth noting: `Pattern.compile(".*\\" + pattern)` blindly escaped the first character of the configured value, so a value not starting with a dot became something else entirely (`foo` → `.*\foo`, where `\f` is a form feed). Such a value is invalid per the spec anyway, but `endsWith` at least treats it as the suffix it looks like.

### Not a regression

The file was added in 2007 (a640ecd76f, later imported here via the 2018 relicensing squash) already containing `Pattern.compile(".*\\" + pattern)`. The matching logic has not been touched since and no commit message or issue records a rationale for the regex, so it reads as an initial implementation choice rather than an encoded requirement.

### Tests

New `ResourceHandlerImplExcludesTest` covers parsing (defaults, empty tokens) and matching (configured suffixes, non-matching ids, suffix-as-infix, line terminators, empty config, custom excludes). Full `impl` suite green at 1200/1200.

🤖 Generated with Claude Opus 4.8
