### PR TITLE
Fix #5880: merge attributesThatAreSet delta on restore instead of replacing

### DIFF
--- a/impl/src/main/java/jakarta/faces/component/ComponentStateHelper.java
+++ b/impl/src/main/java/jakarta/faces/component/ComponentStateHelper.java
@@ -354,15 +354,15 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
                     put(serializable, entry.getKey(), entry.getValue());
                 }
             } else if (value instanceof List) {
-                if (defaultMap != null) {
-                    defaultMap.remove(serializable);
+                List<Object> current = (List<Object>) get(serializable);
+                for (Object item : (List<?>) value) {
+                    if (current == null || !current.contains(item)) {
+                        add(serializable, item);
+                        if (current == null) {
+                            current = (List<Object>) get(serializable);
+                        }
+                    }
                 }
-                if (deltaMap != null) {
-                    deltaMap.remove(serializable);
-                }
-
-                List<?> values = (List<?>) value;
-                values.stream().forEach(o -> add(serializable, o));
             } else {
                 put(serializable, value);
                 handleAttribute(serializable.toString(), value);

--- a/impl/src/test/java/jakarta/faces/component/UIComponentBaseTestCase.java
+++ b/impl/src/test/java/jakarta/faces/component/UIComponentBaseTestCase.java
@@ -447,6 +447,39 @@ public class UIComponentBaseTestCase extends UIComponentTestCase {
         assertEquals(Arrays.asList("attr2"), c.getAttributes().get("jakarta.faces.component.UIComponentBase.attributesThatAreSet"));
     }
 
+    /**
+     * The {@code attributesThatAreSet} delta list only carries entries added after
+     * {@code markInitialState()}. On restore it must therefore be <em>merged</em> onto the list that
+     * {@code buildView} already rebuilt for this request, not replace it. Replacing dropped every
+     * attribute the tag handlers re-registered before the delta was applied &mdash; e.g. a
+     * {@code styleClass} rendered on the first postback but gone from the second onward (issue #5880),
+     * triggered by any {@code setValueExpression(name, ve)} with a non-literal {@code ve} on a
+     * restored component, such as from a {@code PostRestoreStateEvent} listener.
+     */
+    @Test
+    public void testAttributesThatAreSetMergeOnRestore() throws Exception {
+        request.setAttribute("foo", "bar");
+
+        // buildView registers a tag attribute; a post-restore binding then adds a non-literal one.
+        ComponentTestImpl c = new ComponentTestImpl();
+        c.getAttributes().put("styleClass", "foo bar");
+        c.markInitialState();
+        c.setValueExpression("label", application.getExpressionFactory().createValueExpression(facesContext.getELContext(), "#{foo}", String.class));
+        assertEquals(Arrays.asList("styleClass", "label"), c.getAttributes().get("jakarta.faces.component.UIComponentBase.attributesThatAreSet"));
+
+        Object state = c.saveState(facesContext); // delta carries only [label]
+
+        // Next postback: buildView rebuilds styleClass before the delta is restored on top of it.
+        c = new ComponentTestImpl();
+        c.getAttributes().put("styleClass", "foo bar");
+        c.markInitialState();
+        c.pushComponentToEL(facesContext, c);
+        c.restoreState(facesContext, state);
+        c.popComponentFromEL(facesContext);
+
+        assertEquals(Arrays.asList("styleClass", "label"), c.getAttributes().get("jakarta.faces.component.UIComponentBase.attributesThatAreSet"));
+    }
+
     @Test
     public void testValueExpressions() throws Exception {
 


### PR DESCRIPTION
Fixes #5880.

`ComponentStateHelper.restoreState` treated a restored `List` as a wholesale replacement: it discarded both the default and delta entries for the key, then re-added only the saved delta. But the delta list is add-only — it carries only entries appended after `markInitialState` — so replacing dropped everything the tag handlers had just re-registered during `buildView`.

For `attributesThatAreSet` this meant that once a non-literal `setValueExpression(name, ve)` ran on a restored component (e.g. from a `PostRestoreStateEvent` listener), the poisoned delta wiped the pass-through attributes from the second postback onward. Any of `styleClass`, `style`, `title`, `dir`, `lang`, `tabindex` and the `on*` handlers stopped rendering and never recovered. `styleClass` became newly affected in 4.0.19/4.1.10 (#5753); the rest go back to #4269 (2021).

## Fix

Merge the restored delta onto the list `buildView` already rebuilt this request, adding only entries not already present, matching the `Map` branch directly above it — which already merges. The `List` path serves exactly two keys (`attributesThatAreSet` and `UIViewRoot.phaseListeners`), both add-only with no overlap between the rebuilt default and the saved delta, so merge-with-dedup is lossless.

## Test

`UIComponentBaseTestCase#testAttributesThatAreSetMergeOnRestore` reproduces the two-postback drop: a tag attribute registered pre-`markInitialState`, a non-literal binding added as the delta, saved, then restored onto a rebuilt list. Asserts the merged `[styleClass, label]`. Verified it fails against the old replace logic (`expected <[styleClass, label]> but was <[label]>`) and passes with the fix; full `UIComponentBaseTestCase` (43 tests) green.

🤖 Generated with Claude Opus 4.8
