### PR TITLE
Fix #5792: widen h:panelGroup wrapper gate to any renderable attribute

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/GroupRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/GroupRenderer.java
@@ -18,8 +18,11 @@ package org.glassfish.mojarra.renderkit.html_basic;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.behavior.ClientBehaviorHolder;
 import jakarta.faces.component.html.HtmlPanelGroup;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
@@ -125,7 +128,26 @@ public class GroupRenderer extends HtmlBasicRenderer {
      */
     private boolean divOrSpan(UIComponent component, String styleClass) {
 
-        return shouldWriteIdAttribute(component) || styleClass != null || RenderKitUtils.getAttributeIfSet(component, "style") != null;
+        return shouldWriteIdAttribute(component) || styleClass != null || hasRenderablePassThroughAttribute(component) || hasClientBehavior(component);
+
+    }
+
+    private static boolean hasRenderablePassThroughAttribute(UIComponent component) {
+
+        List<String> setAttributes = RenderKitUtils.getAttributesThatAreSet(component);
+        for (Attribute attribute : ATTRIBUTES) {
+            if (RenderKitUtils.getAttributeIfSet(component, setAttributes, attribute.getName()) != null) {
+                return true;
+            }
+        }
+        Map<String, Object> passThroughAttributes = component.getPassThroughAttributes(false);
+        return passThroughAttributes != null && !passThroughAttributes.isEmpty();
+
+    }
+
+    private static boolean hasClientBehavior(UIComponent component) {
+
+        return component instanceof ClientBehaviorHolder holder && !holder.getClientBehaviors().isEmpty();
 
     }
 


### PR DESCRIPTION
`GroupRenderer.divOrSpan` gated the `h:panelGroup` wrapper element on id/`style`/`styleClass` only, so a panelGroup carrying only a pass-through attribute or an attached client behavior emitted no wrapper — yet `encodeBegin` still called `renderPassThruAttributes`, leaving those hooks with no element to land on.

This widens the gate to also emit the wrapper when the component has any renderable pass-through attribute (`f:passThroughAttribute` or the known HTML handlers) or an attached client behavior. The `div` vs `span` selection by `layout` is unchanged.

Matches MyFaces and the rendering contract clarified in jakartaee/faces#2182 / jakartaee/faces#2186. TCK coverage: jakartaee/faces#2217.

Out of scope (per jakartaee/faces#2182): treating `layout="block"` as an unconditional wrapper trigger.

Closes #5792

🤖 Generated with Claude Opus 4.8
