### PR TITLE
Accept all java.time type values when pattern and type co-exist

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/core/ConvertDateTimeHandler.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/core/ConvertDateTimeHandler.java
@@ -16,6 +16,7 @@
 
 package org.glassfish.mojarra.facelets.tag.faces.core;
 
+import java.util.Set;
 import java.util.TimeZone;
 
 import jakarta.el.ELException;
@@ -43,6 +44,14 @@ import org.glassfish.mojarra.facelets.tag.faces.ComponentSupport;
  * @version $Id$
  */
 public final class ConvertDateTimeHandler extends ConverterHandler {
+
+    /**
+     * The values of the {@code type} attribute which represent a {@code java.time} class, as listed in
+     * {@link DateTimeConverter#setType(String)}. Only for these may {@code pattern} and {@code type} co-exist.
+     */
+    private static final Set<String> JAVA_TIME_TYPES = Set.of(
+        "localDate", "localDateTime", "localTime", "offsetTime", "offsetDateTime", "zonedDateTime",
+        "instant", "year", "yearMonth", "monthDay");
 
     private final TagAttribute dateStyle;
 
@@ -94,7 +103,7 @@ public final class ConvertDateTimeHandler extends ConverterHandler {
             // for java.time values
             if (type != null) {
                 String typeStr = type.getValue(ctx);
-                if (isJavaTimeType(typeStr)) {
+                if (JAVA_TIME_TYPES.contains(typeStr)) {
                     c.setType(typeStr);
                 }
             }
@@ -125,16 +134,6 @@ public final class ConvertDateTimeHandler extends ConverterHandler {
                 }
             }
         }
-    }
-
-    private static boolean isJavaTimeType(String type) {
-        boolean result = false;
-        if (null != type && type.length() > 1) {
-            char c = type.charAt(0);
-            result = c == 'l' || c == 'o' || c == 'z';
-        }
-
-        return result;
     }
 
     @Override


### PR DESCRIPTION
## Undraft only when https://github.com/jakartaee/faces/pull/2221 is merged!

---

Companion to jakartaee/faces#2211 / jakartaee/faces#2221, which add `instant`, `year`, `yearMonth` and `monthDay` to the `type` attribute of `DateTimeConverter`.

`ConvertDateTimeHandler.setAttributes` only forwards `type` to the converter alongside a `pattern` when `isJavaTimeType(type)` holds, and that method tested the first character:

```java
char c = type.charAt(0);
result = c == 'l' || c == 'o' || c == 'z';
```

That covers `local*`, `offset*` and `zoned*`, but silently drops the four new type values. The converter then keeps its default `type="date"` and takes the legacy `SimpleDateFormat` branch, which cannot handle a `java.time` value:

- `<f:convertDateTime type="monthDay" pattern="dd-MM" />` parses `30-07` into a `java.util.Date` of 1970-07-30, then fails with `IllegalArgumentException: Cannot convert 7/29/70, 8:00 PM of type class java.util.Date to class java.time.MonthDay` during Process Validations.
- `<f:convertDateTime type="instant" pattern="uuuu-MM-dd HH:mm:ss" />` fails with `IllegalArgumentException: Cannot format given Object as a Date` during Render Response.

Replaced the character check with an explicit set of the values listed in `DateTimeConverter#setType`, and inlined the now-trivial `isJavaTimeType` into its single call site.

Covered by `Spec2211IT` in jakartaee/faces#2221 (`tck/faces50/converters`), which fails on `master` and passes with this change. Verified locally: `faces50/converters` 31/31, `faces23/datetime-converter` 11/11, `faces20/api/converter-validator` green.

🤖 Generated with Claude Opus 5