### PR TITLE
Cache the first id each Facelets tag generates

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/facelets/impl/DefaultFacelet.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/impl/DefaultFacelet.java
@@ -83,6 +83,9 @@ final class DefaultFacelet extends Facelet implements XMLFrontMatterSaver {
     /** Dense per-tag counter slots, keyed by tag id. See {@link #getIdSlot(String)}. */
     private final Map<String, Integer> idSlots = new ConcurrentHashMap<>();
 
+    /** The first id each of this Facelet's tags generates, per id prefix. See {@link #firstIds(String)}. */
+    private final FirstIdCache firstIds = new FirstIdCache(this::getIdSlotCount);
+
     private Doctype savedDoctype;
 
     private String savedXMLDecl;
@@ -238,6 +241,30 @@ final class DefaultFacelet extends Facelet implements XMLFrontMatterSaver {
      */
     int getIdSlotCount() {
         return idSlots.size();
+    }
+
+    /**
+     * Returns the first id each of this Facelet's tags generates under {@code prefix}, indexed by counter slot, for a
+     * build to reuse instead of building the same strings again, or {@code null} when nothing is cached for this
+     * prefix.
+     *
+     * @param prefix the id prefix the calling build is generating under
+     * @return the per-slot first ids, or {@code null} when this Facelet caches no more prefixes
+     */
+    String[] firstIds(String prefix) {
+        return firstIds.ids(prefix);
+    }
+
+    /**
+     * Returns {@code prefix}'s first ids resized to hold every slot handed out so far, for a build that reached a slot
+     * past the end of what {@link #firstIds(String)} returned.
+     *
+     * @param prefix the id prefix the calling build is generating under
+     * @param ids the array to grow
+     * @return the grown array
+     */
+    String[] growFirstIds(String prefix, String[] ids) {
+        return firstIds.grow(prefix, ids);
     }
 
     /**

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/impl/DefaultFaceletContext.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/impl/DefaultFaceletContext.java
@@ -56,6 +56,9 @@ import org.glassfish.mojarra.facelets.el.DefaultVariableMapper;
  */
 final class DefaultFaceletContext extends FaceletContextImplBase {
 
+    /** Stands in for {@link #localIds} once resolved, for a Facelet that caches no first ids for this context. */
+    private static final String[] NOT_CACHED = new String[0];
+
     private final FacesContext faces;
 
     private final ELContext ctx;
@@ -76,6 +79,11 @@ final class DefaultFaceletContext extends FaceletContextImplBase {
     private final Map<DefaultFacelet, int[]> idCounters;
     /** {@link #facelet}'s entry in {@link #idCounters}, resolved on first use. See {@link #localCounters()}. */
     private int[] localCounters;
+    /**
+     * {@link #facelet}'s first ids for the prefix this context generates under, resolved on first use, or
+     * {@link #NOT_CACHED} once resolved to a Facelet holding none for that prefix. See {@link #localIds(String)}.
+     */
+    private String[] localIds;
     private final Map<Integer, Integer> prefixes;
     private String prefix;
     private final StringBuilder uniqueIdBuilder = new StringBuilder(30);
@@ -251,15 +259,63 @@ final class DefaultFaceletContext extends FaceletContextImplBase {
     @Override
     public String generateUniqueId(String base, Facelet owner, int slot) {
 
-        ensurePrefix();
+        String prefix = ensurePrefix();
 
-        int[] counters = owner == facelet ? localCounters() : counters((DefaultFacelet) owner);
+        boolean local = owner == facelet;
+        int[] counters = local ? localCounters() : counters((DefaultFacelet) owner);
 
         if (slot >= counters.length) {
             counters = grow((DefaultFacelet) owner, counters);
         }
 
-        return buildUniqueId(base, counters[slot]++);
+        int count = counters[slot]++;
+
+        // Only a tag's first id within a build is worth caching, and only for the Facelet this context applies, whose
+        // ids this context holds on a field. Anything else is built.
+        if (count > 0 || !local) {
+            return buildUniqueId(base, count);
+        }
+
+        return firstUniqueId(base, slot, prefix);
+    }
+
+    /**
+     * Returns the id {@code base} generates the first time it is applied under {@code prefix}, from the Facelet being
+     * applied when it caches one and by building it otherwise. Taking the prefix as an argument rather than reading the
+     * field keeps this callable only once the prefix exists, which is what selects the right cache entry.
+     */
+    private String firstUniqueId(String base, int slot, String prefix) {
+        String[] ids = localIds(prefix);
+
+        if (ids == NOT_CACHED) {
+            return buildUniqueId(base, 0);
+        }
+
+        if (slot >= ids.length) {
+            ids = facelet.growFirstIds(prefix, ids);
+            localIds = ids;
+        }
+
+        String id = ids[slot];
+
+        if (id == null) {
+            id = buildUniqueId(base, 0);
+            ids[slot] = id;
+        }
+
+        return id;
+    }
+
+    /**
+     * Returns the Facelet being applied's first ids for {@code prefix}, holding onto it so that the common case -- a
+     * tag generating its first id in its own Facelet -- costs an array index rather than a map lookup per component.
+     */
+    private String[] localIds(String prefix) {
+        if (localIds == null) {
+            String[] ids = facelet.firstIds(prefix);
+            localIds = ids == null ? NOT_CACHED : ids;
+        }
+        return localIds;
     }
 
     /**
@@ -290,7 +346,12 @@ final class DefaultFaceletContext extends FaceletContextImplBase {
         return grown;
     }
 
-    private void ensurePrefix() {
+    /**
+     * Settles this context's id prefix if it has not been settled yet.
+     *
+     * @return the prefix every id this context generates carries
+     */
+    private String ensurePrefix() {
         if (prefix == null) {
             StringBuilder builder = new StringBuilder(faceletHierarchy.size() * 30);
             for (int i = 0; i < faceletHierarchy.size(); i++) {
@@ -309,6 +370,8 @@ final class DefaultFaceletContext extends FaceletContextImplBase {
                 prefix = prefixInt + "_" + i;
             }
         }
+
+        return prefix;
     }
 
     private String buildUniqueId(String base, int count) {

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/impl/FirstIdCache.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/impl/FirstIdCache.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.mojarra.facelets.impl;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.IntSupplier;
+
+/**
+ * Holds, per id prefix, the first id each of a Facelet's tags generates within one view build, indexed by the tag's
+ * counter slot. Every build of a given view generates the same id for a given tag under a given prefix, so a build can
+ * hand back the id it handed back last time instead of building the same string again. Only a tag's <em>first</em> id
+ * is worth holding: a tag that generates more than one is being iterated over, where the number of ids follows the
+ * data rather than the view.
+ *
+ * <p>Entries are filled in by whichever build reaches a slot first and are never invalidated, because the id is a pure
+ * function of the prefix and the tag. Concurrent builds therefore need no locking, and every race is benign: two builds
+ * filling the same slot compute the same string, and a build that grows an array while another holds the pre-growth one
+ * loses cached entries but never returns a wrong id, since the loser simply rebuilds the string it could not find.
+ */
+final class FirstIdCache {
+
+    /**
+     * How many prefixes to hold arrays for. A prefix identifies one occurrence of a Facelet in one view's include
+     * hierarchy, so the count is bounded by view structure -- except where a view includes the Facelet from inside an
+     * iteration, which is bounded by data instead. Stop caching there rather than grow without limit.
+     *
+     * <p>What this bounds is the number of arrays, so the strings a Facelet can retain for its lifetime is this times
+     * its tag count: cheap for the ordinary Facelet included once or twice, and still bounded by the view for one
+     * written with thousands of tags and included from as many places.
+     */
+    private static final int MAX_PREFIXES = 64;
+
+    private final Map<String, String[]> idsByPrefix = new ConcurrentHashMap<>();
+
+    /** How many counter slots the owning Facelet has handed out, which grows as its tags are first applied. */
+    private final IntSupplier slotCount;
+
+    FirstIdCache(IntSupplier slotCount) {
+        this.slotCount = slotCount;
+    }
+
+    /**
+     * Returns the first ids generated under {@code prefix}, indexed by counter slot, or {@code null} when this cache
+     * already holds as many prefixes as it will. The array is sized to the slot count at the time it is created, so a
+     * caller reaching a slot beyond its end grows it through {@link #grow(String, String[])}.
+     *
+     * @param prefix the id prefix the calling build is generating under
+     * @return the per-slot first ids, or {@code null} when at the prefix limit
+     */
+    String[] ids(String prefix) {
+        String[] ids = idsByPrefix.get(prefix);
+
+        if (ids == null) {
+            if (idsByPrefix.size() >= MAX_PREFIXES) {
+                return null;
+            }
+            ids = idsByPrefix.computeIfAbsent(prefix, key -> new String[slotCount.getAsInt()]);
+        }
+
+        return ids;
+    }
+
+    /**
+     * Returns {@code prefix}'s ids resized to hold every slot handed out so far, for when tags reserved more slots
+     * after the array was sized -- which a Facelet applied for the first time does as its tags are reached.
+     *
+     * @param prefix the id prefix the calling build is generating under
+     * @param ids the array to grow
+     * @return the grown array
+     */
+    String[] grow(String prefix, String[] ids) {
+        String[] grown = Arrays.copyOf(ids, slotCount.getAsInt());
+        idsByPrefix.put(prefix, grown);
+        return grown;
+    }
+}

--- a/impl/src/test/java/org/glassfish/mojarra/facelets/impl/FirstIdCacheTest.java
+++ b/impl/src/test/java/org/glassfish/mojarra/facelets/impl/FirstIdCacheTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.mojarra.facelets.impl;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * A view build hands back ids from this cache instead of building the strings again, so the cache has to keep an entry
+ * for as long as the Facelet lives, keep the prefixes apart -- the same tag generates a different id under each -- and
+ * stop growing at some point, since a Facelet included from inside an iteration produces a prefix per iteration.
+ */
+class FirstIdCacheTest {
+
+    @Test
+    void idsStayPutForTheSamePrefix() {
+        FirstIdCache cache = new FirstIdCache(() -> 3);
+
+        String[] ids = cache.ids("p");
+        ids[1] = "p_form";
+
+        assertSame(ids, cache.ids("p"), "a later build reaches the ids an earlier one cached");
+        assertEquals(3, ids.length, "sized to the slots handed out");
+    }
+
+    @Test
+    void everyPrefixCachesSeparately() {
+        FirstIdCache cache = new FirstIdCache(() -> 2);
+
+        cache.ids("p")[0] = "p_form";
+        cache.ids("q")[0] = "q_form";
+
+        assertEquals("p_form", cache.ids("p")[0]);
+        assertEquals("q_form", cache.ids("q")[0]);
+    }
+
+    @Test
+    void growingKeepsWhatWasCached() {
+        int[] slots = { 2 };
+        FirstIdCache cache = new FirstIdCache(() -> slots[0]);
+
+        String[] ids = cache.ids("p");
+        ids[0] = "p_form";
+
+        slots[0] = 4;
+        String[] grown = cache.grow("p", ids);
+
+        assertArrayEquals(new String[] { "p_form", null, null, null }, grown);
+        assertSame(grown, cache.ids("p"), "and the grown array is what the next build gets");
+    }
+
+    @Test
+    void cachingStopsAtThePrefixLimit() {
+        FirstIdCache cache = new FirstIdCache(() -> 1);
+
+        for (int i = 0; i < 64; i++) {
+            assertNotNull(cache.ids("p" + i), "prefix " + i + " is within the limit");
+        }
+
+        assertNull(cache.ids("p64"), "a further prefix is not cached at all");
+        assertNotNull(cache.ids("p0"), "while the prefixes already held keep working");
+    }
+}


### PR DESCRIPTION
Every tag a view build applies gets a Facelets id, `prefix + "_" + tagId`, with both parts fixed for the life of the view — so every build of that view computes the same string, and Mojarra rebuilt it every time, once per component tag. Holding it on the (application-scoped) `DefaultFacelet`, indexed by the counter slot each tag already reserves since #5889 and keyed by prefix, hands it back instead.

Note this is the *Facelets* id, which is not the component id. It is what `findChildByTagId` matches a tag to its component by on a refresh (the `MARK_CREATED` marker), and `ComponentTagHandlerDelegateImpl.apply` generates one for every component tag regardless of whether the tag carries an `id` attribute. Where the tag has no `id`, the Facelets id is not the component id either: `IdMapper` aliases it to a short sequential one (`t1`, `t2`, …), and that is what seeds the component id, giving the familiar `j_idt5`. The Facelets id itself reaches the markup only under `org.glassfish.mojarra.useFaceletsID=true`, which is off by default. Where the author wrote `id="..."`, it plays no part in the component id at all. So this helps either way — `form-inputs` below carries 58 explicit ids and still gains.

Apache MyFaces has done the equivalent for years: `SectionUniqueIdCounter` serves ids out of a pre-generated `String[]` sized by `org.apache.myfaces.COMPONENT_UNIQUE_IDS_CACHE_SIZE` (default 300), falling back to generation past the end.

### What is and is not cached

Only a tag's **first** id within a build. A tag that generates more than one is being iterated over, where the number of ids follows the data rather than the view, so caching those would grow without limit. A cap of 64 prefixes bounds the other axis, since a Facelet included from inside an iteration produces one prefix per iteration; past the cap nothing is cached and ids are built as before.

Entries need no locking. An id being a pure function of the prefix and the tag makes every race benign: two builds racing to fill the same slot compute the same string, and a build that grows an array while another holds the pre-growth one loses cached entries but never returns a wrong id, because the loser simply rebuilds the string it could not find.

### Measured

Isolated Facelets build (`BuildViewBenchServlet`, `-Dperf.split=true` so the build is timed apart from `FacesContext` creation and `createView`), Tomcat 11, JDK 21, quiet machine.

| view (buildView step) | before | after | MyFaces |
| --- | --- | --- | --- |
| 1600 components, flat | 1061.0 µs | **987.1 µs (−7.0%)** | 871.1 µs |
| 400 components, flat | 233.6 µs | 226.6 µs | 188.4 µs |
| `form-inputs` | — | **163.7 µs** | 170.0 µs |

The MyFaces arm — untouched code — drifted +4.8% on the 400-component view between those two runs, so drift-corrected both flat views land near −7%. `form-inputs` now builds faster than MyFaces. The gap on the 1600-component view narrows from +21% to +13%; what remains is the second String allocation, in `UIViewRoot.createUniqueId`, which both implementations pay.

For context on the ceiling: a probe that made id generation entirely free measured −14% / −17%, i.e. parity with MyFaces at 1600 components. This change takes the reachable part of that without altering a single generated id.

### Verified

- Full Faces TCK, green.
- Full Mojarra impl unit suite, including four new `FirstIdCacheTest` tests covering entry persistence, per-prefix isolation, growth preserving cached entries, and the prefix limit.
- A self-check build that recomputed the id on every cache hit and compared it against the cached one was driven over all 32 `test/perf` scenarios, full lifecycles including postbacks: **zero mismatches**. Generated ids are unchanged.

Ref eclipse-ee4j/mojarra#5856

🤖 Generated with Claude Opus 5
