### PR TITLE
Backport the #5856 view build time work to 4.0

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/FaceletContextImplBase.java
+++ b/impl/src/main/java/com/sun/faces/facelets/FaceletContextImplBase.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import jakarta.el.ELException;
 import jakarta.faces.FacesException;
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.view.facelets.Facelet;
 import jakarta.faces.view.facelets.FaceletContext;
 import jakarta.faces.view.facelets.FaceletException;
 
@@ -29,6 +30,43 @@ import jakarta.faces.view.facelets.FaceletException;
  * @author edburns
  */
 public abstract class FaceletContextImplBase extends FaceletContext {
+
+    /**
+     * Returns the Facelet a tag handler applying under this context reserves its unique-id counter slot from, or
+     * {@code null} when this context generates unique ids by tag id alone. A handler pairs the returned Facelet with
+     * the slot it reserves, so that it can tell an unchanged pairing (the common case, where its counter is a plain
+     * array index) from one it has to resolve again.
+     *
+     * @return the Facelet being applied, or {@code null} when slot-based id generation is unsupported
+     */
+    public Facelet getUniqueIdSlotOwner() {
+        return null;
+    }
+
+    /**
+     * Returns the unique-id counter slot the Facelet returned by {@link #getUniqueIdSlotOwner()} holds for the given
+     * tag, for a tag handler to hold onto for as long as it lives. Asking twice for the same tag yields the same slot.
+     *
+     * @param tagId the tag id to get a slot for
+     * @return the tag's slot, or -1 when slot-based id generation is unsupported
+     */
+    public int getUniqueIdSlot(String tagId) {
+        return -1;
+    }
+
+    /**
+     * Slot-based variant of {@link #generateUniqueId(String)}, generating the same id from a counter held at
+     * {@code slot} in {@code owner}'s counter array. Implementations that do not support slot-based generation
+     * ignore both and count by tag id.
+     *
+     * @param base the tag id
+     * @param owner the Facelet the slot was reserved from
+     * @param slot the reserved slot
+     * @return the generated unique id
+     */
+    public String generateUniqueId(String base, Facelet owner, int slot) {
+        return generateUniqueId(base);
+    }
 
     /**
      * Push the passed TemplateClient onto the stack for Definition Resolution

--- a/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFacelet.java
+++ b/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFacelet.java
@@ -27,6 +27,8 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -71,6 +73,9 @@ final class DefaultFacelet extends Facelet implements XMLFrontMatterSaver {
     private final long refreshPeriodInMillis;
 
     private final FaceletHandler root;
+
+    /** Dense per-tag counter slots, keyed by tag id. See {@link #getIdSlot(String)}. */
+    private final Map<String, Integer> idSlots = new ConcurrentHashMap<>();
 
     private final URL src;
 
@@ -209,6 +214,28 @@ final class DefaultFacelet extends Facelet implements XMLFrontMatterSaver {
      */
     public String getAlias() {
         return alias;
+    }
+
+    /**
+     * Returns this Facelet's unique-id counter slot for the given tag, assigning the next free one if the tag has
+     * none yet, for a tag handler to hold onto for as long as this (application-scoped) Facelet lives. Slots are
+     * dense per Facelet, so a build can keep its per-tag id counters in an {@code int[]} of {@link #getIdSlotCount()}
+     * entries instead of a map keyed by tag id. Keying by tag id rather than handing out a fresh slot per call keeps
+     * a tag on one slot even if it asks twice, which two handler delegates racing to resolve the same tag would
+     * otherwise turn into two counters, and so into a duplicate id.
+     *
+     * @param tagId the tag id to assign a slot to
+     * @return the tag's slot
+     */
+    int getIdSlot(String tagId) {
+        return idSlots.computeIfAbsent(tagId, id -> idSlots.size());
+    }
+
+    /**
+     * @return how many slots {@link #getIdSlot(String)} has assigned, i.e. the counter array size a build needs.
+     */
+    int getIdSlotCount() {
+        return idSlots.size();
     }
 
     /**

--- a/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFacelet.java
+++ b/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFacelet.java
@@ -77,6 +77,9 @@ final class DefaultFacelet extends Facelet implements XMLFrontMatterSaver {
     /** Dense per-tag counter slots, keyed by tag id. See {@link #getIdSlot(String)}. */
     private final Map<String, Integer> idSlots = new ConcurrentHashMap<>();
 
+    /** The first id each of this Facelet's tags generates, per id prefix. See {@link #firstIds(String)}. */
+    private final FirstIdCache firstIds = new FirstIdCache(this::getIdSlotCount);
+
     private final URL src;
 
     private IdMapper mapper;
@@ -236,6 +239,30 @@ final class DefaultFacelet extends Facelet implements XMLFrontMatterSaver {
      */
     int getIdSlotCount() {
         return idSlots.size();
+    }
+
+    /**
+     * Returns the first id each of this Facelet's tags generates under {@code prefix}, indexed by counter slot, for a
+     * build to reuse instead of building the same strings again, or {@code null} when nothing is cached for this
+     * prefix.
+     *
+     * @param prefix the id prefix the calling build is generating under
+     * @return the per-slot first ids, or {@code null} when this Facelet caches no more prefixes
+     */
+    String[] firstIds(String prefix) {
+        return firstIds.ids(prefix);
+    }
+
+    /**
+     * Returns {@code prefix}'s first ids resized to hold every slot handed out so far, for a build that reached a slot
+     * past the end of what {@link #firstIds(String)} returned.
+     *
+     * @param prefix the id prefix the calling build is generating under
+     * @param ids the array to grow
+     * @return the grown array
+     */
+    String[] growFirstIds(String prefix, String[] ids) {
+        return firstIds.grow(prefix, ids);
     }
 
     /**

--- a/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFaceletContext.java
+++ b/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFaceletContext.java
@@ -56,6 +56,9 @@ import jakarta.faces.view.facelets.FaceletContext;
  */
 final class DefaultFaceletContext extends FaceletContextImplBase {
 
+    /** Stands in for {@link #localIds} once resolved, for a Facelet that caches no first ids for this context. */
+    private static final String[] NOT_CACHED = new String[0];
+
     private final FacesContext faces;
 
     private final ELContext ctx;
@@ -76,6 +79,11 @@ final class DefaultFaceletContext extends FaceletContextImplBase {
     private final Map<DefaultFacelet, int[]> idCounters;
     /** {@link #facelet}'s entry in {@link #idCounters}, resolved on first use. See {@link #localCounters()}. */
     private int[] localCounters;
+    /**
+     * {@link #facelet}'s first ids for the prefix this context generates under, resolved on first use, or
+     * {@link #NOT_CACHED} once resolved to a Facelet holding none for that prefix. See {@link #localIds(String)}.
+     */
+    private String[] localIds;
     private final Map<Integer, Integer> prefixes;
     private String prefix;
     private final StringBuilder uniqueIdBuilder = new StringBuilder(30);
@@ -251,15 +259,63 @@ final class DefaultFaceletContext extends FaceletContextImplBase {
     @Override
     public String generateUniqueId(String base, Facelet owner, int slot) {
 
-        ensurePrefix();
+        String prefix = ensurePrefix();
 
-        int[] counters = owner == facelet ? localCounters() : counters((DefaultFacelet) owner);
+        boolean local = owner == facelet;
+        int[] counters = local ? localCounters() : counters((DefaultFacelet) owner);
 
         if (slot >= counters.length) {
             counters = grow((DefaultFacelet) owner, counters);
         }
 
-        return buildUniqueId(base, counters[slot]++);
+        int count = counters[slot]++;
+
+        // Only a tag's first id within a build is worth caching, and only for the Facelet this context applies, whose
+        // ids this context holds on a field. Anything else is built.
+        if (count > 0 || !local) {
+            return buildUniqueId(base, count);
+        }
+
+        return firstUniqueId(base, slot, prefix);
+    }
+
+    /**
+     * Returns the id {@code base} generates the first time it is applied under {@code prefix}, from the Facelet being
+     * applied when it caches one and by building it otherwise. Taking the prefix as an argument rather than reading the
+     * field keeps this callable only once the prefix exists, which is what selects the right cache entry.
+     */
+    private String firstUniqueId(String base, int slot, String prefix) {
+        String[] ids = localIds(prefix);
+
+        if (ids == NOT_CACHED) {
+            return buildUniqueId(base, 0);
+        }
+
+        if (slot >= ids.length) {
+            ids = facelet.growFirstIds(prefix, ids);
+            localIds = ids;
+        }
+
+        String id = ids[slot];
+
+        if (id == null) {
+            id = buildUniqueId(base, 0);
+            ids[slot] = id;
+        }
+
+        return id;
+    }
+
+    /**
+     * Returns the Facelet being applied's first ids for {@code prefix}, holding onto it so that the common case -- a
+     * tag generating its first id in its own Facelet -- costs an array index rather than a map lookup per component.
+     */
+    private String[] localIds(String prefix) {
+        if (localIds == null) {
+            String[] ids = facelet.firstIds(prefix);
+            localIds = ids == null ? NOT_CACHED : ids;
+        }
+        return localIds;
     }
 
     /**
@@ -290,7 +346,12 @@ final class DefaultFaceletContext extends FaceletContextImplBase {
         return grown;
     }
 
-    private void ensurePrefix() {
+    /**
+     * Settles this context's id prefix if it has not been settled yet.
+     *
+     * @return the prefix every id this context generates carries
+     */
+    private String ensurePrefix() {
         if (prefix == null) {
             StringBuilder builder = new StringBuilder(faceletHierarchy.size() * 30);
             for (int i = 0; i < faceletHierarchy.size(); i++) {
@@ -309,6 +370,8 @@ final class DefaultFaceletContext extends FaceletContextImplBase {
                 prefix = prefixInt + "_" + i;
             }
         }
+
+        return prefix;
     }
 
     private String buildUniqueId(String base, int count) {

--- a/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFaceletContext.java
+++ b/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFaceletContext.java
@@ -19,8 +19,10 @@ package com.sun.faces.facelets.impl;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +68,14 @@ final class DefaultFaceletContext extends FaceletContextImplBase {
     private FunctionMapper fnMapper;
 
     private final Map<String, Integer> ids;
+    /**
+     * Per-tag unique-id counters for this build, one {@code int[]} per Facelet, indexed by the slot a tag handler
+     * reserved through {@link DefaultFacelet#getIdSlot(String)}. Shared across the whole context chain (like
+     * {@link #ids}) so a Facelet included twice in one build keeps counting where the first inclusion left off.
+     */
+    private final Map<DefaultFacelet, int[]> idCounters;
+    /** {@link #facelet}'s entry in {@link #idCounters}, resolved on first use. See {@link #localCounters()}. */
+    private int[] localCounters;
     private final Map<Integer, Integer> prefixes;
     private String prefix;
     private final StringBuilder uniqueIdBuilder = new StringBuilder(30);
@@ -76,6 +86,7 @@ final class DefaultFaceletContext extends FaceletContextImplBase {
         faces = ctx.faces;
         fnMapper = ctx.fnMapper;
         ids = ctx.ids;
+        idCounters = ctx.idCounters;
         prefixes = ctx.prefixes;
         varMapper = ctx.varMapper;
         faceletHierarchy = new ArrayList<>(ctx.faceletHierarchy.size() + 1);
@@ -88,6 +99,7 @@ final class DefaultFaceletContext extends FaceletContextImplBase {
     public DefaultFaceletContext(FacesContext faces, DefaultFacelet facelet) {
         ctx = faces.getELContext();
         ids = new HashMap<>();
+        idCounters = new IdentityHashMap<>();
         prefixes = new HashMap<>();
         clients = new ArrayList<>(5);
         this.faces = faces;
@@ -202,6 +214,83 @@ final class DefaultFaceletContext extends FaceletContextImplBase {
     @Override
     public String generateUniqueId(String base) {
 
+        ensurePrefix();
+
+        Integer cnt = ids.get(base);
+        if (cnt == null) {
+            ids.put(base, 0);
+            return buildUniqueId(base, 0);
+        } else {
+            int i = cnt.intValue() + 1;
+            ids.put(base, i);
+            return buildUniqueId(base, i);
+        }
+    }
+
+    @Override
+    public Facelet getUniqueIdSlotOwner() {
+        return facelet;
+    }
+
+    @Override
+    public int getUniqueIdSlot(String tagId) {
+        return facelet.getIdSlot(tagId);
+    }
+
+    /**
+     * Slot-based counterpart of {@link #generateUniqueId(String)}: same id, but the counter for {@code base} is read
+     * from {@code owner}'s counter array at {@code slot} rather than looked up by tag id in a map. A tag handler
+     * reserves its slot once and reuses it for every build, which is what keeps the per-component build cost of a
+     * view free of map inserts.
+     *
+     * @param base the tag id, as passed to {@link #generateUniqueId(String)}
+     * @param owner the Facelet the slot was reserved from
+     * @param slot the reserved slot
+     * @return the generated unique id
+     */
+    @Override
+    public String generateUniqueId(String base, Facelet owner, int slot) {
+
+        ensurePrefix();
+
+        int[] counters = owner == facelet ? localCounters() : counters((DefaultFacelet) owner);
+
+        if (slot >= counters.length) {
+            counters = grow((DefaultFacelet) owner, counters);
+        }
+
+        return buildUniqueId(base, counters[slot]++);
+    }
+
+    /**
+     * Returns the counter array of the Facelet this context is applying, holding onto it so that the common case --
+     * a tag counting ids in its own Facelet -- costs an array index rather than a map lookup per component.
+     */
+    private int[] localCounters() {
+        if (localCounters == null) {
+            localCounters = counters(facelet);
+        }
+        return localCounters;
+    }
+
+    private int[] counters(DefaultFacelet owner) {
+        return idCounters.computeIfAbsent(owner, f -> new int[f.getIdSlotCount()]);
+    }
+
+    /**
+     * Resizes {@code owner}'s counter array to its current slot count, for when it handed out more slots since the
+     * array was sized -- a Facelet applied for the first time reserves its slots as its tags are first applied.
+     */
+    private int[] grow(DefaultFacelet owner, int[] counters) {
+        int[] grown = Arrays.copyOf(counters, owner.getIdSlotCount());
+        idCounters.put(owner, grown);
+        if (owner == facelet) {
+            localCounters = grown;
+        }
+        return grown;
+    }
+
+    private void ensurePrefix() {
         if (prefix == null) {
             StringBuilder builder = new StringBuilder(faceletHierarchy.size() * 30);
             for (int i = 0; i < faceletHierarchy.size(); i++) {
@@ -220,26 +309,18 @@ final class DefaultFaceletContext extends FaceletContextImplBase {
                 prefix = prefixInt + "_" + i;
             }
         }
+    }
 
-        Integer cnt = ids.get(base);
-        if (cnt == null) {
-            ids.put(base, 0);
-            uniqueIdBuilder.delete(0, uniqueIdBuilder.length());
-            uniqueIdBuilder.append(prefix);
+    private String buildUniqueId(String base, int count) {
+        uniqueIdBuilder.delete(0, uniqueIdBuilder.length());
+        uniqueIdBuilder.append(prefix);
+        uniqueIdBuilder.append("_");
+        uniqueIdBuilder.append(base);
+        if (count > 0) {
             uniqueIdBuilder.append("_");
-            uniqueIdBuilder.append(base);
-            return uniqueIdBuilder.toString();
-        } else {
-            int i = cnt.intValue() + 1;
-            ids.put(base, i);
-            uniqueIdBuilder.delete(0, uniqueIdBuilder.length());
-            uniqueIdBuilder.append(prefix);
-            uniqueIdBuilder.append("_");
-            uniqueIdBuilder.append(base);
-            uniqueIdBuilder.append("_");
-            uniqueIdBuilder.append(i);
-            return uniqueIdBuilder.toString();
+            uniqueIdBuilder.append(count);
         }
+        return uniqueIdBuilder.toString();
     }
 
     /*

--- a/impl/src/main/java/com/sun/faces/facelets/impl/FirstIdCache.java
+++ b/impl/src/main/java/com/sun/faces/facelets/impl/FirstIdCache.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.facelets.impl;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.IntSupplier;
+
+/**
+ * Holds, per id prefix, the first id each of a Facelet's tags generates within one view build, indexed by the tag's
+ * counter slot. Every build of a given view generates the same id for a given tag under a given prefix, so a build can
+ * hand back the id it handed back last time instead of building the same string again. Only a tag's <em>first</em> id
+ * is worth holding: a tag that generates more than one is being iterated over, where the number of ids follows the
+ * data rather than the view.
+ *
+ * <p>Entries are filled in by whichever build reaches a slot first and are never invalidated, because the id is a pure
+ * function of the prefix and the tag. Concurrent builds therefore need no locking, and every race is benign: two builds
+ * filling the same slot compute the same string, and a build that grows an array while another holds the pre-growth one
+ * loses cached entries but never returns a wrong id, since the loser simply rebuilds the string it could not find.
+ */
+final class FirstIdCache {
+
+    /**
+     * How many prefixes to hold arrays for. A prefix identifies one occurrence of a Facelet in one view's include
+     * hierarchy, so the count is bounded by view structure -- except where a view includes the Facelet from inside an
+     * iteration, which is bounded by data instead. Stop caching there rather than grow without limit.
+     *
+     * <p>What this bounds is the number of arrays, so the strings a Facelet can retain for its lifetime is this times
+     * its tag count: cheap for the ordinary Facelet included once or twice, and still bounded by the view for one
+     * written with thousands of tags and included from as many places.
+     */
+    private static final int MAX_PREFIXES = 64;
+
+    private final Map<String, String[]> idsByPrefix = new ConcurrentHashMap<>();
+
+    /** How many counter slots the owning Facelet has handed out, which grows as its tags are first applied. */
+    private final IntSupplier slotCount;
+
+    FirstIdCache(IntSupplier slotCount) {
+        this.slotCount = slotCount;
+    }
+
+    /**
+     * Returns the first ids generated under {@code prefix}, indexed by counter slot, or {@code null} when this cache
+     * already holds as many prefixes as it will. The array is sized to the slot count at the time it is created, so a
+     * caller reaching a slot beyond its end grows it through {@link #grow(String, String[])}.
+     *
+     * @param prefix the id prefix the calling build is generating under
+     * @return the per-slot first ids, or {@code null} when at the prefix limit
+     */
+    String[] ids(String prefix) {
+        String[] ids = idsByPrefix.get(prefix);
+
+        if (ids == null) {
+            if (idsByPrefix.size() >= MAX_PREFIXES) {
+                return null;
+            }
+            ids = idsByPrefix.computeIfAbsent(prefix, key -> new String[slotCount.getAsInt()]);
+        }
+
+        return ids;
+    }
+
+    /**
+     * Returns {@code prefix}'s ids resized to hold every slot handed out so far, for when tags reserved more slots
+     * after the array was sized -- which a Facelet applied for the first time does as its tags are reached.
+     *
+     * @param prefix the id prefix the calling build is generating under
+     * @param ids the array to grow
+     * @return the grown array
+     */
+    String[] grow(String prefix, String[] ids) {
+        String[] grown = Arrays.copyOf(ids, slotCount.getAsInt());
+        idsByPrefix.put(prefix, grown);
+        return grown;
+    }
+}

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
@@ -34,6 +34,7 @@ import com.sun.faces.component.behavior.AjaxBehaviors;
 import com.sun.faces.component.validator.ComponentValidators;
 import com.sun.faces.context.StateContext;
 import com.sun.faces.facelets.impl.IdMapper;
+import com.sun.faces.facelets.FaceletContextImplBase;
 import com.sun.faces.facelets.tag.MetaRulesetImpl;
 import com.sun.faces.facelets.tag.faces.core.FacetHandler;
 import com.sun.faces.util.FacesLogger;
@@ -55,6 +56,7 @@ import jakarta.faces.component.behavior.ClientBehaviorHolder;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.view.facelets.ComponentConfig;
 import jakarta.faces.view.facelets.ComponentHandler;
+import jakarta.faces.view.facelets.Facelet;
 import jakarta.faces.view.facelets.FaceletContext;
 import jakarta.faces.view.facelets.MetaRuleset;
 import jakarta.faces.view.facelets.TagAttribute;
@@ -76,6 +78,26 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
     private final String rendererType;
 
     private CreateComponentDelegate createCompositeComponentDelegate;
+
+    /**
+     * This tag's unique-id counter slot and the Facelet holding it, so {@link #apply} can count this tag's generated
+     * ids by array index instead of by a per-build map lookup on the tag id. Held as one object so that both are read
+     * together: a build that saw the owner must see that owner's slot. Bound to the Facelet being applied rather than
+     * the one this tag was compiled in, because a {@code ui:define} body applies under the template it is inserted
+     * into; a tag that alternates between templates simply rebinds.
+     */
+    private static final class IdSlot {
+
+        private final Facelet owner;
+        private final int slot;
+
+        private IdSlot(Facelet owner, int slot) {
+            this.owner = owner;
+            this.slot = slot;
+        }
+    }
+
+    private volatile IdSlot idSlot;
 
     public ComponentTagHandlerDelegateImpl(ComponentHandler owner) {
         this.owner = owner;
@@ -123,7 +145,7 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
         }
 
         // our id
-        String id = ctx.generateUniqueId(owner.getTagId());
+        String id = generateUniqueId(ctx);
 
         // grab our component
         UIComponent c = findChild(ctx, parent, id);
@@ -439,6 +461,35 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
             c.setRendererType(rendererType);
         }
 
+    }
+
+
+    /**
+     * Generates this tag's unique id through {@link com.sun.faces.facelets.impl.DefaultFaceletContext}'s slot-based
+     * counter where the context supports it (the only implementation Facelets builds views with), and through the
+     * public {@link FaceletContext} API otherwise, which a wrapping context or a foreign implementation may supply.
+     */
+    private String generateUniqueId(FaceletContext ctx) {
+
+        if (!(ctx instanceof FaceletContextImplBase)) {
+            return ctx.generateUniqueId(owner.getTagId());
+        }
+
+        FaceletContextImplBase context = (FaceletContextImplBase) ctx;
+        Facelet slotOwner = context.getUniqueIdSlotOwner();
+
+        if (slotOwner == null) {
+            return ctx.generateUniqueId(owner.getTagId());
+        }
+
+        IdSlot slot = idSlot;
+
+        if (slot == null || slot.owner != slotOwner) {
+            slot = new IdSlot(slotOwner, context.getUniqueIdSlot(owner.getTagId()));
+            idSlot = slot;
+        }
+
+        return context.generateUniqueId(owner.getTagId(), slot.owner, slot.slot);
     }
 
     protected void doNewComponentActions(FaceletContext ctx, String id, UIComponent c) {

--- a/impl/src/main/java/com/sun/faces/util/Util.java
+++ b/impl/src/main/java/com/sun/faces/util/Util.java
@@ -681,6 +681,18 @@ public class Util {
     }
 
     /**
+     * Returns the first argument if is non-null, otherwise the second argument.
+     *
+     * @param <T> The generic object type.
+     * @param o1 The value to be tested for to be tested for non-<code>null</code>.
+     * @param o2 The alternative value to be returned if value is null
+     * @return value if is not null, otherwise return alternative
+     */
+    public static <T> T coalesce(T o1, T o2) {
+        return o1 != null ? o1 : o2;
+    }
+
+    /**
      * Returns the first non-<code>null</code> object of the argument list, or <code>null</code> if there is no such
      * element.
      *

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -2383,17 +2383,14 @@ public abstract class UIComponentBase extends UIComponent {
                 throw new NullPointerException();
             }
 
-            // markerPut keeps the field cache in sync for framework markers. Persistent markers (MARK_CREATED etc.)
-            // are still mirrored into the attributes map below so full-state restore can read them back. MARK_DELETED
-            // is a transient build-time flag (markForDeletion/finalizeForDeletion set and clear it on every component
-            // each refresh) that is never present when state is saved, so it stays field-only to avoid per-component
-            // StateHelper traffic.
+            // markerPut keeps the field cache in sync for framework markers; a marker not exempted below is also
+            // mirrored into the attributes map so full-state restore can read it back. The exempted three are
+            // field-only, which is what keeps them out of the StateHelper on every Facelets build: MARK_DELETED and
+            // the facet name are build-time flags that are always cleared again before state is saved, and
+            // MARK_CREATED is re-attached to the attributes map at full-state save (saveState), partial state
+            // rebuilding it via buildView. Exempting a further marker requires it to meet that same condition.
             boolean marker = component.markerPut(keyValue, value);
-            if (marker && (MARK_DELETED.equals(keyValue) || MARK_CREATED.equals(keyValue))) {
-                // MARK_DELETED is a transient build-time flag; MARK_CREATED is field-backed (markCreated) and set on
-                // every component during buildView. Neither needs the per-component StateHelper mirror on the hot
-                // c:forEach re-apply path: MARK_DELETED is never saved, and MARK_CREATED is re-attached to the
-                // attributes map once at full-state save (saveState) -- partial state rebuilds it via buildView.
+            if (marker && (MARK_DELETED.equals(keyValue) || MARK_CREATED.equals(keyValue) || KEY.equals(keyValue))) {
                 return null;
             }
 
@@ -2474,7 +2471,7 @@ public abstract class UIComponentBase extends UIComponent {
                 throw new NullPointerException();
             }
             boolean marker = component.markerRemove(key);
-            if (marker && MARK_DELETED.equals(key)) {
+            if (marker && (MARK_DELETED.equals(key) || KEY.equals(key))) {
                 return null;
             }
             if (ATTRIBUTES_THAT_ARE_SET_KEY.equals(key)) {

--- a/impl/src/main/java/jakarta/faces/context/FacesContext.java
+++ b/impl/src/main/java/jakarta/faces/context/FacesContext.java
@@ -16,11 +16,15 @@
 
 package jakarta.faces.context;
 
+import static java.lang.StackWalker.Option.RETAIN_CLASS_REFERENCE;
+
+import java.lang.StackWalker.StackFrame;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import jakarta.el.ELContext;
@@ -66,27 +70,33 @@ public abstract class FacesContext {
     private static ConcurrentHashMap initContextServletContext = new ConcurrentHashMap(2);
 
     /**
+     * Frames between this constructor and the caller that decides whether this instance came from a factory: the walk
+     * starts at this constructor, the concrete context's constructor follows, and its caller is next.
+     */
+    private static final int CALLER_FRAME = 2;
+
+    /**
+     * Walks the caller of this class' constructor. Retaining class references hands back the declaring class itself, so
+     * the caller is identified without resolving its name through a class loader, and the walk is bounded because only
+     * one frame past the concrete context's own constructor is ever inspected.
+     */
+    private static final StackWalker CALLER_WALKER = StackWalker.getInstance(Set.of(RETAIN_CLASS_REFERENCE), CALLER_FRAME + 1);
+
+    /**
      * Default constructor.
      * <p>
      * This looks at the callstack to see if we're created from a factory.
      * </p>
      */
     public FacesContext() {
-        Thread curThread = Thread.currentThread();
-        StackTraceElement[] callstack = curThread.getStackTrace();
-        if (null != callstack) {
-            String declaringClassName = callstack[3].getClassName();
-            try {
-                ClassLoader curLoader = curThread.getContextClassLoader();
-                Class<?> declaringClass = curLoader.loadClass(declaringClassName);
-                if (!FacesContextFactory.class.isAssignableFrom(declaringClass)) {
-                    isCreatedFromValidFactory = false;
-                }
-            } catch (ClassNotFoundException cnfe) {
+        Class<?> declaringClass = CALLER_WALKER.walk(frames -> frames.skip(CALLER_FRAME)
+                .map(StackFrame::getDeclaringClass)
+                .findFirst()
+                .orElse(null));
 
-            }
+        if (declaringClass != null && !FacesContextFactory.class.isAssignableFrom(declaringClass)) {
+            isCreatedFromValidFactory = false;
         }
-
     }
 
     // -------------------------------------------------------------- Properties

--- a/impl/src/test/java/com/sun/faces/facelets/impl/FirstIdCacheTest.java
+++ b/impl/src/test/java/com/sun/faces/facelets/impl/FirstIdCacheTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.facelets.impl;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * A view build hands back ids from this cache instead of building the strings again, so the cache has to keep an entry
+ * for as long as the Facelet lives, keep the prefixes apart -- the same tag generates a different id under each -- and
+ * stop growing at some point, since a Facelet included from inside an iteration produces a prefix per iteration.
+ */
+class FirstIdCacheTest {
+
+    @Test
+    void idsStayPutForTheSamePrefix() {
+        FirstIdCache cache = new FirstIdCache(() -> 3);
+
+        String[] ids = cache.ids("p");
+        ids[1] = "p_form";
+
+        assertSame(ids, cache.ids("p"), "a later build reaches the ids an earlier one cached");
+        assertEquals(3, ids.length, "sized to the slots handed out");
+    }
+
+    @Test
+    void everyPrefixCachesSeparately() {
+        FirstIdCache cache = new FirstIdCache(() -> 2);
+
+        cache.ids("p")[0] = "p_form";
+        cache.ids("q")[0] = "q_form";
+
+        assertEquals("p_form", cache.ids("p")[0]);
+        assertEquals("q_form", cache.ids("q")[0]);
+    }
+
+    @Test
+    void growingKeepsWhatWasCached() {
+        int[] slots = { 2 };
+        FirstIdCache cache = new FirstIdCache(() -> slots[0]);
+
+        String[] ids = cache.ids("p");
+        ids[0] = "p_form";
+
+        slots[0] = 4;
+        String[] grown = cache.grow("p", ids);
+
+        assertArrayEquals(new String[] { "p_form", null, null, null }, grown);
+        assertSame(grown, cache.ids("p"), "and the grown array is what the next build gets");
+    }
+
+    @Test
+    void cachingStopsAtThePrefixLimit() {
+        FirstIdCache cache = new FirstIdCache(() -> 1);
+
+        for (int i = 0; i < 64; i++) {
+            assertNotNull(cache.ids("p" + i), "prefix " + i + " is within the limit");
+        }
+
+        assertNull(cache.ids("p64"), "a further prefix is not cached at all");
+        assertNotNull(cache.ids("p0"), "while the prefixes already held keep working");
+    }
+}

--- a/impl/src/test/java/jakarta/faces/component/UIComponentBaseMarkerAttributesTest.java
+++ b/impl/src/test/java/jakarta/faces/component/UIComponentBaseMarkerAttributesTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.component;
+
+import static com.sun.faces.facelets.tag.faces.ComponentSupport.MARK_CREATED;
+import static com.sun.faces.facelets.tag.faces.ComponentSupport.MARK_DELETED;
+import static com.sun.faces.facelets.tag.faces.core.FacetHandler.KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Facelets marks every component it creates with the tag id it came from, scopes a facet by putting its name on the
+ * parent component's attributes for the duration of the facet body, and flags components for deletion the same way.
+ * Those markers are answered from a field rather than from the state map, so the attributes map has to keep reading
+ * like a map while the marker stays out of the component's state - except that the creation marker, which is live on
+ * every component, still has to survive a full-state save, since restoring full state runs no view build to
+ * re-establish it.
+ */
+class UIComponentBaseMarkerAttributesTest {
+
+    @Test
+    void fieldBackedMarkersReadBackThroughTheAttributesMap() {
+        Map<String, Object> attributes = new UIPanel().getAttributes();
+        attributes.put(KEY, "header");
+        attributes.put(MARK_CREATED, "j_id1");
+
+        assertEquals("header", attributes.get(KEY));
+        assertEquals("j_id1", attributes.get(MARK_CREATED));
+        assertTrue(attributes.containsKey(KEY));
+        assertTrue(attributes.containsKey(MARK_CREATED));
+
+        attributes.remove(KEY);
+        attributes.remove(MARK_CREATED);
+
+        assertNull(attributes.get(KEY));
+        assertNull(attributes.get(MARK_CREATED));
+        assertFalse(attributes.containsKey(KEY));
+        assertFalse(attributes.containsKey(MARK_CREATED));
+    }
+
+    @Test
+    void buildTimeMarkersStayOutOfTheStateBackedAttributes() {
+        Map<String, Object> attributes = new UIPanel().getAttributes();
+        attributes.put(KEY, "header");
+        attributes.put(MARK_CREATED, "j_id1");
+        attributes.put(MARK_DELETED, Boolean.TRUE);
+        attributes.put("data-role", "banner");
+
+        assertEquals(Set.of("data-role"), attributes.keySet(),
+                "only the plain attribute is state-backed, so only it can be saved");
+    }
+
+    @Test
+    void fullStateSaveCarriesTheCreationMarker() {
+        FacesContext context = mock(FacesContext.class);
+        UIPanel saved = new UIPanel();
+        saved.getAttributes().put(MARK_CREATED, "j_id1");
+
+        UIPanel restored = new UIPanel();
+        restored.restoreState(context, saved.saveState(context));
+
+        assertEquals("j_id1", restored.getAttributes().get(MARK_CREATED),
+                "full state carries no view build to re-establish the marker");
+    }
+}


### PR DESCRIPTION
Backports the whole of the #5856 view-build-time work to 4.0. Five commits, each mirroring one upstream change, kept separate so any one of them can be dropped or reverted on its own.

| commit | upstream | what |
| --- | --- | --- |
| `5599136c0f` | jakartaee/faces#2223 | identify the `FacesContext` creator with `StackWalker` instead of a full stack trace |
| `c27e7737e7` | jakartaee/faces#2222 | keep the Facelets facet-name marker out of component state |
| `1cc317e812` | #5889 | generate Facelets unique ids from per-tag counter slots |
| `b65a909b58` | #5892 | cache the first id each Facelets tag generates |
| `75270f7e02` | #5891 | `Util.coalesce` allocation-free for two arguments (cherry-picked from 4.1, original authorship preserved) |

Measured on master, where the benchmark harness lives: `FacesContext` creation 12.5 µs → 2.8 µs (per request, not per component); the Facelets build of a 200-facet dataTable −11.5%; flat markup −7…−9% from the counter slots and a further −7% from the first-id cache.

### Porting notes

**Java 11.** 4.0 sets `maven.compiler.source=11`, so two constructs from #5889 could not come across as written: the `IdSlot` holder is a `private static final class` rather than a `record`, and the `instanceof FaceletContextImplBase context` pattern match is an explicit cast. Everything else is unchanged — `StackWalker` and `Set.of` are Java 9, so faces#2223 ports as-is.

**The API is in this repo on 4.0**, so the two `jakartaee/faces` PRs land here as ordinary commits against `impl/src/main/java/jakarta/...` rather than as a submodule bump. 4.0 reaches the facet-name marker constant as `FacetHandler.KEY`, where 5.0 has `PackageUtils.FACET_NAME`; the change is otherwise identical.

**No `test/perf` module on 4.0**, so #5889's benchmark scenario views and its `BuildViewBenchIT` change are omitted. This branch carries impl changes only, which also means none of the numbers above can be reproduced on 4.0 directly.

### Verification

- Full Mojarra impl unit suite on 4.0, green, including seven backported tests: four in `FirstIdCacheTest` (entry persistence, per-prefix isolation, growth preserving entries, the prefix limit) and three in `UIComponentBaseMarkerAttributesTest` (markers read back through the attributes map, build-time markers stay out of state, full-state save carries `MARK_CREATED`).
- Each transplanted file was diffed against its master counterpart with the package renamed: `FirstIdCache` and `FaceletContextImplBase` come out identical, and the residual differences in `DefaultFacelet` and `DefaultFaceletContext` are pre-existing 4.0-versus-master drift rather than translation slips.
- The TCK has been run against the master form of every one of these changes. It has **not** yet been run against this backport — that is what CI is for here.

Ref eclipse-ee4j/mojarra#5856

🤖 Generated with Claude Opus 5
