### PR TITLE
Keep FacesContext free of synthetic declared methods

### DIFF
--- a/impl/src/main/java/jakarta/faces/context/FacesContext.java
+++ b/impl/src/main/java/jakarta/faces/context/FacesContext.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 import jakarta.el.ELContext;
 import jakarta.faces.FactoryFinder;
@@ -83,16 +85,27 @@ public abstract class FacesContext {
     private static final StackWalker CALLER_WALKER = StackWalker.getInstance(Set.of(RETAIN_CLASS_REFERENCE), CALLER_FRAME + 1);
 
     /**
+     * Picks the caller's class out of the walked frames. Deliberately an anonymous class: this class must not declare any
+     * method which a concrete context does not have, and a lambda compiles into a synthetic one.
+     */
+    private static final Function<Stream<StackFrame>, Class<?>> CALLER_EXTRACTOR = new Function<>() {
+        @Override
+        public Class<?> apply(Stream<StackFrame> frames) {
+            return frames.skip(CALLER_FRAME)
+                    .map(StackFrame::getDeclaringClass)
+                    .findFirst()
+                    .orElse(null);
+        }
+    };
+
+    /**
      * Default constructor.
      * <p>
      * This looks at the callstack to see if we're created from a factory.
      * </p>
      */
     public FacesContext() {
-        Class<?> declaringClass = CALLER_WALKER.walk(frames -> frames.skip(CALLER_FRAME)
-                .map(StackFrame::getDeclaringClass)
-                .findFirst()
-                .orElse(null));
+        Class<?> declaringClass = CALLER_WALKER.walk(CALLER_EXTRACTOR);
 
         if (declaringClass != null && !FacesContextFactory.class.isAssignableFrom(declaringClass)) {
             isCreatedFromValidFactory = false;


### PR DESCRIPTION
The 4.0.22 CI build failed in `old-tck-run` with 5399 passed, 1 failed:

```
FAILED........com/sun/ts/tests/jsf/api/jakarta_faces/context/facescontext/URLClient.java#facesCtxISEAfterReleaseTest
Expected: IllegalStateException
Received: NoSuchMethodException
```

`facesCtxISEAfterReleaseTest` reflects over `FacesContext.class.getDeclaredMethods()`, skips a fixed exclusion list, and hands each name+signature to `JSFTestUtil.checkForISE`, which resolves it on the concrete context via `getClass().getMethod(...)`. Since 5599136c0f the caller walk is a lambda, and javac compiles that into `private static Class lambda$new$0(Stream)` **declared on `FacesContext`** — a method `FacesContextImpl` does not have, hence the `NoSuchMethodException`.

The current TCK servlet filters those out with `!name.startsWith("lambda$")`; the old TCK does not, and it ships as a prebuilt distribution (checked in both `old-faces-tck-4.0.2` and `-5.0.0`), so it cannot be corrected on its side. `jakarta.faces.context.FacesContext` simply must not declare any method that a concrete context lacks.

## Fix

Hold the walk function in an anonymous `Function` rather than a lambda. Note a lambda *assigned to a field* would not have helped — that only renames the synthetic to `lambda$static$0` on the same class. Frame indexing is unaffected: `walk()` starts the stream at its own caller, so the function's own frames are never on it.

## Verification

Replayed the TCK's reflection locally against `impl/target/classes` (the old TCK zip in `~/.m2` carries its full sources, so this needs no container):

- before: `checked=33 failed=1`, `NoSuchMethodException: FacesContextImpl.lambda$new$0(Stream) [synthetic=true]` — 33 checks matches the 32 `Test PASSED` plus 1 `Test FAILED` in the release log
- after: `checked=32 failed=0`, and `javap -p` shows no `lambda$` member left on `FacesContext`

Full impl unit suite green: `Tests run: 1223, Failures: 0, Errors: 0, Skipped: 4`.

4.1 and master carry the same lambda and will be upmerged.

🤖 Generated with Claude Opus 5
