### PR TITLE
Fix #5898: read disableClientStateEncryption as a value

### DIFF
--- a/impl/src/main/java/com/sun/faces/renderkit/ClientSideStateHelper.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/ClientSideStateHelper.java
@@ -421,7 +421,7 @@ public class ClientSideStateHelper extends StateHelper {
      */
     protected void init() {
 
-        if (webConfig.canProcessJndiEntries() && !webConfig.isSet(BooleanWebContextInitParameter.DisableClientStateEncryption)) {
+        if (webConfig.canProcessJndiEntries() && !webConfig.isOptionEnabled(BooleanWebContextInitParameter.DisableClientStateEncryption)) {
             guard = new ByteArrayGuard();
         } else {
             if (LOGGER.isLoggable(Level.FINE)) {


### PR DESCRIPTION
Closes #5898.

`ClientSideStateHelper#init()` consulted `com.sun.faces.disableClientStateEncryption` with `isSet()`, which reports whether the parameter is present in the deployment descriptor rather than what it says. `WebConfiguration#initSetList()` fills that set straight from `ServletContext#getInitParameterNames()` and nothing ever inspects a value, so `<param-value>false</param-value>` marked the parameter as set exactly like `true` did, and client state encryption was silently switched off for an application which explicitly asked to keep it.

Reading it with `isOptionEnabled()` treats it like every other boolean parameter. Only the `false` case changes, from unencrypted to encrypted; absent and `true` are unaffected, since the parameter's declared default is already `false`.

This is the only site where `isSet()` was used as the value. The other call sites all use it to decide whether a value was specified at all and then read it with `isOptionEnabled()`: `ConfigureListener` for deriving `com.sun.faces.enableDistributable` from `<distributable/>` and for the project stage default of `com.sun.faces.enableThreading`, and `SAXCompiler` for deciding whether to touch the parser's `disallow-doctype-decl` feature. Those are left alone.

Found while reviewing #5897.

Full `impl` test suite passes, 1222 tests.

🤖 Generated with Claude Opus 5
