### PR TITLE
Normalize the contracts directory comparison

### DIFF
--- a/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
@@ -1400,7 +1400,7 @@ public class RenderKitUtils {
                 return "";
             }
             WebConfiguration webConfig = WebConfiguration.getInstance();
-            if (value.startsWith(webConfig.getOptionValue(WebConfiguration.WebContextInitParameter.WebAppContractsDirectory))) {
+            if (Util.ensureLeadingSlash(value).startsWith(Util.ensureLeadingSlash(webConfig.getOptionValue(WebConfiguration.WebContextInitParameter.WebAppContractsDirectory)))) {
                 if (context.isProjectStage(ProjectStage.Development)) {
                     String msg = "Illegal path, direct contract references are not allowed: " + value;
                     context.addMessage(component.getClientId(context), new FacesMessage(FacesMessage.SEVERITY_ERROR, msg, msg));


### PR DESCRIPTION
`RenderKitUtils` compared a component's path attribute against the **raw** value of `jakarta.faces.WEBAPP_CONTRACTS_DIRECTORY`:

```java
if (value.startsWith(webConfig.getOptionValue(WebAppContractsDirectory))) {
    // Development: "Illegal path, direct contract references are not allowed"
    return "RES_NOT_FOUND";
}
```

`value` is a path such as `/contracts/foo/style.css`, while `WebappResourceHelper` normalizes the same parameter with `ensureLeadingSlash` before using it. The specification states the value must not start with a `/`, so an application which configures it that way ends up comparing `/contracts/foo/style.css` against `contracts`, which never matches, and the check rejecting direct contract references silently stops working. It only works today because Mojarra's own default deviates from the specification and carries the leading slash.

Normalizing both sides makes the check independent of how the parameter is spelled. Mojarra 5.0 already does this through `ResourceManager#isContractsResource()`, which applies `ensureLeadingSlash` to the argument and compares against the normalized base path; this is the 4.x equivalent.

Noticed while documenting the context parameters in #5897, alongside #5898.

Full `impl` test suite passes, 1222 tests.

🤖 Generated with Claude Opus 5
