### PR TITLE
Fix #5904: tolerate an empty fragment or query string

### DIFF
--- a/impl/src/main/java/com/sun/faces/context/UrlBuilder.java
+++ b/impl/src/main/java/com/sun/faces/context/UrlBuilder.java
@@ -297,26 +297,20 @@ class UrlBuilder {
 
     private void cleanFragment() {
         if (fragment != null) {
-            // trim
             String f = fragment.trim();
-            // remove '#'
-            if ( f.charAt(0) == FRAGMENT_SEPARATOR_CHAR ) {
+            if (f.startsWith(FRAGMENT_SEPARATOR)) {
                 f = f.substring(1);
             }
-            // null if empty
             fragment = f.isEmpty() ? null : f;
         }
     }
 
     private void cleanQueryString() {
         if (queryString != null) {
-            // trim
             String q = queryString.trim();
-            // remove '?'
-            if ( q.charAt(0) == QUERY_STRING_SEPARATOR_CHAR ) {
+            if (q.startsWith(QUERY_STRING_SEPARATOR)) {
                 q = q.substring(1);
             }
-            // null if empty
             queryString = q.isEmpty() ? null : q;
         }
     }

--- a/impl/src/test/java/com/sun/faces/context/UrlBuilderTest.java
+++ b/impl/src/test/java/com/sun/faces/context/UrlBuilderTest.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.context;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * Tests for {@link UrlBuilder}.
+ *
+ * <p>Covers how a seed URL is split into path, query string and fragment, how each segment is normalized (trimmed,
+ * leading separator stripped, empty reduced to absent), and how the segments are reassembled by {@code createUrl}
+ * together with any added parameters.
+ */
+class UrlBuilderTest {
+
+    @BeforeEach
+    void setCurrentFacesContext() {
+        FacesContext facesContext = mock(FacesContext.class);
+        when(facesContext.getExternalContext()).thenReturn(mock(ExternalContext.class));
+        CurrentFacesContext.set(facesContext);
+    }
+
+    @AfterEach
+    void clearCurrentFacesContext() {
+        CurrentFacesContext.set(null);
+    }
+
+    // -------- seed URL parsing ----------------------------------------------
+
+    @Test
+    void seedUrl_pathOnly() {
+        assertEquals("https://example.com/page", buildUrl("https://example.com/page"));
+    }
+
+    @Test
+    void seedUrl_queryString() {
+        assertEquals("https://example.com/page?foo=bar", buildUrl("https://example.com/page?foo=bar"));
+        assertEquals("https://example.com/page?foo=bar&baz=bak", buildUrl("https://example.com/page?foo=bar&baz=bak"));
+    }
+
+    @Test
+    void seedUrl_fragment() {
+        assertEquals("https://example.com/page#foo", buildUrl("https://example.com/page#foo"));
+    }
+
+    @Test
+    void seedUrl_queryStringAndFragment() {
+        assertEquals("https://example.com/page?foo=bar#baz", buildUrl("https://example.com/page?foo=bar#baz"));
+    }
+
+    /**
+     * The fragment is split off before the query string, so a question mark inside the fragment stays part of the
+     * fragment and does not become a query string of its own.
+     */
+    @Test
+    void seedUrl_questionMarkInsideFragmentIsNotAQueryString() {
+        assertEquals("https://example.com#?foo=bar", buildUrl("https://example.com#?foo=bar"));
+        assertEquals("https://example.com?foo=bar#?baz=bak", buildUrl("https://example.com?foo=bar#?baz=bak"));
+        assertEquals("https://example.com#/foo/bar?baz=bak&ban=bar", buildUrl("https://example.com#/foo/bar?baz=bak&ban=bar"));
+    }
+
+    @Test
+    void seedUrl_emptyOrBlankIsRejected() {
+        assertThrows(IllegalArgumentException.class, () -> new UrlBuilder(null, UTF_8.name()));
+        assertThrows(IllegalArgumentException.class, () -> new UrlBuilder("", UTF_8.name()));
+        assertThrows(IllegalArgumentException.class, () -> new UrlBuilder("   ", UTF_8.name()));
+    }
+
+    // -------- empty segments (issue 5904) -----------------------------------
+
+    /**
+     * A seed URL ending in a bare hash mark leaves an empty fragment behind, which must be dropped rather than throw a
+     * {@link StringIndexOutOfBoundsException} while stripping the leading hash mark.
+     */
+    @Test
+    void seedUrl_trailingFragmentSeparatorIsDropped() {
+        assertEquals("https://example.com/", buildUrl("https://example.com/#"));
+        assertEquals("https://example.com/page", buildUrl("https://example.com/page#"));
+    }
+
+    /**
+     * A seed URL ending in a bare question mark leaves an empty query string behind, which must be dropped rather than
+     * throw a {@link StringIndexOutOfBoundsException} while stripping the leading question mark.
+     */
+    @Test
+    void seedUrl_trailingQueryStringSeparatorIsDropped() {
+        assertEquals("https://example.com/", buildUrl("https://example.com/?"));
+        assertEquals("https://example.com/page", buildUrl("https://example.com/page?"));
+    }
+
+    @Test
+    void seedUrl_trailingQueryStringAndFragmentSeparatorAreDropped() {
+        assertEquals("https://example.com/page", buildUrl("https://example.com/page?#"));
+    }
+
+    @Test
+    void seedUrl_blankSegmentsAreDropped() {
+        assertEquals("https://example.com/page", buildUrl("https://example.com/page#   "));
+        assertEquals("https://example.com/page", buildUrl("https://example.com/page?   "));
+    }
+
+    /**
+     * Only one leading hash mark is stripped, so a doubled one at the end of the seed URL reduces to an empty fragment
+     * and is dropped altogether.
+     */
+    @Test
+    void seedUrl_doubledTrailingFragmentSeparatorIsDropped() {
+        assertEquals("https://example.com/page", buildUrl("https://example.com/page##"));
+    }
+
+    @Test
+    void seedUrl_doubledTrailingQueryStringSeparatorIsDropped() {
+        assertEquals("https://example.com/page", buildUrl("https://example.com/page??"));
+    }
+
+    /**
+     * Only one leading separator is stripped from an extracted segment, so anything beyond the first one is content.
+     */
+    @Test
+    void seedUrl_onlyOneLeadingSeparatorIsStripped() {
+        assertEquals("https://example.com/page##", buildUrl("https://example.com/page###"));
+        assertEquals("https://example.com/page??", buildUrl("https://example.com/page???"));
+        assertEquals("https://example.com/page#top", buildUrl("https://example.com/page##top"));
+        assertEquals("https://example.com/page?a=1", buildUrl("https://example.com/page??a=1"));
+    }
+
+    /**
+     * Reproduces the reported failure in its original shape: {@code ExternalContext#encodeRedirectURL} on a base URL
+     * that ends in a bare hash mark.
+     */
+    @Test
+    void seedUrl_trailingFragmentSeparatorWithParameters() {
+        UrlBuilder builder = new UrlBuilder("https://example.com/#", UTF_8.name());
+        builder.addParameters(parameters("foo", "bar"));
+        assertEquals("https://example.com/?foo=bar", builder.createUrl());
+    }
+
+    // -------- setFragment ---------------------------------------------------
+
+    @Test
+    void setFragment_isAppendedAfterHashMark() {
+        assertEquals("https://example.com#foo", buildUrl("https://example.com", builder -> builder.setFragment("foo")));
+    }
+
+    @Test
+    void setFragment_leadingHashMarkIsStrippedOnce() {
+        assertEquals("https://example.com#foo", buildUrl("https://example.com", builder -> builder.setFragment("#foo")));
+        assertEquals("https://example.com##foo", buildUrl("https://example.com", builder -> builder.setFragment("##foo")));
+    }
+
+    @Test
+    void setFragment_isTrimmed() {
+        assertEquals("https://example.com#foo", buildUrl("https://example.com", builder -> builder.setFragment("  foo  ")));
+        assertEquals("https://example.com#foo", buildUrl("https://example.com", builder -> builder.setFragment("  #foo  ")));
+    }
+
+    @Test
+    void setFragment_emptyOrBlankOrNullIsDropped() {
+        assertEquals("https://example.com", buildUrl("https://example.com", builder -> builder.setFragment(null)));
+        assertEquals("https://example.com", buildUrl("https://example.com", builder -> builder.setFragment("")));
+        assertEquals("https://example.com", buildUrl("https://example.com", builder -> builder.setFragment("   ")));
+        assertEquals("https://example.com", buildUrl("https://example.com", builder -> builder.setFragment("#")));
+    }
+
+    @Test
+    void setFragment_replacesTheSeedFragment() {
+        assertEquals("https://example.com#bar", buildUrl("https://example.com#foo", builder -> builder.setFragment("bar")));
+        assertEquals("https://example.com", buildUrl("https://example.com#foo", builder -> builder.setFragment("")));
+    }
+
+    // -------- setQueryString ------------------------------------------------
+
+    @Test
+    void setQueryString_isAppendedAfterQuestionMark() {
+        assertEquals("https://example.com?foo=bar", buildUrl("https://example.com", builder -> builder.setQueryString("foo=bar")));
+    }
+
+    @Test
+    void setQueryString_leadingQuestionMarkIsStrippedOnce() {
+        assertEquals("https://example.com?foo=bar", buildUrl("https://example.com", builder -> builder.setQueryString("?foo=bar")));
+        assertEquals("https://example.com??foo=bar", buildUrl("https://example.com", builder -> builder.setQueryString("??foo=bar")));
+    }
+
+    @Test
+    void setQueryString_isTrimmed() {
+        assertEquals("https://example.com?foo=bar", buildUrl("https://example.com", builder -> builder.setQueryString("  foo=bar  ")));
+        assertEquals("https://example.com?foo=bar", buildUrl("https://example.com", builder -> builder.setQueryString("  ?foo=bar  ")));
+    }
+
+    @Test
+    void setQueryString_emptyOrBlankOrNullIsDropped() {
+        assertEquals("https://example.com", buildUrl("https://example.com", builder -> builder.setQueryString(null)));
+        assertEquals("https://example.com", buildUrl("https://example.com", builder -> builder.setQueryString("")));
+        assertEquals("https://example.com", buildUrl("https://example.com", builder -> builder.setQueryString("   ")));
+        assertEquals("https://example.com", buildUrl("https://example.com", builder -> builder.setQueryString("?")));
+    }
+
+    @Test
+    void setQueryString_replacesTheSeedQueryString() {
+        assertEquals("https://example.com?baz=bak", buildUrl("https://example.com?foo=bar", builder -> builder.setQueryString("baz=bak")));
+        assertEquals("https://example.com", buildUrl("https://example.com?foo=bar", builder -> builder.setQueryString("")));
+    }
+
+    // -------- parameters ----------------------------------------------------
+
+    @Test
+    void addParameters_startsTheQueryString() {
+        UrlBuilder builder = new UrlBuilder("https://example.com/page", UTF_8.name());
+        builder.addParameters(parameters("foo", "bar"));
+        assertEquals("https://example.com/page?foo=bar", builder.createUrl());
+    }
+
+    @Test
+    void addParameters_extendsTheSeedQueryString() {
+        UrlBuilder builder = new UrlBuilder("https://example.com/page?foo=bar", UTF_8.name());
+        builder.addParameters(parameters("baz", "bak"));
+        assertEquals("https://example.com/page?foo=bar&baz=bak", builder.createUrl());
+    }
+
+    @Test
+    void addParameters_areAppendedBeforeTheFragment() {
+        UrlBuilder builder = new UrlBuilder("https://example.com/page#anchor", UTF_8.name());
+        builder.addParameters(parameters("foo", "bar"));
+        assertEquals("https://example.com/page?foo=bar#anchor", builder.createUrl());
+    }
+
+    @Test
+    void addParameters_valuesAreEncoded() {
+        UrlBuilder builder = new UrlBuilder("https://example.com/page", UTF_8.name());
+        builder.addParameters("foo", singletonList("?bar&baz=bak#anchor"));
+        assertEquals("https://example.com/page?foo=%3Fbar%26baz%3Dbak%23anchor", builder.createUrl());
+    }
+
+    @Test
+    void addParameters_multipleValuesAreRepeated() {
+        UrlBuilder builder = new UrlBuilder("https://example.com/page", UTF_8.name());
+        builder.addParameters("foo", asList("bar", "baz"));
+        assertEquals("https://example.com/page?foo=bar&foo=baz", builder.createUrl());
+    }
+
+    @Test
+    void addParameters_nullValuesAreSkipped() {
+        UrlBuilder builder = new UrlBuilder("https://example.com/page", UTF_8.name());
+        builder.addParameters("foo", asList("bar", null));
+        assertEquals("https://example.com/page?foo=bar", builder.createUrl());
+    }
+
+    @Test
+    void addParameters_emptyOrBlankNameIsRejected() {
+        UrlBuilder builder = new UrlBuilder("https://example.com/page", UTF_8.name());
+        assertThrows(IllegalArgumentException.class, () -> builder.addParameters(null, singletonList("bar")));
+        assertThrows(IllegalArgumentException.class, () -> builder.addParameters("", singletonList("bar")));
+        assertThrows(IllegalArgumentException.class, () -> builder.addParameters("   ", singletonList("bar")));
+    }
+
+    // -------- helpers -------------------------------------------------------
+
+    private static String buildUrl(String url) {
+        return new UrlBuilder(url, UTF_8.name()).createUrl();
+    }
+
+    private static String buildUrl(String url, Consumer<UrlBuilder> customizer) {
+        UrlBuilder builder = new UrlBuilder(url, UTF_8.name());
+        customizer.accept(builder);
+        return builder.createUrl();
+    }
+
+    private static Map<String, List<String>> parameters(String name, String value) {
+        Map<String, List<String>> parameters = new LinkedHashMap<>();
+        parameters.put(name, singletonList(value));
+        return parameters;
+    }
+
+    /**
+     * Gives access to the protected {@code FacesContext#setCurrentInstance}, which is otherwise unreachable from a test
+     * in another package.
+     */
+    private abstract static class CurrentFacesContext extends FacesContext {
+
+        static void set(FacesContext facesContext) {
+            setCurrentInstance(facesContext);
+        }
+    }
+}


### PR DESCRIPTION
Closes #5904

`UrlBuilder.cleanFragment()` and `cleanQueryString()` strip the leading separator with `charAt(0)`, which throws `StringIndexOutOfBoundsException` when the segment is empty. A seed URL ending in a bare `#` or `?` produces exactly that, because `extractSegments` has already consumed the separator via `substring(index + 1)`. So `encodeRedirectURL("https://www.someurl.com/#")` — and `encodeBookmarkableURL` / `encodePartialActionURL` alike — crashes.

I fixed both methods, not only the reported one: `cleanQueryString` has the identical defect and crashes on a trailing `?`.

The fix restores the `startsWith()` form that 4.0 still has, rather than adding an `!isEmpty()` guard in front of the `charAt` — it removes the failure mode by construction, and the two branches now read the same.

## Scope

Regressed in #5251 (commit d0376338a32acee83f697669868914695a7b72f7, "+ fixed imports + little optimizations... still a bit ugly"), which swapped `startsWith(SEPARATOR)` for `charAt(0) == SEPARATOR_CHAR` in both methods and thereby dropped the empty-string tolerance that `startsWith` gave for free. That never reached 4.0, so only 4.1 and master are affected; master gets this via the usual upmerge.

## Tests

New `UrlBuilderTest`, 31 cases covering seed URL parsing, segment normalization and parameter assembly. With the fix reverted, 9 of them fail with the exact stack trace from the issue, at `cleanFragment` **and** `cleanQueryString`.

Beyond the regression itself it pins the surrounding contract, notably that exactly one leading separator is stripped from an extracted segment (`###` → `##`, `??a=1` → `?a=1`) and that a `?` inside a fragment stays part of the fragment rather than becoming a query string.

## Note, not addressed here

The strip-leading-separator leniency exists for the setters — `setFragment("#top")` and `setFragment("top")` should both mean `top`. `extractSegments` calls the same cleaners even though it has already removed the separator, so a genuine leading `?` in a query string is silently eaten: `page??a=1` builds as `page?a=1`, changing the parameter name from `?a` to `a`. Per RFC 3986 a `?` is legal in a query, so that one is arguably wrong; the fragment side is stripping something already malformed. Behaviour is shared with 4.0 and unrelated to this crash, so I left it alone and only pinned it in the tests. Happy to file it separately if it's worth changing.

🤖 Generated with Claude Opus 5
