### PR TITLE
Document the faces submodule in DEVELOPERS.md

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -9,17 +9,33 @@ In case you want to checkout this repository and manually build from source your
 ### Mojarra 5.0
 
 1. Make sure that you have JDK 17 and Maven installed.
-2. Checkout branch [`master`][28].
-3. Run the following commands from the `impl` directory of the project:
+2. Make sure that git is configured to keep submodules in sync:
+
+    ```bash
+    git config --global submodule.recurse true
+    ```
+
+    This covers every future `git pull`, `git checkout` and `git switch`, but not `git clone`, so the initial checkout in the next step needs its own flag.
+
+3. Checkout branch [`master`][28], including submodules:
+
+    ```bash
+    git clone --recurse-submodules https://github.com/eclipse-ee4j/mojarra.git
+    ```
+
+    In an existing clone, run `git submodule update --init` instead.
+
+4. Run the following commands from the `impl` directory of the project:
 
     ```bash
     # under the impl dir of project
     mvn clean install
     ```
 
-4. The binary is now available as `target/mojarra-5.x.x-SNAPSHOT.jar`.
+5. The binary is now available as `target/mojarra-5.x.x-SNAPSHOT.jar`.
 
-Note that since 5.0 the API part is split into [Faces project](https://github.com/jakartaee/faces/tree/5.0).
+Note that since 5.0 the API part is split into [Faces project](https://github.com/jakartaee/faces/tree/5.0), which is wired in as the `faces` git submodule.
+Its sources are needed at build time, among others for the TypeScript definitions of `faces.js`, so a clone without submodules will fail to build.
 
 ### Mojarra 4.1
 
@@ -59,6 +75,9 @@ In case you want to checkout to edit the source code of Mojarra with full IDE su
 
 1. Checkout the desired branch ([`master`][28], [`4.1`][32], or [`4.0`][31]) using File -> Import -> Git
 2. Right click the Mojarra project after checkout, choose Configure -> Convert to Maven Project
+
+On [`master`][28], make sure that `submodule.recurse` is set as explained above and that the `faces` submodule is populated, else the build will fail.
+Eclipse does not fetch submodules during import, so run `git submodule update --init` in the checkout afterwards, or clone from the command line instead.
 
 ## Pull Requests
 


### PR DESCRIPTION
Since 5.0 the API lives in [jakartaee/faces](https://github.com/jakartaee/faces/tree/5.0), wired into this repository as the `faces` git submodule. Its sources are needed at build time — among others for the `faces.d.ts` type definitions which the TypeScript sources of `faces.js` import — so a clone made without `--recurse-submodules` leaves `faces/` empty and the build dies in rollup on four files at once:

```
[INFO] [!] (plugin typescript) RollupError: [plugin typescript] faces/ajax.ts (1:28): @rollup/plugin-typescript TS2307: Cannot find module '../../../../../faces/api/src/main/resources/META-INF/resources/jakarta.faces/faces' or its corresponding type declarations.
```

DEVELOPERS.md only said to checkout `master`, which is why this keeps biting people. The 5.0 build instructions now lead with `git config --global submodule.recurse true`, which keeps every later `git pull`, `git checkout` and `git switch` in sync, and then clone with `--recurse-submodules`. Both are needed: per git-config, `submodule.recurse` applies to checkout, fetch, grep, pull, push, read-tree, reset, restore and switch, but explicitly not to `clone`. For an existing checkout there is `git submodule update --init`. The Eclipse instructions point at both, since File -> Import -> Git does not fetch submodules either.

CI is blind to this: `build.yml` checks `jakartaee/faces` out into `path: faces` with a second `actions/checkout` rather than using submodules, so it never sees an empty `faces/`.

Docs only, no code changes.

🤖 Generated with Claude Opus 5
