### PR TITLE
Update DefaultFaceletFactory to forbid absolute URLs

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/facelets/impl/DefaultFaceletFactory.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/impl/DefaultFaceletFactory.java
@@ -37,6 +37,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
@@ -63,6 +64,7 @@ import org.glassfish.mojarra.application.ApplicationAssociate;
 import org.glassfish.mojarra.application.resource.ResourceManager;
 import org.glassfish.mojarra.config.WebConfiguration;
 import org.glassfish.mojarra.context.FacesFileNotFoundException;
+import org.glassfish.mojarra.context.FacesContextParam;
 import org.glassfish.mojarra.facelets.compiler.Compiler;
 import org.glassfish.mojarra.util.Cache;
 import org.glassfish.mojarra.util.FacesLogger;
@@ -86,6 +88,7 @@ public class DefaultFaceletFactory {
     private ResourceManager manager;
     private URL baseUrl;
     private String baseUrlAsString;
+    private String[] faceletsSuffixes;
     private long refreshPeriodInMillis;
     private FaceletCache<DefaultFacelet> cache;
     private ConcurrentMap<String, FaceletCache<DefaultFacelet>> cachePerContract;
@@ -112,6 +115,7 @@ public class DefaultFaceletFactory {
         this.manager = ApplicationAssociate.getInstance(externalContext).getResourceManager();
         baseUrl = resolver.resolveUrl("/");
         baseUrlAsString = baseUrl.toExternalForm();
+        faceletsSuffixes = FacesContextParam.FACELETS_SUFFIX.getValue(facesContext);
         this.idMappers = config.isOptionEnabled(UseFaceletsID) ? null : new Cache<>(new IdMapperFactory());
         this.refreshPeriodInMillis = refreshPeriodInSeconds >= 0 ? refreshPeriodInSeconds * 1000 : -1;
         if (log.isLoggable(Level.FINE)) {
@@ -163,14 +167,48 @@ public class DefaultFaceletFactory {
     public URL resolveURL(URL source, String path) throws IOException {
         // PENDING(FCAPUTO): always go to the resolver to make resource library contracts work with relative urls
         if (path.startsWith("/")) {
-            URL url = resolver.resolveUrl(path);
+            URL url = this.resolver.resolveUrl(path);
             if (url == null) {
                 throw new FacesFileNotFoundException(path + " Not Found in ExternalContext as a Resource");
+            }
+            // A top-level view is already constrained by the ViewHandler/container; an include or
+            // template (resolved against a nested facelet as source) must point at a Facelet resource,
+            // so a user-controlled src cannot disclose descriptors such as /WEB-INF/web.xml.
+            if (source != baseUrl) {
+                requireFaceletResource(url, path);
             }
             return url;
         }
 
-        return new URL(source, path);
+        // A relative src/template must resolve to a Facelet inside this application. Reject absolute
+        // URLs (http:, file:, jar:, ...) whose scheme discards the base, "../" traversal that escapes
+        // the deployment, and any non-Facelet resource.
+        URL url = new URL(source, path);
+        requireSameOrigin(source, url, path);
+        requireWithinApplicationRoot(url, path);
+        requireFaceletResource(url, path);
+        return url;
+    }
+
+    private void requireSameOrigin(URL source, URL url, String path) throws FacesFileNotFoundException {
+        if (!url.getProtocol().equals(source.getProtocol()) || !Objects.equals(url.getAuthority(), source.getAuthority())) {
+            throw new FacesFileNotFoundException(path + " must be a relative path within the application");
+        }
+    }
+
+    private void requireWithinApplicationRoot(URL url, String path) throws FacesFileNotFoundException {
+        if (url.getProtocol().equals(baseUrl.getProtocol()) && !url.toExternalForm().startsWith(baseUrlAsString)) {
+            throw new FacesFileNotFoundException(path + " is not within the application root");
+        }
+    }
+
+    private void requireFaceletResource(URL url, String path) throws FacesFileNotFoundException {
+        String resourcePath = url.getPath();
+        for (String suffix : faceletsSuffixes) {
+            if (resourcePath.endsWith(suffix)) {
+                return;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Port fix from 4.1.

This fix is slightly different (a single Facelet suffix versus a List) as it appears Faces only supports one mapping per deployment. Claude agrees, but we all know it can be wrong from to time, and I certainly can, so a sanity check would be great. It felt wrong, though, to make a list of a single `FacesContextParam.FACELETS_SUFFIX.getValue(facesContext)`.