### PR TITLE
Make ASCII case folding independent of the default locale

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/annotation/NamedEventConfigHandler.java
+++ b/impl/src/main/java/com/sun/faces/application/annotation/NamedEventConfigHandler.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import com.sun.faces.application.ApplicationAssociate;
@@ -88,7 +89,7 @@ public class NamedEventConfigHandler implements ConfigAnnotationHandler {
             name = name.substring(0, index);
         }
 
-        name = annotatedClass.getPackage().getName() + ("." + name.charAt(0)).toLowerCase() + name.substring(1);
+        name = annotatedClass.getPackage().getName() + ("." + name.charAt(0)).toLowerCase(Locale.ROOT) + name.substring(1);
         nem.addNamedEvent(name, (Class<? extends SystemEvent>) annotatedClass);
 
         String shortName = ((NamedEvent) annotation).shortName();

--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
@@ -30,6 +30,7 @@ import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static jakarta.servlet.http.HttpServletResponse.SC_NOT_MODIFIED;
 import static jakarta.servlet.http.MappingMatch.EXTENSION;
 import static java.lang.Boolean.FALSE;
+import static java.util.Locale.ROOT;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.WARNING;
 
@@ -252,7 +253,7 @@ public class ResourceHandlerImpl extends ResourceHandler {
 
         String contentType = getContentType(FacesContext.getCurrentInstance(), resourceName);
         if (null != contentType) {
-            contentType = contentType.toLowerCase();
+            contentType = contentType.toLowerCase(ROOT);
             if (-1 != contentType.indexOf("javascript")) {
                 rendererType = "jakarta.faces.resource.Script";
             } else if (-1 != contentType.indexOf("css")) {
@@ -268,7 +269,7 @@ public class ResourceHandlerImpl extends ResourceHandler {
             return null;
         }
 
-        final String type = contentType.toLowerCase();
+        final String type = contentType.toLowerCase(ROOT);
         if (type.equals(ScriptRenderer.DEFAULT_CONTENT_TYPE)) {
             return "script";
         } else if (type.equals(StylesheetRenderer.DEFAULT_CONTENT_TYPE)) {

--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceManager.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceManager.java
@@ -356,7 +356,7 @@ public class ResourceManager {
     static boolean nameContainsForbiddenSequence(String name) {
         boolean result = false;
         if (name != null) {
-            name = name.toLowerCase();
+            name = name.toLowerCase(Locale.ROOT);
 
             result = name.startsWith(".") || name.contains("../") || name.contains("..\\") || name.startsWith("/") || name.startsWith("\\")
                     || name.endsWith("/") ||

--- a/impl/src/main/java/com/sun/faces/application/view/ViewScopeContextManager.java
+++ b/impl/src/main/java/com/sun/faces/application/view/ViewScopeContextManager.java
@@ -22,6 +22,7 @@ import static com.sun.faces.cdi.CdiUtils.getBeanReference;
 import static com.sun.faces.config.WebConfiguration.BooleanWebContextInitParameter.EnableDistributable;
 import static com.sun.faces.context.SessionMap.getMutex;
 import static com.sun.faces.util.Util.getCdiBeanManager;
+import static java.util.Locale.ROOT;
 import static java.util.logging.Level.FINEST;
 import static java.util.logging.Level.WARNING;
 
@@ -310,7 +311,7 @@ public class ViewScopeContextManager {
      * @return the name.
      */
     private String getName(Object instance) {
-        String name = instance.getClass().getSimpleName().substring(0, 1).toLowerCase() + instance.getClass().getSimpleName().substring(1);
+        String name = instance.getClass().getSimpleName().substring(0, 1).toLowerCase(ROOT) + instance.getClass().getSimpleName().substring(1);
 
         Named named = instance.getClass().getAnnotation(Named.class);
         if (named != null && named.value() != null && !named.value().trim().equals("")) {

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/FacesComponentTagLibrary.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/FacesComponentTagLibrary.java
@@ -17,6 +17,7 @@
 package com.sun.faces.facelets.tag.faces;
 
 import java.util.List;
+import java.util.Locale;
 
 import com.sun.faces.application.ApplicationAssociate;
 import com.sun.faces.application.annotation.FacesComponentUsage;
@@ -83,7 +84,7 @@ public class FacesComponentTagLibrary extends LazyTagLibrary {
                 }
             } else if (null != tagName) {
                 tagName = cur.getTarget().getSimpleName();
-                tagName = tagName.substring(0, 1).toLowerCase() + tagName.substring(1);
+                tagName = tagName.substring(0, 1).toLowerCase(Locale.ROOT) + tagName.substring(1);
                 if (localName.equals(tagName)) {
                     result = cur;
                     break;

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/HtmlResponseWriter.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/HtmlResponseWriter.java
@@ -21,6 +21,7 @@ import java.io.Writer;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -260,7 +261,7 @@ public class HtmlResponseWriter extends ResponseWriter {
             throw new IllegalArgumentException(MessageUtils.getExceptionMessageString(MessageUtils.ENCODING_ERROR_MESSAGE_ID));
         }
 
-        String charsetName = encoding.toUpperCase();
+        String charsetName = encoding.toUpperCase(Locale.ROOT);
 
         switch (disableUnicodeEscaping) {
         case True:

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/TextRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/TextRenderer.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import jakarta.faces.application.FacesMessage;
@@ -113,7 +114,7 @@ public class TextRenderer extends HtmlBasicInputRenderer {
                 String type = ((HtmlInputText) component).getType();
 
                 if (context.isProjectStage(ProjectStage.Development)) {
-                    String recommendedComponent = RECOMMENDED_COMPONENTS_BY_DISCOMMENDED_TYPES.get(type.trim().toLowerCase());
+                    String recommendedComponent = RECOMMENDED_COMPONENTS_BY_DISCOMMENDED_TYPES.get(type.trim().toLowerCase(Locale.ROOT));
 
                     if (recommendedComponent != null) {
                         String message = "<h:inputText type=\"" + type + "\"> is discommended, you should instead use " + recommendedComponent;

--- a/impl/src/main/java/jakarta/faces/component/UIViewRoot.java
+++ b/impl/src/main/java/jakarta/faces/component/UIViewRoot.java
@@ -1457,7 +1457,7 @@ public class UIViewRoot extends UIComponentBase implements UniqueIdVendor {
             if (2 != localeStr.length()) {
                 throw new IllegalArgumentException("Illegal locale String: " + localeStr);
             }
-            lang = localeStr.toLowerCase();
+            lang = localeStr;
         }
 
         // we have a separator, it must be either '-' or '_'

--- a/impl/src/main/java/jakarta/faces/webapp/FacesServlet.java
+++ b/impl/src/main/java/jakarta/faces/webapp/FacesServlet.java
@@ -25,6 +25,7 @@ import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static java.util.Collections.emptySet;
 import static java.util.EnumSet.allOf;
 import static java.util.EnumSet.range;
+import static java.util.Locale.ROOT;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINER;
 import static java.util.logging.Level.SEVERE;
@@ -671,8 +672,8 @@ public final class FacesServlet implements Servlet {
     private boolean notProcessWebInfIfPrefixMapped(HttpServletRequest request, HttpServletResponse response) throws IOException {
         String pathInfo = request.getPathInfo();
         if (pathInfo != null) {
-            pathInfo = pathInfo.toUpperCase();
-            if (pathInfo.contains("/WEB-INF/") || pathInfo.contains("/WEB-INF") || pathInfo.contains("/META-INF/") || pathInfo.contains("/META-INF")) {
+            pathInfo = pathInfo.toUpperCase(ROOT);
+            if (pathInfo.contains("/WEB-INF") || pathInfo.contains("/META-INF")) {
                 response.sendError(SC_NOT_FOUND);
                 return true;
             }

--- a/impl/src/test/java/jakarta/faces/component/UIViewRootTest.java
+++ b/impl/src/test/java/jakarta/faces/component/UIViewRootTest.java
@@ -22,11 +22,14 @@ import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import jakarta.el.ValueExpression;
 import jakarta.faces.application.Application;
 import jakarta.faces.application.ProjectStage;
 import jakarta.faces.context.ExternalContext;
@@ -131,6 +134,45 @@ public class UIViewRootTest {
         assertEquals("one", viewMap.get("one"));
 
         setFacesContext(null);
+    }
+
+    /**
+     * A locale string must resolve to the same locale on every server. Under a Turkish or Azeri default locale
+     * {@code I} lowercases to dotless {@code i} (U+0131), which would turn a language such as {@code IT} into
+     * {@code ıt}.
+     */
+    @Test
+    public void testGetLocaleFromStringIsIndependentOfDefaultLocale() {
+        FacesContext facesContext = Mockito.mock(FacesContext.class);
+        ExternalContext externalContext = Mockito.mock(ExternalContext.class);
+
+        setFacesContext(facesContext);
+        when(facesContext.getExternalContext()).thenReturn(externalContext);
+        when(externalContext.getApplicationMap()).thenReturn(null);
+
+        Locale defaultLocale = Locale.getDefault();
+
+        try {
+            for (Locale locale : List.of(Locale.US, Locale.forLanguageTag("tr-TR"), Locale.forLanguageTag("az-AZ"))) {
+                Locale.setDefault(locale);
+                assertEquals("it", localeOf(facesContext, "IT").getLanguage(), locale.toString());
+                assertEquals("fi", localeOf(facesContext, "FI").getLanguage(), locale.toString());
+                assertEquals("it", localeOf(facesContext, "it").getLanguage(), locale.toString());
+            }
+        } finally {
+            Locale.setDefault(defaultLocale);
+            setFacesContext(null);
+        }
+    }
+
+    private static Locale localeOf(FacesContext facesContext, String localeString) {
+        ValueExpression expression = Mockito.mock(ValueExpression.class);
+        when(expression.getValue(facesContext.getELContext())).thenReturn(localeString);
+
+        UIViewRoot viewRoot = new UIViewRoot();
+        viewRoot.setValueExpression("locale", expression);
+
+        return viewRoot.getLocale();
     }
 
     private void setFacesContext(FacesContext facesContext) {

--- a/impl/src/test/java/jakarta/faces/webapp/FacesServletTestCase.java
+++ b/impl/src/test/java/jakarta/faces/webapp/FacesServletTestCase.java
@@ -18,6 +18,9 @@ package jakarta.faces.webapp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
+import java.util.Locale;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -203,9 +206,41 @@ public class FacesServletTestCase extends JUnitFacesTestCaseBase {
         assertEquals(HttpServletResponse.SC_OK, response.getStatus());
     }
 
+    /**
+     * The protected path check must not depend on the default locale of the deploying JVM. Under a Turkish or Azeri
+     * locale {@code i} uppercases to dotted capital {@code I} (U+0130), which would let the lowercase spellings of
+     * {@code /WEB-INF} and {@code /META-INF} through a guard that uppercases with the default locale.
+     */
+    @Test
+    public void testProtectedPathsAreRejectedRegardlessOfDefaultLocale() throws Exception {
+        Locale defaultLocale = Locale.getDefault();
+
+        try {
+            for (Locale locale : List.of(Locale.US, Locale.forLanguageTag("tr-TR"), Locale.forLanguageTag("az-AZ"))) {
+                Locale.setDefault(locale);
+                FacesServlet me = new FacesServlet();
+                me.init(config);
+
+                for (String protectedPath : List.of("/WEB-INF/web.xml", "/web-inf/web.xml", "/META-INF/MANIFEST.MF", "/meta-inf/MANIFEST.MF")) {
+                    this.sendRequest(me, "GET", protectedPath);
+                    assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus(), locale + " must reject " + protectedPath);
+                }
+
+                this.sendRequest(me, "GET", "/view.xhtml");
+                assertEquals(HttpServletResponse.SC_OK, response.getStatus(), locale + " must accept an ordinary view");
+            }
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
+    }
+
     private void sendRequest(FacesServlet me, String method) throws Exception {
+        this.sendRequest(me, method, "/test");
+    }
+
+    private void sendRequest(FacesServlet me, String method, String pathInfo) throws Exception {
         request.setMethod(method);
-        request.setPathElements("/test", "/test", "/test", "");
+        request.setPathElements("/test", "/test", pathInfo, "");
         me.service(request, response);
     }
 }


### PR DESCRIPTION
Addresses #5923 on 4.0.

`String.toUpperCase()` and `toLowerCase()` without an argument fold with the JVM default locale. Under a Turkish or Azeri locale `i` uppercases to dotted capital `İ` (U+0130) and `I` lowercases to dotless `ı` (U+0131), so every subsequent comparison against an ASCII literal spelled with `i` or `I` fails and the behaviour of the application depends on the locale of the server it happens to be deployed on. Each commit pins one such fold to `Locale.ROOT`, or drops it where it is redundant.

One commit per site, so any of them can be reverted on its own:

| Commit | Site | Effect under `tr`/`az` |
|---|---|---|
| ff40e4bd3f | `FacesServlet` | `/faces/web-inf/web.xml` passes a guard explicitly written to cover the lowercase spelling |
| 6fd712c2c6 | `UIViewRoot` | `locale="IT"` resolves to language `ıt` |
| 9816991242 | `NamedEventConfigHandler`, `ViewScopeContextManager`, `FacesComponentTagLibrary` | `ItemBean` derives `ıtemBean`, so event, bean and tag names no longer match what the application writes in EL |
| ca8a6e1c9a | `HtmlResponseWriter` | `iso-8859-1` uppercases to `İSO-8859-1`, leaving ISO escaping enabled. Fails safe, output is only over-escaped |
| d79f1cd9bb | `TextRenderer` | `type="FILE"` folds to `fıle`, so the development-mode warning about a discommended type is skipped |
| a85307e33c | `ResourceHandlerImpl` | `TEXT/JAVASCRIPT` folds to `javascrıpt`, so no renderer type is derived |
| b1f0148fa1 | `ResourceManager` | Correct today, since the traversal literals carry no `i` or `I`. Pinned because a security check should not rest on a locale-dependent fold |

The `FacesServlet` commit also drops two dead checks. `contains("/WEB-INF/")` is subsumed by `contains("/WEB-INF")`, likewise for `/META-INF`. They are a fossil: the guard was introduced in 2005 as `startsWith("/WEB-INF/") || equals("/WEB-INF")`, where the two forms did different jobs, and was mechanically widened to `contains` for all four in 2012 without collapsing the now-redundant pair. The `service()` javadoc lists the same four strings and is spec text, so it is left as it is.

## Testing

`FacesServletTestCase` and `UIViewRootTest` each gained a regression test that exercises the fold under `en_US`, `tr_TR` and `az_AZ`. Both were verified to fail without their fix (`tr_TR must reject /web-inf/web.xml ==> expected: <404> but was: <200>` and `tr_TR ==> expected: <it> but was: <ıt>`) and to pass with it. The full `impl` unit suite is green: 86 classes, 0 failures, 0 errors.

The remaining five commits carry no test. Their seams are private or renderer-level, and each is a one-token change with no behavioural difference outside a Turkish or Azeri locale; adding a seam purely to test them did not seem worth the churn.

## Not in this PR

4.1 and master still need the port. The six non-`FacesServlet` sites are common to all branches, but on master the guard lives in `org.glassfish.mojarra.webapp.FacesServletImpl`, so that one is a hand-port rather than a cherry-pick.

`Util.getLocaleFromString` carries the same fold as `UIViewRoot` but reaches it only after `Locale.forLanguageTag` has already failed, which for a two letter language never happens, so its copy is unreachable and is left alone.

---

🤖 Generated with Claude Opus 5
