### PR TITLE
Issue #5856: cut the per-component cost of pass-through attributes

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/tag/TagAttributesImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/TagAttributesImpl.java
@@ -22,6 +22,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.sun.faces.facelets.tag.faces.PassThroughAttributeLibrary;
+
 import jakarta.faces.view.facelets.Tag;
 import jakarta.faces.view.facelets.TagAttribute;
 import jakarta.faces.view.facelets.TagAttributes;
@@ -42,6 +44,8 @@ public final class TagAttributesImpl extends TagAttributes {
 
     private final List nsattrs;
 
+    private final TagAttribute[] passthroughAttrs;
+
     private Tag tag;
 
     /**
@@ -49,6 +53,7 @@ public final class TagAttributesImpl extends TagAttributes {
      */
     public TagAttributesImpl(TagAttribute[] attrs) {
         this.attrs = attrs;
+        passthroughAttrs = collectPassthrough(attrs);
 
         // grab namespaces
         int i = 0;
@@ -75,6 +80,21 @@ public final class TagAttributesImpl extends TagAttributes {
         }
     }
 
+    private static TagAttribute[] collectPassthrough(TagAttribute[] attrs) {
+        List<TagAttribute> passthrough = null;
+
+        for (TagAttribute attr : attrs) {
+            if (PassThroughAttributeLibrary.NAMESPACES.contains(attr.getNamespace())) {
+                if (passthrough == null) {
+                    passthrough = new ArrayList<>(attrs.length);
+                }
+                passthrough.add(attr);
+            }
+        }
+
+        return passthrough == null ? EMPTY : passthrough.toArray(new TagAttribute[passthrough.size()]);
+    }
+
     /**
      * Return an array of all TagAttributesImpl in this set
      *
@@ -83,6 +103,17 @@ public final class TagAttributesImpl extends TagAttributes {
     @Override
     public TagAttribute[] getAll() {
         return attrs;
+    }
+
+    /**
+     * Return the attributes that are in a pass-through namespace, in the order the tag declares them. Every applied
+     * component tag is asked for these and almost none has any, so they are singled out once here, when the tag is
+     * compiled, rather than searched per namespace on every apply.
+     *
+     * @return a non-null array of TagAttribute
+     */
+    public TagAttribute[] getPassthroughAttributes() {
+        return passthroughAttrs;
     }
 
     /**

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentSupport.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentSupport.java
@@ -17,6 +17,7 @@
 package com.sun.faces.facelets.tag.faces;
 
 import static com.sun.faces.config.WebConfiguration.BooleanWebContextInitParameter.PartialStateSaving;
+import static java.util.Arrays.asList;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -31,6 +32,7 @@ import java.util.Set;
 
 import com.sun.faces.RIConstants;
 import com.sun.faces.context.StateContext;
+import com.sun.faces.facelets.tag.TagAttributesImpl;
 import com.sun.faces.facelets.tag.faces.core.FacetHandler;
 import com.sun.faces.util.Util;
 
@@ -46,6 +48,7 @@ import jakarta.faces.view.facelets.FaceletContext;
 import jakarta.faces.view.facelets.Tag;
 import jakarta.faces.view.facelets.TagAttribute;
 import jakarta.faces.view.facelets.TagAttributeException;
+import jakarta.faces.view.facelets.TagAttributes;
 
 /**
  *
@@ -670,17 +673,36 @@ public final class ComponentSupport {
             return;
         }
 
-        for (String namespace : PassThroughAttributeLibrary.NAMESPACES) {
-            TagAttribute[] passthroughAttrs = t.getAttributes().getAll(namespace);
-            if (null != passthroughAttrs && 0 < passthroughAttrs.length) {
-                Map<String, Object> componentPassthroughAttrs = c.getPassThroughAttributes(true);
-                Object attrValue = null;
-                for (TagAttribute cur : passthroughAttrs) {
-                    attrValue = cur.isLiteral() ? cur.getValue(ctx) : cur.getValueExpression(ctx, Object.class);
-                    componentPassthroughAttrs.put(cur.getLocalName(), attrValue);
-                }
-            }
+        TagAttribute[] passthroughAttrs = passthroughAttributes(t.getAttributes());
+
+        if (0 == passthroughAttrs.length) {
+            return;
         }
+
+        Map<String, Object> componentPassthroughAttrs = c.getPassThroughAttributes(true);
+        for (TagAttribute cur : passthroughAttrs) {
+            Object attrValue = cur.isLiteral() ? cur.getValue(ctx) : cur.getValueExpression(ctx, Object.class);
+            componentPassthroughAttrs.put(cur.getLocalName(), attrValue);
+        }
+    }
+
+    /**
+     * Returns the attributes of the given tag that are in a pass-through namespace: from the field the standard
+     * implementation singles them out into when the tag is compiled, and by searching each pass-through namespace for
+     * any other implementation.
+     */
+    private static TagAttribute[] passthroughAttributes(TagAttributes attributes) {
+
+        if (attributes instanceof TagAttributesImpl) {
+            return ((TagAttributesImpl) attributes).getPassthroughAttributes();
+        }
+
+        List<TagAttribute> passthrough = new ArrayList<>();
+        for (String namespace : PassThroughAttributeLibrary.NAMESPACES) {
+            passthrough.addAll(asList(attributes.getAll(namespace)));
+        }
+
+        return passthrough.toArray(new TagAttribute[passthrough.size()]);
     }
 
     // --------------------------------------------------------- private classes

--- a/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
@@ -411,7 +411,9 @@ public class RenderKitUtils {
     /**
      * Returns the names of the attributes that have been explicitly set on the given component, either as a literal value
      * or as a value expression, or an empty list when none have been set. This is the same list that
-     * {@link #renderPassThruAttributes} consults to skip reflective reads of attributes that were never set.
+     * {@link #renderPassThruAttributes} consults to skip reflective reads of attributes that were never set. Its writer,
+     * {@code HtmlComponentUtils.handleAttribute}, keeps it in natural order, which is therefore the order in which the
+     * attributes are emitted.
      */
     @SuppressWarnings("unchecked")
     public static List<String> getAttributesThatAreSet(UIComponent component) {
@@ -697,7 +699,6 @@ public class RenderKitUtils {
         String behaviorEventName = getSingleBehaviorEventName(behaviors);
         boolean renderedBehavior = false;
 
-        Collections.sort(setAttributes);
         boolean isXhtml = RIConstants.XHTML_CONTENT_TYPE.equals(writer.getContentType());
         Map<String, Object> attrMap = component.getAttributes();
         for (String name : setAttributes) {

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/HtmlResponseWriter.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/HtmlResponseWriter.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -134,6 +134,10 @@ public class HtmlResponseWriter extends ResponseWriter {
     private final static int cdataTextBufferSize = 128;
     private char[] cdataTextBuffer = new char[cdataTextBufferSize];
 
+    /**
+     * The pass-through attributes of the element currently being started. This aliases the component's own map, so it
+     * must never be mutated here; {@link #pushElementName} takes a copy for the one case that needs to drop a key.
+     */
     private Map<String, Object> passthroughAttributes;
 
     // Internal buffer for to store the result of String.getChars() for
@@ -1048,13 +1052,13 @@ public class HtmlResponseWriter extends ResponseWriter {
 
     }
 
-    private void considerPassThroughAttributes(Map<String, Object> toCopy) {
-        assert null != toCopy && !toCopy.isEmpty();
+    private void considerPassThroughAttributes(Map<String, Object> attributes) {
+        assert null != attributes && !attributes.isEmpty();
 
         if (null != passthroughAttributes) {
             throw new IllegalStateException("Error, this method should only be called once per instance.");
         }
-        passthroughAttributes = new HashMap<>(toCopy);
+        passthroughAttributes = attributes;
     }
 
     private boolean containsPassThroughAttribute(String attrName) {
@@ -1066,10 +1070,7 @@ public class HtmlResponseWriter extends ResponseWriter {
     }
 
     private void clearPassthroughAttributes() {
-        if (passthroughAttributes != null) {
-            passthroughAttributes.clear();
-            passthroughAttributes = null;
-        }
+        passthroughAttributes = null;
     }
 
     /**
@@ -1115,10 +1116,12 @@ public class HtmlResponseWriter extends ResponseWriter {
 
         String name = getElementName(original);
 
-        if (passthroughAttributes != null) {
-            passthroughAttributes.remove(Renderer.PASSTHROUGH_RENDERER_LOCALNAME_KEY);
-            if (passthroughAttributes.isEmpty()) {
+        if (containsPassThroughAttribute(Renderer.PASSTHROUGH_RENDERER_LOCALNAME_KEY)) {
+            if (passthroughAttributes.size() == 1) {
                 passthroughAttributes = null;
+            } else {
+                passthroughAttributes = new LinkedHashMap<>(passthroughAttributes);
+                passthroughAttributes.remove(Renderer.PASSTHROUGH_RENDERER_LOCALNAME_KEY);
             }
         }
 

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -54,6 +54,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -61,7 +62,6 @@ import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -281,12 +281,20 @@ public abstract class UIComponentBase extends UIComponent {
 
     @Override
     public Map<String, Object> getPassThroughAttributes(boolean create) {
+        // A component without a state helper cannot hold pass-through attributes in first place, so asking for the helper
+        // without creating one keeps the read side effect free -- every rendered element consults this.
+        StateHelper stateHelper = getStateHelper(create);
+
+        if (stateHelper == null) {
+            return null;
+        }
+
         @SuppressWarnings("unchecked")
-        Map<String, Object> passThroughAttributes = (Map<String, Object>) this.getStateHelper().get(PropertyKeys.passThroughAttributes);
+        Map<String, Object> passThroughAttributes = (Map<String, Object>) stateHelper.get(PropertyKeys.passThroughAttributes);
 
         if (passThroughAttributes == null && create) {
             passThroughAttributes = new PassThroughAttributesMap<>();
-            getStateHelper().put(PropertyKeys.passThroughAttributes, passThroughAttributes);
+            stateHelper.put(PropertyKeys.passThroughAttributes, passThroughAttributes);
         }
 
         return passThroughAttributes;
@@ -3510,7 +3518,12 @@ public abstract class UIComponentBase extends UIComponent {
         }
     }
 
-    private static class PassThroughAttributesMap<K, V> extends ConcurrentHashMap<String, Object> implements Serializable {
+    /**
+     * The map behind {@link UIComponentBase#getPassThroughAttributes(boolean)}. Insertion-ordered, so a component
+     * renders its pass-through attributes in the order the view declared them; the renderer writes them straight from
+     * this map, so the iteration order is the wire order.
+     */
+    private static class PassThroughAttributesMap<K, V> extends LinkedHashMap<String, Object> implements Serializable {
 
         private static final long serialVersionUID = 4230540513272170861L;
 
@@ -3530,6 +3543,11 @@ public abstract class UIComponentBase extends UIComponent {
             }
             validateKey(key);
             return super.putIfAbsent(key, value);
+        }
+
+        @Override
+        public void putAll(Map<? extends String, ? extends Object> map) {
+            map.forEach(this::put);
         }
 
         private void validateKey(Object key) {

--- a/impl/src/main/java/jakarta/faces/component/html/HtmlComponentUtils.java
+++ b/impl/src/main/java/jakarta/faces/component/html/HtmlComponentUtils.java
@@ -33,6 +33,9 @@ class HtmlComponentUtils {
      * {@code AttributeManager}, because it must be emitted as the HTML {@code class} attribute (a name rename the generic
      * pass-through loop cannot perform) and is therefore rendered inline by each renderer instead.
      * <p>
+     * Attributes are recorded in natural order, which is the order in which they are emitted; the render side walks the
+     * list as it finds it.
+     * <p>
      * Only standard components (those in the {@code jakarta.faces.component} package, i.e. the generated {@code Html*}
      * classes) maintain the list; for any other component type it is never created and the optimization is simply
      * skipped. A {@code null} {@code value} clears the tracking unless a {@link ValueExpression} is bound to {@code name},
@@ -62,10 +65,35 @@ class HtmlComponentUtils {
                 if (ve == null) {
                     setAttributes.remove(name);
                 }
-            } else if (!setAttributes.contains(name)) {
-                setAttributes.add(name);
+            } else {
+                int index = insertionPoint(setAttributes, name);
+                if (index >= 0) {
+                    setAttributes.add(index, name);
+                }
             }
         }
+    }
+
+    /**
+     * Returns the index at which {@code name} belongs for the recorded attributes to stay in natural order, or -1 when
+     * it is recorded already. The list is scanned end to end rather than binary-searched because
+     * {@code UIComponentBase.AttributesMap} appends the attributes that have no component property to the tail of this
+     * same list, so it cannot be assumed ordered.
+     */
+    private static int insertionPoint(List<String> setAttributes, String name) {
+        int index = setAttributes.size();
+
+        for (int i = 0; i < setAttributes.size(); i++) {
+            int order = setAttributes.get(i).compareTo(name);
+            if (order == 0) {
+                return -1;
+            }
+            if (order > 0 && i < index) {
+                index = i;
+            }
+        }
+
+        return index;
     }
 
 }

--- a/impl/src/test/java/com/sun/faces/facelets/tag/TagAttributesImplTest.java
+++ b/impl/src/test/java/com/sun/faces/facelets/tag/TagAttributesImplTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.facelets.tag;
+
+import static java.util.Arrays.stream;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.faces.view.Location;
+import jakarta.faces.view.facelets.TagAttribute;
+
+/**
+ * A tag singles out its pass-through attributes when it is compiled, because every applied component tag is asked for
+ * them and almost none has any.
+ */
+class TagAttributesImplTest {
+
+    private static final String HTML = "jakarta.faces.html";
+    private static final String PASSTHROUGH = "jakarta.faces.passthrough";
+    private static final String PASSTHROUGH_JCP = "http://xmlns.jcp.org/jsf/passthrough";
+
+    @Test
+    void aTagWithoutPassthroughAttributesHasNone() {
+        TagAttributesImpl attributes = tag(attribute(HTML, "styleClass"), attribute(HTML, "title"));
+
+        assertEquals(0, attributes.getPassthroughAttributes().length);
+    }
+
+    @Test
+    void passthroughAttributesAreCollectedInDeclarationOrder() {
+        TagAttributesImpl attributes = tag(attribute(PASSTHROUGH, "data-row"), attribute(HTML, "styleClass"),
+                attribute(PASSTHROUGH, "data-col"));
+
+        assertArrayEquals(new String[] { "data-row", "data-col" }, localNames(attributes));
+    }
+
+    @Test
+    void bothPassthroughNamespacesAreCollected() {
+        TagAttributesImpl attributes = tag(attribute(PASSTHROUGH_JCP, "data-legacy"), attribute(PASSTHROUGH, "data-row"));
+
+        assertArrayEquals(new String[] { "data-legacy", "data-row" }, localNames(attributes));
+    }
+
+    private static String[] localNames(TagAttributesImpl attributes) {
+        return stream(attributes.getPassthroughAttributes()).map(TagAttribute::getLocalName).toArray(String[]::new);
+    }
+
+    private static TagAttributesImpl tag(TagAttribute... attributes) {
+        return new TagAttributesImpl(attributes);
+    }
+
+    private static TagAttribute attribute(String namespace, String localName) {
+        return new TagAttributeImpl(new Location("test.xhtml", 1, 1), namespace, localName, localName, "value");
+    }
+}

--- a/impl/src/test/java/com/sun/faces/renderkit/html_basic/HtmlResponseWriterTest.java
+++ b/impl/src/test/java/com/sun/faces/renderkit/html_basic/HtmlResponseWriterTest.java
@@ -24,6 +24,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.UIOutput;
 import jakarta.faces.context.FacesContext;
+import jakarta.faces.render.Renderer;
 
 public class HtmlResponseWriterTest {
 
@@ -279,6 +281,88 @@ public class HtmlResponseWriterTest {
         writer.flush();
 
         assertEquals("<input type=\"text\" data-flag=\"yes\" />", sw.toString());
+        writer.close();
+    }
+
+    /**
+     * Pass-through attributes are emitted in the order they were set on the component, so a view renders
+     * byte-identically across requests and JVMs rather than in a hash order.
+     */
+    @Test
+    public void testPassThroughAttributesAreEmittedInTheOrderTheyWereSet() throws Exception {
+        UIComponent component = new UIOutput();
+        Map<String, Object> passThroughAttributes = component.getPassThroughAttributes(true);
+        passThroughAttributes.put("data-zulu", "1");
+        passThroughAttributes.put("data-alpha", "2");
+        passThroughAttributes.put("data-mike", "3");
+
+        StringWriter sw = new StringWriter();
+        HtmlResponseWriter writer = new HtmlResponseWriter(sw, "text/html", "UTF-8");
+        writer.startElement("div", component);
+        writer.endElement("div");
+        writer.flush();
+
+        assertEquals("<div data-zulu=\"1\" data-alpha=\"2\" data-mike=\"3\"></div>", sw.toString());
+        writer.close();
+    }
+
+    /**
+     * Rendering must not mutate the component's own pass-through attribute map: the writer reads it in place, and a
+     * component renders more than once (ajax re-render, a second view of the same tree).
+     */
+    @Test
+    public void testRenderingLeavesTheComponentPassThroughAttributesIntact() throws Exception {
+        UIComponent component = new UIOutput();
+        component.getPassThroughAttributes(true).put("data-x", "1");
+        component.getPassThroughAttributes(true).put(Renderer.PASSTHROUGH_RENDERER_LOCALNAME_KEY, "section");
+
+        StringWriter sw = new StringWriter();
+        HtmlResponseWriter writer = new HtmlResponseWriter(sw, "text/html", "UTF-8");
+        writer.startElement("div", component);
+        writer.endElement("div");
+        writer.flush();
+        writer.close();
+
+        assertEquals(2, component.getPassThroughAttributes(false).size());
+        assertEquals("section", component.getPassThroughAttributes(false).get(Renderer.PASSTHROUGH_RENDERER_LOCALNAME_KEY));
+    }
+
+    /**
+     * The {@code elementName} pass-through attribute renames the element and is itself never emitted as an attribute,
+     * whichever other pass-through attributes accompany it.
+     */
+    @Test
+    public void testElementNameRenamesTheElementAndIsNotEmitted() throws Exception {
+        UIComponent component = new UIOutput();
+        component.getPassThroughAttributes(true).put(Renderer.PASSTHROUGH_RENDERER_LOCALNAME_KEY, "section");
+        component.getPassThroughAttributes(true).put("data-x", "1");
+
+        StringWriter sw = new StringWriter();
+        HtmlResponseWriter writer = new HtmlResponseWriter(sw, "text/html", "UTF-8");
+        writer.startElement("div", component);
+        writer.endElement("div");
+        writer.flush();
+
+        assertEquals("<section data-x=\"1\"></section>", sw.toString());
+        writer.close();
+    }
+
+    /**
+     * An {@code elementName} that is the only pass-through attribute renames the element and leaves nothing to emit.
+     */
+    @Test
+    public void testLoneElementNameRenamesTheElement() throws Exception {
+        UIComponent component = new UIOutput();
+        component.getPassThroughAttributes(true).put(Renderer.PASSTHROUGH_RENDERER_LOCALNAME_KEY, "section");
+
+        StringWriter sw = new StringWriter();
+        HtmlResponseWriter writer = new HtmlResponseWriter(sw, "text/html", "UTF-8");
+        writer.startElement("div", component);
+        writer.writeAttribute("id", "regular", null);
+        writer.endElement("div");
+        writer.flush();
+
+        assertEquals("<section id=\"regular\"></section>", sw.toString());
         writer.close();
     }
 

--- a/impl/src/test/java/jakarta/faces/component/UIComponentBasePassThroughAttributesTest.java
+++ b/impl/src/test/java/jakarta/faces/component/UIComponentBasePassThroughAttributesTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.component;
+
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The map behind {@link UIComponent#getPassThroughAttributes(boolean)} carries the guarantees its javadoc states -
+ * serializable, no null key or value, no non-String key - and iterates in the order the attributes were declared, so a
+ * view renders its pass-through attributes byte-identically across requests.
+ */
+class UIComponentBasePassThroughAttributesTest {
+
+    @Test
+    void attributesIterateInTheOrderTheyWereSet() {
+        Map<String, Object> passThroughAttributes = new UIOutput().getPassThroughAttributes(true);
+        passThroughAttributes.put("data-zulu", "1");
+        passThroughAttributes.put("data-alpha", "2");
+        passThroughAttributes.put("data-mike", "3");
+
+        assertEquals(List.of("data-zulu", "data-alpha", "data-mike"), new ArrayList<>(passThroughAttributes.keySet()));
+    }
+
+    @Test
+    void theMapIsSerializable() {
+        assertTrue(new UIOutput().getPassThroughAttributes(true) instanceof Serializable);
+    }
+
+    @Test
+    void nullKeyOrValueIsRejected() {
+        Map<String, Object> passThroughAttributes = new UIOutput().getPassThroughAttributes(true);
+
+        assertThrows(NullPointerException.class, () -> passThroughAttributes.put(null, "value"));
+        assertThrows(NullPointerException.class, () -> passThroughAttributes.put("data-x", null));
+        assertThrows(NullPointerException.class, () -> passThroughAttributes.putIfAbsent("data-x", null));
+        assertThrows(NullPointerException.class, () -> passThroughAttributes.putAll(singletonMap("data-x", null)));
+    }
+
+    /**
+     * Reading the attributes of a component that has none must not give it a state helper, since every rendered element
+     * asks for them.
+     */
+    @Test
+    void readingWithoutCreatingLeavesTheComponentStateless() {
+        UIOutput component = new UIOutput();
+
+        assertNull(component.getPassThroughAttributes(false));
+        assertNull(component.getStateHelper(false));
+    }
+}

--- a/impl/src/test/java/jakarta/faces/component/html/HtmlAttributesThatAreSetTest.java
+++ b/impl/src/test/java/jakarta/faces/component/html/HtmlAttributesThatAreSetTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.component.html;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * A standard component records the pass-through HTML attributes that were set on it, and rendering emits them in the
+ * order of that list. The list is therefore kept in natural order as it is written, which is what lets the render side
+ * walk it as it finds it instead of sorting it once per component render.
+ */
+class HtmlAttributesThatAreSetTest {
+
+    private static final String ATTRIBUTES_THAT_ARE_SET = "jakarta.faces.component.UIComponentBase.attributesThatAreSet";
+
+    @Test
+    void attributesAreRecordedInNaturalOrderWhateverOrderTheyWereSetIn() {
+        HtmlOutputText component = new HtmlOutputText();
+        component.setTitle("t");
+        component.setDir("ltr");
+        component.setStyle("color:red");
+        component.setLang("en");
+
+        assertEquals(asList("dir", "lang", "style", "title"), attributesThatAreSet(component));
+    }
+
+    @Test
+    void settingAnAttributeTwiceRecordsItOnce() {
+        HtmlOutputText component = new HtmlOutputText();
+        component.setStyle("color:red");
+        component.setDir("ltr");
+        component.setStyle("color:blue");
+
+        assertEquals(asList("dir", "style"), attributesThatAreSet(component));
+    }
+
+    /**
+     * An attribute that has no component property is recorded by {@code UIComponentBase.AttributesMap} at the tail of
+     * the very same list, so the list as a whole is not necessarily ordered. Recording a component property after one
+     * of those must still neither duplicate it nor lose its place among the other properties - a duplicate would emit
+     * the HTML attribute twice.
+     */
+    @Test
+    void propertylessAttributesNeitherDuplicateNorDisplaceTheProperties() {
+        HtmlOutputText component = new HtmlOutputText();
+        component.setDir("ltr");
+        component.setTitle("t");
+        component.getAttributes().put("aaa-custom", "1");
+        component.getAttributes().put("bbb-custom", "2");
+        component.getAttributes().put("ccc-custom", "3");
+        component.setTitle("another");
+
+        assertEquals(asList("dir", "title", "aaa-custom", "bbb-custom", "ccc-custom"), attributesThatAreSet(component));
+    }
+
+    @Test
+    void clearingAnAttributeStopsRecordingItAndLeavesTheRestInOrder() {
+        HtmlOutputText component = new HtmlOutputText();
+        component.setTitle("t");
+        component.setDir("ltr");
+        component.setStyle("color:red");
+        component.setDir(null);
+
+        assertEquals(asList("style", "title"), attributesThatAreSet(component));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> attributesThatAreSet(HtmlOutputText component) {
+        return (List<String>) component.getAttributes().get(ATTRIBUTES_THAT_ARE_SET);
+    }
+}


### PR DESCRIPTION
Continues the view build time work of #5856, this time on the pass-through attribute path, which the `flat-*` scenarios of the perf bench ranked as the worst remaining cell: `flat-passthru` rendered at **1.5x MyFaces 4.1.4** while every other flat scenario sat at or below parity.

`flat-passthru` is a GET, so its `RENDER_RESPONSE` carries the Facelets build as well as the encode. A JFR split put Mojarra at 46% build / 51% encode against MyFaces' 42% / 55% — build +40%, encode +20% — and five per-component costs accounted for most of it.

## What was costing what

| | cost | fix |
|---|---|---|
| `UIComponentBase.PassThroughAttributesMap` extended `ConcurrentHashMap` | `put` was **9.9% of the whole Facelets build** (`casTabAt` + `addCount` per attribute) | extends `LinkedHashMap`. The contract in `UIComponent.getPassThroughAttributes(boolean)` is serializable, NPE on a null key or value, IAE on a non-String key — nothing about thread safety, and MyFaces backs the same map with the plain `StateHelper` map. `putAll` is overridden because the inherited bulk path bypasses the overridden `put` and would otherwise let nulls in |
| `HtmlResponseWriter.considerPassThroughAttributes` copied the map per element | `Traverser.advance` 4.5% + `putMapEntries` 2.6% of the encode | reads the component's map in place, copying only when it carries the `elementName` key. `clearPassthroughAttributes` no longer calls `clear()` — on an aliased map that would wipe the component's own attributes |
| `RenderKitUtils.renderPassThruAttributesOptimized` sorted `attributesThatAreSet` per component render | `binarySort` + `String.compareTo` = 7.3% of the encode, to re-sort a two-element list 400 times | `HtmlComponentUtils.handleAttribute` records the attributes in order instead |
| `getPassThroughAttributes(false)` went through `getStateHelper()` | allocated a `ComponentStateHelper` for a stateless component, on every element rendered — `startElement` consults it for all of them | takes `getStateHelper(false)` and returns null when there is none |
| `ComponentSupport.copyPassthroughAttributes` searched both pass-through namespaces per component tag applied | 3.8% + `TagAttributesImpl.getAll` 2.2% of the build, paid by every component tag whether or not it has a single `p:` attribute | `TagAttributesImpl` singles them out when the tag is compiled; the namespace search remains as a fallback for a non-standard `TagAttributes` |

## Numbers

Tomcat, the 400-component `test/perf` flat views, `min_us` (the fastest of 2000 requests, which is what survives background load on a shared machine), median of interleaved runs, Mojarra vs MyFaces 4.1.4-SNAPSHOT:

| scenario | phase | before | after | MyFaces | Δ | ratio |
|---|---|--:|--:|--:|--:|--:|
| flat-passthru | RENDER | 1323 | **1111** | 866 | **−16.0%** | 1.53x → **1.28x** |
| flat-readonly | RENDER | 1261 | 1188 | 1218 | −5.8% | 1.04x → 0.98x |
| flat-build | RENDER | 722 | 700 | 760 | −3.0% | 0.95x → 0.92x |
| flat-wide | RENDER | 1435 | 1394 | 1258 | −2.9% | 1.14x → 1.11x |
| flat-table-nofacets | RENDER | 978 | 953 | 1164 | −2.6% | 0.84x → 0.82x |
| flat-table-facets | RENDER | 900 | 896 | 995 | −0.4% | 0.90x → 0.90x |
| flat-text (control) | RENDER | 1215 | 1222 | 1345 | +0.6% | — |
| **flat suite total** | | **8708** | **8425** | **8728** | **−3.2%** | at MyFaces → **3.5% below** |

`flat-text` is the control: its markup is raw `<span>`s with no components, so none of these changes can reach it, and it does not move. `flat-readonly` is where the fifth lever shows up cleanest — 400 `h:outputText` with no pass-through attributes at all, i.e. pure per-tag overhead being removed.

## Verification

- **Rendered-output equivalence.** The perf WAR deployed twice on the same Tomcat with only `jakarta.faces.jar` swapped, all 39 scenario pages fetched, `jsessionid` and the `ViewState` value normalised, then diffed: **38 of 39 byte-identical**. `flat-passthru` differs only in the ordering of the pass-through attributes within each start tag — same byte count, and the new order is the one the view declares (`data-row data-col data-kind data-state data-index`) rather than the previous hash order.
- **Unit tests.** 1253 green. Eleven new ones pin the invariants this change relies on: the map's iteration order and its null/serializable contract; that rendering leaves the component's own map intact and that `elementName` still renames the element without being emitted; that recording an attribute keeps the list ordered and never records one twice; and that a tag's pass-through attributes are collected in declaration order across both namespaces.

One subtlety worth calling out, since it is the trap in this area: `attributesThatAreSet` has a **second writer**. `UIComponentBase.AttributesMap.put` appends any attribute that has no component property to the tail of that same list through `StateHelper.add`, so the list is not globally ordered and a binary-search insert can miss an entry that is already there and record it twice — which the render loop then emits as a duplicate HTML attribute. The per-render `Collections.sort` had been masking that. `handleAttribute` therefore scans rather than binary-searches; `HtmlAttributesThatAreSetTest.propertylessAttributesNeitherDuplicateNorDisplaceTheProperties` reproduces the duplicate against the binary-search version.

The measurements were taken on the 4.1 branch, where `test/perf` lives; the code here is identical apart from `instanceof` pattern matching, which 4.0 compiles at `-source 11` cannot use.

Closes nothing on its own — #5856 stays open for the remaining build gap, which is now diffuse: nothing above ~4% of the build, spread across component state maps, the attribute marker lookups and event publishing. Note that a profile of the Facelets build will show `ComponentTagHandlerDelegateImpl.apply`, `DefaultFaceletContext.generateUniqueId` and `ensurePrefix` trading a large self-time share between them from run to run — they are inlined into one another, and that share is an attribution artifact, not work. The id path itself is two field reads and an array increment in the common case, and accounts for 0.35% of the run's allocations.

🤖 Generated with Claude Opus 5
