### PR TITLE
Fix #5927: honor SKIP_ITERATION in UIRepeat, degrade rowStatePreserved cleanly

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/component/UIRepeat.java
+++ b/impl/src/main/java/com/sun/faces/facelets/component/UIRepeat.java
@@ -17,7 +17,6 @@
 package com.sun.faces.facelets.component;
 
 import static com.sun.faces.cdi.CdiUtils.createDataModel;
-import static com.sun.faces.renderkit.RenderKitUtils.PredefinedPostbackParameter.BEHAVIOR_SOURCE_PARAM;
 import static com.sun.faces.util.Util.isNestedInIterator;
 
 import java.io.IOException;
@@ -762,16 +761,11 @@ public class UIRepeat extends UINamingContainer {
         return false;
     }
 
+    // SKIP_ITERATION is honored unconditionally, as UIData does. A visit that asks for it wants the
+    // row-less clientIds: full state saving keys the saved component state by them, so iterating anyway
+    // makes the restore look up repeat:N:foo for state filed under repeat:foo and restore nothing.
     private boolean requiresRowIteration(VisitContext ctx) {
-        boolean shouldIterate = !ctx.getHints().contains(VisitHint.SKIP_ITERATION);
-        if (!shouldIterate) {
-            FacesContext faces = ctx.getFacesContext();
-            String sourceId = BEHAVIOR_SOURCE_PARAM.getValue(faces);
-            boolean containsSource = sourceId != null ? sourceId.startsWith(super.getClientId(faces) + getSeparatorChar(faces)) : false;
-            return containsSource;
-        } else {
-            return shouldIterate;
-        }
+        return !ctx.getHints().contains(VisitHint.SKIP_ITERATION);
     }
 
     // Tests whether we need to visit our children as part of

--- a/impl/src/main/java/jakarta/faces/component/UIData.java
+++ b/impl/src/main/java/jakarta/faces/component/UIData.java
@@ -485,7 +485,11 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
      * @throws IllegalArgumentException if <code>rowIndex</code> is less than -1
      */
     public void setRowIndex(int rowIndex) {
-        if (isRowStatePreserved()) {
+        // Preserving the full per-row state needs the initial descendant state that markInitialState()
+        // captures; without it that path can neither save nor restore a row, and in particular never
+        // resets the descendant clientIds, so every row would render row 0's ids. Fall back to the
+        // per-row submitted-value state, which keeps the ids correct.
+        if (isRowStatePreserved() && _initialDescendantFullComponentState != null) {
             setRowIndexRowStatePreserved(rowIndex);
         } else {
             setRowIndexWithoutRowStatePreserved(rowIndex);


### PR DESCRIPTION
Closes #5927.

`UIRepeat.requiresRowIteration` now honors `SKIP_ITERATION` unconditionally, matching `UIData`. It is a literal revert of 42a30d96bd (JAVASERVERFACES-3833, 2015), whose own regression test — `Issue3837IT` in the TCK — passes without it under both state saving modes.

`UIData.setRowIndex` only takes the `rowStatePreserved` path when the initial descendant state that drives it is actually available, instead of silently leaving the descendant client IDs unmanaged.

`mvn -pl impl clean install`: 1253 tests, 0 failures.

Behavioural verification was done on the 5.0 branch against the Jakarta Faces TCK, where both changes are identical; the 5.0 TCK cannot run against a 4.0 API. With `-Dwebapp.partialStateSaving=false` the first change fixes `Issue1821IT`, `Issue2640IT`, `Issue2910IT`, `Issue1581IT` and `Issue5078IT`, and the second fixes `NestedRepeatRepeatRowStatePreservedIT` and `NestedTableTableRowStatePreservedIT`. No partial-state-saving regressions across 250 tests in the 12 TCK modules combining `ui:repeat` or `h:dataTable` with ajax.

Note `Issue3837IT` is `@Disabled` in the TCK per the accepted challenge in jakartaee/faces#1757, so a plain TCK run does not exercise the scenario the reverted check was added for; it has to be enabled explicitly.

🤖 Generated with Claude Opus 5
