### PR TITLE
Issue #5856: cut two per-component lookups out of the view build

### DIFF
--- a/impl/src/main/java/com/sun/faces/context/FacesContextImpl.java
+++ b/impl/src/main/java/com/sun/faces/context/FacesContextImpl.java
@@ -62,8 +62,6 @@ import jakarta.faces.render.RenderKitFactory;
 
 public class FacesContextImpl extends FacesContext {
 
-    private static final String POST_BACK_MARKER = FacesContextImpl.class.getName() + "_POST_BACK";
-
     // Queried by InjectionFacesContextFactory
     private static final ThreadLocal<FacesContext> DEFAULT_FACES_CONTEXT = new ThreadLocal<>();
 
@@ -87,6 +85,7 @@ public class FacesContextImpl extends FacesContext {
     private boolean renderResponse = false;
     private boolean responseComplete = false;
     private boolean validationFailed = false;
+    private Boolean postback;
     private Map<Object, Object> attributes;
     private List<String> resourceLibraryContracts;
     private PhaseId currentPhaseId;
@@ -182,7 +181,6 @@ public class FacesContextImpl extends FacesContext {
     public boolean isPostback() {
 
         assertNotReleased();
-        Boolean postback = (Boolean) getAttributes().get(POST_BACK_MARKER);
         if (postback == null) {
             RenderKit rk = getRenderKit();
             if (rk != null) {
@@ -193,7 +191,6 @@ public class FacesContextImpl extends FacesContext {
                 String rkId = vh.calculateRenderKitId(this);
                 postback = RenderKitUtils.getResponseStateManager(this, rkId).isPostback(this);
             }
-            getAttributes().put(POST_BACK_MARKER, postback);
         }
 
         return postback;
@@ -526,6 +523,7 @@ public class FacesContextImpl extends FacesContext {
         renderResponse = false;
         responseComplete = false;
         validationFailed = false;
+        postback = null;
         viewRoot = null;
         maxSeverity = null;
         application = null;

--- a/impl/src/main/java/com/sun/faces/renderkit/Attribute.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/Attribute.java
@@ -21,7 +21,7 @@ package com.sun.faces.renderkit;
  * @author asmirnov@exadel.com
  *
  */
-public class Attribute implements Comparable<Attribute> {
+public class Attribute {
 
     private final String name;
 
@@ -59,12 +59,6 @@ public class Attribute implements Comparable<Attribute> {
      */
     public String[] getEvents() {
         return events;
-    }
-
-    @Override
-    public int compareTo(Attribute o) {
-        // Compare attributes by name for a fast search in the RenderKitUtils methods.
-        return getName().compareTo(o.getName());
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/renderkit/AttributeManager.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/AttributeManager.java
@@ -19,7 +19,6 @@
 package com.sun.faces.renderkit;
 
 import static com.sun.faces.renderkit.Attribute.attr;
-import static com.sun.faces.util.CollectionsUtils.ar;
 
 import java.util.Map;
 
@@ -37,10 +36,14 @@ public class AttributeManager {
         OUTPUTLABEL, OUTPUTLINK, OUTPUTTEXT, PANELGRID, PANELGROUP,
         SELECTBOOLEANCHECKBOX, SELECTMANYCHECKBOX, SELECTMANYLISTBOX,
         SELECTMANYMENU, SELECTONELISTBOX, SELECTONEMENU, SELECTONERADIO,
-        OUTPUTBODY, OUTPUTDOCTYPE, OUTPUTHEAD;
+        OUTPUTBODY, OUTPUTHEAD;
     }
 
-    private static Map<Key, Attribute[]> ATTRIBUTE_LOOKUP = CollectionsUtils.<Key, Attribute[]>map()
+    private static Attributes ar(Attribute... attributes) {
+        return new Attributes(attributes);
+    }
+
+    private static Map<Key, Attributes> ATTRIBUTE_LOOKUP = CollectionsUtils.<Key, Attributes>map()
             .add(Key.COMMANDBUTTON,
                     ar(attr("accesskey"), attr("dir"), attr("lang"), attr("onblur", "blur"), attr("onchange", "change"), attr("ondblclick", "dblclick"),
                         attr("onfocus", "focus"), attr("onkeydown", "keydown"), attr("onkeypress", "keypress"), attr("onkeyup", "keyup"),
@@ -97,7 +100,7 @@ public class AttributeManager {
             .add(Key.MESSAGESMESSAGES,
                     ar(attr("dir"), attr("lang"), attr("role"), attr("style"), attr("title")))
             .add(Key.OUTCOMETARGETBUTTON,
-                    ar(attr("accesskey"), attr("dir"), attr("lang"), attr("onblur", "blur"), attr("onclick", "click"),
+                    ar(attr("accesskey"), attr("dir"), attr("lang"), attr("onblur", "blur"),
                             attr("ondblclick", "dblclick"), attr("onfocus", "focus"), attr("onkeydown", "keydown"), attr("onkeypress", "keypress"),
                             attr("onkeyup", "keyup"), attr("onmousedown", "mousedown"), attr("onmousemove", "mousemove"), attr("onmouseout", "mouseout"),
                             attr("onmouseover", "mouseover"), attr("onmouseup", "mouseup"), attr("role"), attr("style"), attr("tabindex"), attr("title")))
@@ -173,13 +176,11 @@ public class AttributeManager {
                             attr("onkeypress", "keypress"), attr("onkeyup", "keyup"), attr("onload", "load"), attr("onmousedown", "mousedown"),
                             attr("onmousemove", "mousemove"), attr("onmouseout", "mouseout"), attr("onmouseover", "mouseover"), attr("onmouseup", "mouseup"),
                             attr("onunload", "unload"), attr("role"), attr("style"), attr("title"), attr("xmlns")))
-            .add(Key.OUTPUTDOCTYPE,
-                    ar(attr("public"), attr("rootElement"), attr("system")))
             .add(Key.OUTPUTHEAD,
                     ar(attr("dir"), attr("lang"), attr("xmlns")))
             .fix();
 
-    public static Attribute[] getAttributes(Key key) {
+    public static Attributes getAttributes(Key key) {
         return ATTRIBUTE_LOOKUP.get(key);
     }
 }

--- a/impl/src/main/java/com/sun/faces/renderkit/Attributes.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/Attributes.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.renderkit;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * One renderer's pass-through attribute table, which can be asked for an attribute by name or iterated whole.
+ * <p>
+ * The by-name index is what lets the table be declared in any order: a lookup that searched the attributes instead
+ * would need them sorted by name, an invariant that cannot be checked at the declaration site and that fails silently
+ * -- an attribute declared out of order would simply stop rendering.
+ *
+ * @see AttributeManager#getAttributes(AttributeManager.Key)
+ */
+public final class Attributes implements Iterable<Attribute> {
+
+    private final Attribute[] attributes;
+
+    private final Map<String, Attribute> byName;
+
+    Attributes(Attribute... attributes) {
+        this.attributes = attributes;
+        byName = new HashMap<>(attributes.length, 1.0f);
+        for (Attribute attribute : attributes) {
+            byName.put(attribute.getName(), attribute);
+        }
+    }
+
+    /**
+     * Returns the attribute this table holds under the given name, or {@code null} when it holds none.
+     *
+     * @param name the attribute name to look up
+     * @return the named attribute, or {@code null}
+     */
+    public Attribute get(String name) {
+        return byName.get(name);
+    }
+
+    @Override
+    public Iterator<Attribute> iterator() {
+        return Arrays.asList(attributes).iterator();
+    }
+}

--- a/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
@@ -293,10 +293,10 @@ public class RenderKitUtils {
      * @param context the FacesContext for this request
      * @param writer writer the {@link jakarta.faces.context.ResponseWriter} to be used when writing the attributes
      * @param component the component
-     * @param attributes an array of attributes to be processed
+     * @param attributes the pass-through attributes to be processed
      * @throws IOException if an error occurs writing the attributes
      */
-    public static void renderPassThruAttributes(FacesContext context, ResponseWriter writer, UIComponent component, Attribute[] attributes) throws IOException {
+    public static void renderPassThruAttributes(FacesContext context, ResponseWriter writer, UIComponent component, Attributes attributes) throws IOException {
 
         assert null != component;
 
@@ -339,13 +339,13 @@ public class RenderKitUtils {
      * @param component the component
      * @param clientId the client id to be associated with any behaviors
      * @param incExec whether to include incExec parameter
-     * @param attributes an array of attributes to be processed
+     * @param attributes the pass-through attributes to be processed
      * @param defaultDomEvent the name of the default dom-level event of this component (e.g. "click", "change")
      * @param defaultComponentEvent the name of the default component-level event of this component (e.g. "action", "valueChange")
      * @throws IOException if an error occurs writing the attributes
      */
     public static void renderPassThruAttributes(FacesContext context, ResponseWriter writer, UIComponent component, String clientId, boolean incExec,
-            Attribute[] attributes, String defaultDomEvent, String defaultComponentEvent) throws IOException {
+            Attributes attributes, String defaultDomEvent, String defaultComponentEvent) throws IOException {
 
         Map<String, List<ClientBehavior>> behaviors = null;
         boolean hasValueChangeBehavior = false;
@@ -379,7 +379,7 @@ public class RenderKitUtils {
     }
 
     private static void renderPassThruAttributesInternal(FacesContext context, ResponseWriter writer, UIComponent component,
-            Attribute[] attributes, Map<String, List<ClientBehavior>> behaviors, String defaultDomEvent) throws IOException {
+            Attributes attributes, Map<String, List<ClientBehavior>> behaviors, String defaultDomEvent) throws IOException {
 
         assert null != writer;
         assert null != component;
@@ -680,18 +680,18 @@ public class RenderKitUtils {
 
     /**
      * <p>
-     * For each attribute in <code>setAttributes</code>, perform a binary search against the array of
-     * <code>knownAttributes</code> If a match is found and the value is not <code>null</code>, render the attribute.
+     * For each attribute in <code>setAttributes</code>, look it up among <code>knownAttributes</code>. If it is one of
+     * them and the value is not <code>null</code>, render the attribute.
      *
      * @param context the {@link FacesContext} of the current request
      * @param writer the current writer
      * @param component the component whose attributes we're rendering
-     * @param knownAttributes an array of pass-through attributes supported by this component
+     * @param knownAttributes the pass-through attributes supported by this component
      * @param setAttributes a <code>List</code> of attributes that have been set on the provided component
      * @param behaviors the non-null behaviors map for this request.
      * @throws IOException if an error occurs during the write
      */
-    private static void renderPassThruAttributesOptimized(FacesContext context, ResponseWriter writer, UIComponent component, Attribute[] knownAttributes,
+    private static void renderPassThruAttributesOptimized(FacesContext context, ResponseWriter writer, UIComponent component, Attributes knownAttributes,
             List<String> setAttributes, Map<String, List<ClientBehavior>> behaviors, String excludedEventAttribute) throws IOException {
 
         // We should only come in here if we've got zero or one behavior event
@@ -707,17 +707,12 @@ public class RenderKitUtils {
                 continue;
             }
 
-            // Note that this search can be optimized by switching from
-            // an array to a Map<String, Attribute>. This would change
-            // the search time from O(log n) to O(1).
-            int index = Arrays.binarySearch(knownAttributes, Attribute.attr(name));
-            if (index >= 0) {
+            Attribute knownAttribute = knownAttributes.get(name);
+            if (knownAttribute != null) {
                 Object value = attrMap.get(name);
                 if (value != null && shouldRenderAttribute(value)) {
 
-                    Attribute attr = knownAttributes[index];
-
-                    if (isBehaviorEventAttribute(attr, behaviorEventName)) {
+                    if (isBehaviorEventAttribute(knownAttribute, behaviorEventName)) {
                         addBehaviorEventListener(context, component, null, null, name, value, behaviorEventName, behaviorEventName, null, false, false,
                                 ResourceHandlerImpl.resolveCurrentNonce(context) != null, false);
 
@@ -780,12 +775,12 @@ public class RenderKitUtils {
      * @param context the {@link FacesContext} of the current request
      * @param writer the current writer
      * @param component the component whose attributes we're rendering
-     * @param knownAttributes an array of pass-through attributes supported by this component
+     * @param knownAttributes the pass-through attributes supported by this component
      * @param setAttributes a <code>List</code> of attributes that have been set on the provided component
      * @param behaviors the non-null behaviors map for this request.
      * @throws IOException if an error occurs during the write
      */
-    private static void renderPassThruAttributesUnoptimized(FacesContext context, ResponseWriter writer, UIComponent component, Attribute[] knownAttributes,
+    private static void renderPassThruAttributesUnoptimized(FacesContext context, ResponseWriter writer, UIComponent component, Attributes knownAttributes,
             List<String> setAttributes, Map<String, List<ClientBehavior>> behaviors, String excludedEventAttribute) throws IOException {
 
         boolean isXhtml = RIConstants.XHTML_CONTENT_TYPE.equals(writer.getContentType());

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/BaseTableRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/BaseTableRenderer.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.RenderKitUtils;
 import com.sun.faces.util.Util;
 
@@ -82,7 +82,7 @@ public abstract class BaseTableRenderer extends HtmlBasicRenderer {
      * @param attributes pass-through attributes that the component supports
      * @throws IOException if content cannot be written
      */
-    protected void renderTableStart(FacesContext context, UIComponent table, ResponseWriter writer, Attribute[] attributes) throws IOException {
+    protected void renderTableStart(FacesContext context, UIComponent table, ResponseWriter writer, Attributes attributes) throws IOException {
 
         writer.startElement("table", table);
         writeIdAttributeIfNecessary(context, writer, table);

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/BodyRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/BodyRenderer.java
@@ -19,7 +19,7 @@ package com.sun.faces.renderkit.html_basic;
 import java.io.IOException;
 import java.util.ListIterator;
 
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 
@@ -36,7 +36,7 @@ import jakarta.faces.context.ResponseWriter;
  */
 public class BodyRenderer extends HtmlBasicRenderer {
 
-    private static final Attribute[] BODY_ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.OUTPUTBODY);
+    private static final Attributes BODY_ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.OUTPUTBODY);
 
     @Override
     public void decode(FacesContext context, UIComponent component) {

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/ButtonRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/ButtonRenderer.java
@@ -34,7 +34,7 @@ import jakarta.faces.event.ActionEvent;
 
 import com.sun.faces.RIConstants;
 import com.sun.faces.application.resource.ResourceHandlerImpl;
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 
@@ -44,7 +44,7 @@ import com.sun.faces.renderkit.RenderKitUtils;
 
 public class ButtonRenderer extends HtmlBasicRenderer {
 
-    private static final Attribute[] ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.COMMANDBUTTON);
+    private static final Attributes ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.COMMANDBUTTON);
 
     // ---------------------------------------------------------- Public Methods
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/CheckboxRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/CheckboxRenderer.java
@@ -28,7 +28,7 @@ import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
 import jakarta.faces.convert.ConverterException;
 
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 
@@ -38,7 +38,7 @@ import com.sun.faces.renderkit.RenderKitUtils;
 
 public class CheckboxRenderer extends HtmlBasicInputRenderer {
 
-    private static final Attribute[] ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.SELECTBOOLEANCHECKBOX);
+    private static final Attributes ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.SELECTBOOLEANCHECKBOX);
 
     // ---------------------------------------------------------- Public Methods
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/CommandLinkRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/CommandLinkRenderer.java
@@ -33,7 +33,7 @@ import jakarta.faces.event.ActionEvent;
 
 import static com.sun.faces.util.Util.componentIsDisabled;
 import com.sun.faces.application.resource.ResourceHandlerImpl;
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 
@@ -44,7 +44,7 @@ import com.sun.faces.renderkit.RenderKitUtils;
 
 public class CommandLinkRenderer extends LinkRenderer {
 
-    private static final Attribute[] ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.COMMANDLINK);
+    private static final Attributes ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.COMMANDLINK);
 
     // ---------------------------------------------------------- Public Methods
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/DoctypeRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/DoctypeRenderer.java
@@ -18,9 +18,6 @@ package com.sun.faces.renderkit.html_basic;
 
 import java.io.IOException;
 
-import com.sun.faces.renderkit.Attribute;
-import com.sun.faces.renderkit.AttributeManager;
-
 import jakarta.faces.component.Doctype;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.context.FacesContext;
@@ -28,8 +25,6 @@ import jakarta.faces.context.ResponseWriter;
 import jakarta.faces.render.Renderer;
 
 public class DoctypeRenderer extends Renderer {
-
-    private static final Attribute[] DOCTYPE_ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.OUTPUTDOCTYPE);
 
     @Override
     public void decode(FacesContext context, UIComponent component) {

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/FormRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/FormRenderer.java
@@ -27,7 +27,7 @@ import java.util.logging.Level;
 
 import com.sun.faces.config.WebConfiguration;
 import com.sun.faces.config.WebConfiguration.BooleanWebContextInitParameter;
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 
@@ -44,7 +44,7 @@ import jakarta.faces.context.ResponseWriter;
  * */
 public class FormRenderer extends HtmlBasicRenderer {
 
-    private static final Attribute[] ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.FORMFORM);
+    private static final Attributes ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.FORMFORM);
 
     private boolean writeStateAtEnd;
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/GridRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/GridRenderer.java
@@ -19,7 +19,7 @@ package com.sun.faces.renderkit.html_basic;
 import java.io.IOException;
 import java.util.Iterator;
 
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 
 import jakarta.faces.component.UIComponent;
@@ -33,7 +33,7 @@ import jakarta.faces.context.ResponseWriter;
 
 public class GridRenderer extends BaseTableRenderer {
 
-    private static final Attribute[] ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.PANELGRID);
+    private static final Attributes ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.PANELGRID);
 
     // ---------------------------------------------------------- Public Methods
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/GroupRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/GroupRenderer.java
@@ -19,7 +19,7 @@ package com.sun.faces.renderkit.html_basic;
 import java.io.IOException;
 import java.util.Iterator;
 
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 
@@ -34,7 +34,7 @@ import jakarta.faces.context.ResponseWriter;
  */
 public class GroupRenderer extends HtmlBasicRenderer {
 
-    private static final Attribute[] ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.PANELGROUP);
+    private static final Attributes ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.PANELGROUP);
     // ---------------------------------------------------------- Public Methods
 
     @Override

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/HeadRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/HeadRenderer.java
@@ -18,7 +18,7 @@ package com.sun.faces.renderkit.html_basic;
 
 import java.io.IOException;
 
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 
@@ -37,7 +37,7 @@ import jakarta.faces.render.Renderer;
  */
 public class HeadRenderer extends Renderer {
 
-    private static final Attribute[] HEAD_ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.OUTPUTHEAD);
+    private static final Attributes HEAD_ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.OUTPUTHEAD);
 
     @Override
     public void decode(FacesContext context, UIComponent component) {

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/ImageRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/ImageRenderer.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.util.logging.Level;
 
 import com.sun.faces.RIConstants;
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 
@@ -37,7 +37,7 @@ import jakarta.faces.context.ResponseWriter;
 
 public class ImageRenderer extends HtmlBasicRenderer {
 
-    private static final Attribute[] ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.GRAPHICIMAGE);
+    private static final Attributes ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.GRAPHICIMAGE);
 
     // ---------------------------------------------------------- Public Methods
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/LabelRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/LabelRenderer.java
@@ -23,7 +23,7 @@ import java.util.EnumSet;
 import java.util.Set;
 import java.util.logging.Level;
 
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 
@@ -44,7 +44,7 @@ import jakarta.faces.context.ResponseWriter;
  */
 public class LabelRenderer extends HtmlBasicInputRenderer {
 
-    private static final Attribute[] ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.OUTPUTLABEL);
+    private static final Attributes ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.OUTPUTLABEL);
 
     private static final String RENDER_END_ELEMENT = "com.sun.faces.RENDER_END_ELEMENT";
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/LinkRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/LinkRenderer.java
@@ -21,7 +21,7 @@ package com.sun.faces.renderkit.html_basic;
 import java.io.IOException;
 import java.util.logging.Level;
 
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 
@@ -38,7 +38,7 @@ import jakarta.faces.context.ResponseWriter;
 
 public abstract class LinkRenderer extends HtmlBasicRenderer {
 
-    private static final Attribute[] ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.COMMANDLINK);
+    private static final Attributes ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.COMMANDLINK);
 
     // ------------------------------------------------------- Protected Methods
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/MenuRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/MenuRenderer.java
@@ -82,7 +82,7 @@ import jakarta.faces.model.SelectItemGroup;
 
 import com.sun.faces.RIConstants;
 import com.sun.faces.io.FastStringWriter;
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 import com.sun.faces.renderkit.SelectItemsIterator;
@@ -97,7 +97,7 @@ import com.sun.faces.util.Util;
  */
 public class MenuRenderer extends HtmlBasicInputRenderer {
 
-    private static final Attribute[] ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.SELECTMANYMENU);
+    private static final Attributes ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.SELECTMANYMENU);
 
     // ---------------------------------------------------------- Public Methods
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/MessagesRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/MessagesRenderer.java
@@ -21,7 +21,7 @@ package com.sun.faces.renderkit.html_basic;
 import java.io.IOException;
 import java.util.Iterator;
 
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 
@@ -42,7 +42,7 @@ import jakarta.faces.context.ResponseWriter;
 
 public class MessagesRenderer extends HtmlBasicRenderer {
 
-    private static final Attribute[] ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.MESSAGESMESSAGES);
+    private static final Attributes ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.MESSAGESMESSAGES);
 
     // ---------------------------------------------------------- Public Methods
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutcomeTargetButtonRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutcomeTargetButtonRenderer.java
@@ -26,7 +26,7 @@ import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
 
 import com.sun.faces.RIConstants;
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 import com.sun.faces.util.MessageUtils;
@@ -34,7 +34,7 @@ import com.sun.faces.util.Util;
 
 public class OutcomeTargetButtonRenderer extends OutcomeTargetRenderer {
 
-    private static final Attribute[] ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.OUTCOMETARGETBUTTON);
+    private static final Attributes ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.OUTCOMETARGETBUTTON);
 
     // --------------------------------------------------- Methods from Renderer
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutcomeTargetLinkRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutcomeTargetLinkRenderer.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 import com.sun.faces.util.MessageUtils;
@@ -35,7 +35,7 @@ import jakarta.faces.context.ResponseWriter;
 
 public class OutcomeTargetLinkRenderer extends OutcomeTargetRenderer {
 
-    private static final Attribute[] ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.OUTCOMETARGETLINK);
+    private static final Attributes ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.OUTCOMETARGETLINK);
 
     private static final String NO_NAV_CASE = OutcomeTargetLinkRenderer.class.getName() + "_NO_NAV_CASE";
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutcomeTargetRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutcomeTargetRenderer.java
@@ -25,7 +25,7 @@ import java.util.logging.Level;
 
 import com.sun.faces.application.NavigationHandlerImpl;
 import com.sun.faces.flow.FlowHandlerImpl;
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.RenderKitUtils;
 import com.sun.faces.util.Util;
 
@@ -49,7 +49,7 @@ public abstract class OutcomeTargetRenderer extends HtmlBasicRenderer {
 
     // ------------------------------------------------------- Protected Methods
 
-    protected void renderPassThruAttributes(FacesContext ctx, ResponseWriter writer, UIComponent component, Attribute[] attributes, List excludedAttributes)
+    protected void renderPassThruAttributes(FacesContext ctx, ResponseWriter writer, UIComponent component, Attributes attributes, List excludedAttributes)
             throws IOException {
         RenderKitUtils.renderPassThruAttributes(ctx, writer, component, attributes);
         RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, component, excludedAttributes);

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutputLinkRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/OutputLinkRenderer.java
@@ -25,7 +25,7 @@ import static java.util.logging.Level.FINE;
 import java.io.IOException;
 import java.net.URLEncoder;
 
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 
@@ -43,7 +43,7 @@ import jakarta.faces.context.ResponseWriter;
  */
 public class OutputLinkRenderer extends LinkRenderer {
 
-    private static final Attribute[] ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.OUTPUTLINK);
+    private static final Attributes ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.OUTPUTLINK);
 
     // ---------------------------------------------------------- Public Methods
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/PassthroughRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/PassthroughRenderer.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
 
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 
@@ -34,7 +34,7 @@ public class PassthroughRenderer extends HtmlBasicRenderer {
 
 // We are purposely piggy backing off the PANELGROUP attributes since they are
 // identical for this renderer.
-    private static final Attribute[] ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.PANELGROUP);
+    private static final Attributes ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.PANELGROUP);
 
     @Override
     public void encodeBegin(FacesContext context, UIComponent component) throws IOException {

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/RadioRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/RadioRenderer.java
@@ -49,7 +49,7 @@ import jakarta.faces.event.PostAddToViewEvent;
 import jakarta.faces.model.SelectItem;
 
 import com.sun.faces.RIConstants;
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 import com.sun.faces.renderkit.SelectItemsIterator;
@@ -63,7 +63,7 @@ import com.sun.faces.util.Util;
 @ListenerFor(systemEventClass = PostAddToViewEvent.class)
 public class RadioRenderer extends SelectManyCheckboxListRenderer implements ComponentSystemEventListener {
 
-    private static final Attribute[] ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.SELECTONERADIO);
+    private static final Attributes ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.SELECTONERADIO);
 
     // -------------------------------------------------------------------------------------------------- Public Methods
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/SecretRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/SecretRenderer.java
@@ -25,7 +25,7 @@ import jakarta.faces.component.html.HtmlInputSecret;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
 
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 
@@ -35,7 +35,7 @@ import com.sun.faces.renderkit.RenderKitUtils;
 
 public class SecretRenderer extends HtmlBasicInputRenderer {
 
-    private static final Attribute[] ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.INPUTSECRET);
+    private static final Attributes ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.INPUTSECRET);
 
     // ---------------------------------------------------------- Public Methods
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/SelectManyCheckboxListRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/SelectManyCheckboxListRenderer.java
@@ -34,7 +34,7 @@ import jakarta.faces.convert.Converter;
 import jakarta.faces.model.SelectItem;
 import jakarta.faces.model.SelectItemGroup;
 
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 import com.sun.faces.util.RequestStateManager;
@@ -46,7 +46,7 @@ import com.sun.faces.util.RequestStateManager;
 
 public class SelectManyCheckboxListRenderer extends MenuRenderer {
 
-    private static final Attribute[] ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.SELECTMANYCHECKBOX);
+    private static final Attributes ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.SELECTMANYCHECKBOX);
 
     // ---------------------------------------------------------- Public Methods
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/TableRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/TableRenderer.java
@@ -23,7 +23,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 import com.sun.faces.util.Util;
@@ -44,7 +44,7 @@ import jakarta.faces.context.ResponseWriter;
 
 public class TableRenderer extends BaseTableRenderer {
 
-    private static final Attribute[] ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.DATATABLE);
+    private static final Attributes ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.DATATABLE);
 
     // ---------------------------------------------------------- Public Methods
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/TextRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/TextRenderer.java
@@ -37,7 +37,7 @@ import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
 
 import com.sun.faces.config.WebConfiguration;
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 
@@ -47,9 +47,9 @@ import com.sun.faces.renderkit.RenderKitUtils;
  */
 public class TextRenderer extends HtmlBasicInputRenderer {
 
-    private static final Attribute[] INPUTTEXT_ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.INPUTTEXT);
-    private static final Attribute[] INPUTFILE_ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.INPUTFILE);
-    private static final Attribute[] OUTPUT_ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.OUTPUTTEXT);
+    private static final Attributes INPUTTEXT_ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.INPUTTEXT);
+    private static final Attributes INPUTFILE_ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.INPUTFILE);
+    private static final Attributes OUTPUT_ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.OUTPUTTEXT);
 
     private static final Map<String, String> RECOMMENDED_COMPONENTS_BY_DISCOMMENDED_TYPES = mapRecommendedComponentsByDiscommendedTypes();
 
@@ -145,7 +145,7 @@ public class TextRenderer extends HtmlBasicInputRenderer {
             }
 
             // style is rendered as a passthru attribute
-            Attribute[] attributes = component instanceof HtmlInputFile ? INPUTFILE_ATTRIBUTES : INPUTTEXT_ATTRIBUTES;
+            Attributes attributes = component instanceof HtmlInputFile ? INPUTFILE_ATTRIBUTES : INPUTTEXT_ATTRIBUTES;
             RenderKitUtils.renderPassThruAttributes(context, writer, component, null, false, attributes, "change", "valueChange");
             RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, component);
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/TextareaRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/TextareaRenderer.java
@@ -24,7 +24,7 @@ import jakarta.faces.component.UIComponent;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
 
-import com.sun.faces.renderkit.Attribute;
+import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
 
@@ -34,7 +34,7 @@ import com.sun.faces.renderkit.RenderKitUtils;
 
 public class TextareaRenderer extends HtmlBasicInputRenderer {
 
-    private static final Attribute[] ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.INPUTTEXTAREA);
+    private static final Attributes ATTRIBUTES = AttributeManager.getAttributes(AttributeManager.Key.INPUTTEXTAREA);
 
     // ---------------------------------------------------------- Public Methods
 

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -61,7 +61,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -112,24 +111,22 @@ public abstract class UIComponentBase extends UIComponent {
     private static final int CHILD_STATE = 1;
 
     /**
-     * This class's <code>PropertyDescriptor</code>s (keyed by property name) within the application-scoped descriptors
-     * cache &mdash; the {@code Map<Class, Map<String, PropertyDescriptor>>} kept in the application map (see
-     * {@link #populateDescriptorsMapIfNecessary}).
+     * This class's <code>PropertyDescriptor</code>s (keyed by property name), held per class in the
+     * {@link #COMPONENT_METADATA} cache.
      */
     private Map<String, PropertyDescriptor> propertyDescriptorMap;
 
     /**
-     * This class's read methods (keyed by property name) within the application-scoped read-methods cache &mdash; the
-     * {@code Map<Class, Map<String, Method>>} kept in the application map alongside the descriptors cache (see
-     * {@link #populateDescriptorsMapIfNecessary}). It holds the access-suppressed read {@link Method}s strongly, which
-     * keeps the suppression durable (a {@link PropertyDescriptor}'s read method is handed back via a soft reference that
+     * This class's access-suppressed read methods (keyed by property name), held strongly per class in the
+     * {@link #COMPONENT_METADATA} cache. Holding the suppressed read {@link Method}s strongly keeps the suppression
+     * durable (a {@link PropertyDescriptor}'s read method is handed back via a soft reference that
      * can be regenerated) and lets the hot attribute-read path skip re-suppressing and re-caching it per component.
      */
     private Map<String, Method> readMethodMap;
 
     /**
      * This class's write methods (keyed by property name), the write-side counterpart of {@link #readMethodMap} kept in
-     * its own application-scoped cache (see {@link #populateDescriptorsMapIfNecessary}). Holds the access-suppressed
+     * the same {@link #COMPONENT_METADATA} cache. Holds the access-suppressed
      * setter {@link Method}s strongly so the {@code getAttributes().put} property-write path (Facelets applying a
      * literal-text {@code ValueExpression} or a non-property literal during buildView) skips the per-put access check
      * and the soft-reference setter rediscovery.
@@ -3558,12 +3555,10 @@ public abstract class UIComponentBase extends UIComponent {
 
     }
 
-    private static final String COMPONENT_METADATA_MAP_KEY = "com.sun.faces.component.COMPONENT_METADATA_MAP";
-
     /**
-     * Application-scoped per-class reflective metadata, composed into a single value so the per-construction
-     * {@link #populateDescriptorsMapIfNecessary} does one application-map lookup and one per-class lookup rather than
-     * three of each. The three maps are always produced and cached together, so bundling them is behaviour-equivalent.
+     * Per-class reflective metadata, composed into a single value so the per-construction
+     * {@link #populateDescriptorsMapIfNecessary} resolves all three maps in one lookup rather than three. The three
+     * maps are always produced and cached together, so bundling them is behaviour-equivalent.
      */
     private static final class ComponentMetadata {
         private final Map<String, PropertyDescriptor> propertyDescriptors;
@@ -3577,77 +3572,76 @@ public abstract class UIComponentBase extends UIComponent {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private void populateDescriptorsMapIfNecessary() {
-        FacesContext facesContext = FacesContext.getCurrentInstance();
-        Class<?> clazz = getClass();
-        Map<Class<?>, ComponentMetadata> metadataByClass = null;
-
-        /*
-         * If we can find a valid FacesContext we are going to use it to get access to the metadata cache.
-         */
-        if (facesContext != null && facesContext.getExternalContext() != null && facesContext.getExternalContext().getApplicationMap() != null) {
-
-            Map<String, Object> applicationMap = facesContext.getExternalContext().getApplicationMap();
-
-            metadataByClass = (Map<Class<?>, ComponentMetadata>) applicationMap.computeIfAbsent(
-                    COMPONENT_METADATA_MAP_KEY, k -> new ConcurrentHashMap<>());
-
-            ComponentMetadata metadata = metadataByClass.get(clazz);
-            if (metadata != null) {
-                propertyDescriptorMap = metadata.propertyDescriptors;
-                readMethodMap = metadata.readMethods;
-                writeMethodMap = metadata.writeMethods;
-                return;
-            }
+    /**
+     * The reflective metadata of every component class constructed so far. A {@link ClassValue} attaches each entry to
+     * the {@link Class} it describes, so an entry -- which strongly holds that class's accessor {@link Method}s -- stays
+     * reachable exactly as long as the class does, and resolving one costs neither a {@link FacesContext} nor a lookup
+     * in a map keyed by class. Every component construction resolves it, so nothing here may depend on request state.
+     */
+    private static final ClassValue<ComponentMetadata> COMPONENT_METADATA = new ClassValue<>() {
+        @Override
+        protected ComponentMetadata computeValue(Class<?> componentClass) {
+            return createComponentMetadata(componentClass);
         }
+    };
 
-        // We did not find the metadata for this class so we are now going to load it.
-
-        PropertyDescriptor propertyDescriptors[] = getPropertyDescriptors();
-        if (propertyDescriptors != null) {
-            propertyDescriptorMap = new HashMap<>(propertyDescriptors.length, 1.0f);
-            readMethodMap = new HashMap<>(propertyDescriptors.length, 1.0f);
-            writeMethodMap = new HashMap<>(propertyDescriptors.length, 1.0f);
-            for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
-                // Suppress the access check once, here, and strongly cache the accessor per class so the
-                // suppression stays durable (PropertyDescriptor.getReadMethod/getWriteMethod hand it back via a soft
-                // reference that can be regenerated) and the hot attribute-read/write paths never re-suppress or
-                // re-cache it.
-                Method readMethod = propertyDescriptor.getReadMethod();
-                if (readMethod != null) {
-                    AttributesMap.suppressAccessCheck(readMethod);
-                    readMethodMap.put(propertyDescriptor.getName(), readMethod);
-                }
-                Method writeMethod = propertyDescriptor.getWriteMethod();
-                if (writeMethod != null) {
-                    AttributesMap.suppressAccessCheck(writeMethod);
-                    writeMethodMap.put(propertyDescriptor.getName(), writeMethod);
-                }
-                propertyDescriptorMap.put(propertyDescriptor.getName(), propertyDescriptor);
-            }
-
-            if (LOGGER.isLoggable(FINE)) {
-                LOGGER.log(FINE, "fine.component.populating_descriptor_map", new Object[] { clazz, currentThread().getName() });
-            }
-
-            if (metadataByClass != null) {
-                metadataByClass.putIfAbsent(clazz, new ComponentMetadata(propertyDescriptorMap, readMethodMap, writeMethodMap));
-            }
+    private void populateDescriptorsMapIfNecessary() {
+        ComponentMetadata metadata = COMPONENT_METADATA.get(getClass());
+        if (metadata != null) {
+            propertyDescriptorMap = metadata.propertyDescriptors;
+            readMethodMap = metadata.readMethods;
+            writeMethodMap = metadata.writeMethods;
         }
     }
 
     /**
+     * Introspects {@code componentClass} into its {@link ComponentMetadata}, or {@code null} when it exposes no
+     * property descriptors at all.
+     */
+    private static ComponentMetadata createComponentMetadata(Class<?> componentClass) {
+        PropertyDescriptor[] propertyDescriptors = getPropertyDescriptors(componentClass);
+        if (propertyDescriptors == null) {
+            return null;
+        }
+
+        Map<String, PropertyDescriptor> propertyDescriptorMap = new HashMap<>(propertyDescriptors.length, 1.0f);
+        Map<String, Method> readMethodMap = new HashMap<>(propertyDescriptors.length, 1.0f);
+        Map<String, Method> writeMethodMap = new HashMap<>(propertyDescriptors.length, 1.0f);
+        for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
+            // Suppress the access check once, here, and strongly cache the accessor per class so the
+            // suppression stays durable (PropertyDescriptor.getReadMethod/getWriteMethod hand it back via a soft
+            // reference that can be regenerated) and the hot attribute-read/write paths never re-suppress or
+            // re-cache it.
+            Method readMethod = propertyDescriptor.getReadMethod();
+            if (readMethod != null) {
+                AttributesMap.suppressAccessCheck(readMethod);
+                readMethodMap.put(propertyDescriptor.getName(), readMethod);
+            }
+            Method writeMethod = propertyDescriptor.getWriteMethod();
+            if (writeMethod != null) {
+                AttributesMap.suppressAccessCheck(writeMethod);
+                writeMethodMap.put(propertyDescriptor.getName(), writeMethod);
+            }
+            propertyDescriptorMap.put(propertyDescriptor.getName(), propertyDescriptor);
+        }
+
+        if (LOGGER.isLoggable(FINE)) {
+            LOGGER.log(FINE, "fine.component.populating_descriptor_map", new Object[] { componentClass, currentThread().getName() });
+        }
+
+        return new ComponentMetadata(propertyDescriptorMap, readMethodMap, writeMethodMap);
+    }
+    /**
      * <p>
-     * Return an array of <code>PropertyDescriptors</code> for this {@link UIComponent}'s implementation class. If no
+     * Return an array of <code>PropertyDescriptors</code> for the given {@link UIComponent} implementation class. If no
      * descriptors can be identified, a zero-length array will be returned.
      * </p>
      *
      * @throws FacesException if an introspection exception occurs
      */
-    private PropertyDescriptor[] getPropertyDescriptors() {
+    private static PropertyDescriptor[] getPropertyDescriptors(Class<?> componentClass) {
         try {
-            return getBeanInfo(getClass()).getPropertyDescriptors();
+            return getBeanInfo(componentClass).getPropertyDescriptors();
         } catch (IntrospectionException e) {
             throw new FacesException(e);
         }

--- a/impl/src/test/java/com/sun/faces/context/FacesContextImplPostbackTest.java
+++ b/impl/src/test/java/com/sun/faces/context/FacesContextImplPostbackTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.context;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.faces.FactoryFinder;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.render.RenderKitFactory;
+
+import com.sun.faces.lifecycle.LifecycleImpl;
+import com.sun.faces.mock.MockHttpServletRequest;
+import com.sun.faces.mock.MockHttpServletResponse;
+import com.sun.faces.mock.MockRenderKit;
+import com.sun.faces.mock.MockServletContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Whether a request is a postback is asked once per component tag while a view is being built, so the answer is
+ * resolved once and reused for the lifetime of the {@link FacesContext}. It therefore has to stay stable even when the
+ * request state it was derived from changes afterwards.
+ */
+class FacesContextImplPostbackTest {
+
+    private MockHttpServletRequest request;
+    private FacesContextImpl facesContext;
+
+    @BeforeEach
+    void setUp() {
+        FactoryFinder.setFactory(FactoryFinder.RENDER_KIT_FACTORY, "com.sun.faces.mock.MockRenderKitFactory");
+        request = new MockHttpServletRequest();
+        facesContext = new FacesContextImpl(
+                new ExternalContextImpl(new MockServletContext(), request, new MockHttpServletResponse()),
+                new LifecycleImpl());
+
+        RenderKitFactory renderKitFactory = (RenderKitFactory) FactoryFinder.getFactory(FactoryFinder.RENDER_KIT_FACTORY);
+        try {
+            renderKitFactory.addRenderKit(RenderKitFactory.HTML_BASIC_RENDER_KIT, new MockRenderKit());
+        } catch (IllegalArgumentException alreadyRegistered) {
+            // The factory outlives a single test and rejects a second registration under the same id.
+        }
+
+        UIViewRoot viewRoot = new UIViewRoot();
+        viewRoot.setRenderKitId(RenderKitFactory.HTML_BASIC_RENDER_KIT);
+        facesContext.setViewRoot(viewRoot);
+    }
+
+    @Test
+    void theResolvedAnswerSurvivesLaterChangesToTheRequest() {
+        assertFalse(facesContext.isPostback());
+
+        // MockResponseStateManager inherits ResponseStateManager.isPostback, which reports any request carrying
+        // parameters as a postback -- so a request that gains one would flip the unresolved answer.
+        request.addParameter("jakarta.faces.ViewState", "stateless");
+
+        assertFalse(facesContext.isPostback());
+    }
+
+    @Test
+    void aRequestCarryingStateIsAPostback() {
+        request.addParameter("jakarta.faces.ViewState", "stateless");
+
+        assertTrue(facesContext.isPostback());
+    }
+}

--- a/impl/src/test/java/com/sun/faces/renderkit/AttributesLookupTest.java
+++ b/impl/src/test/java/com/sun/faces/renderkit/AttributesLookupTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.renderkit;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.sun.faces.renderkit.AttributeManager.Key;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Rendering decides whether to emit a component's attribute by asking the renderer's table for it by name, so an
+ * attribute the table cannot find under its own name is an attribute that silently stops rendering. These tables are
+ * hand-maintained literals of up to 27 entries, and the lookup is what frees them from having to be declared in any
+ * particular order.
+ */
+class AttributesLookupTest {
+
+    @Test
+    void everyDeclaredAttributeIsFoundUnderItsOwnName() {
+        for (Key key : Key.values()) {
+            Attributes attributes = AttributeManager.getAttributes(key);
+            assertNotNull(attributes, () -> "no table registered for " + key);
+
+            Set<String> names = new HashSet<>();
+            for (Attribute attribute : attributes) {
+                assertSame(attribute, attributes.get(attribute.getName()), () -> key + " lost " + attribute.getName());
+                assertTrue(names.add(attribute.getName()), () -> key + " declares " + attribute.getName() + " twice");
+            }
+            assertTrue(!names.isEmpty(), () -> key + " declares no attributes");
+        }
+    }
+
+    @Test
+    void anAttributeTheTableDoesNotDeclareIsNotFound() {
+        Attributes attributes = AttributeManager.getAttributes(Key.PANELGROUP);
+
+        assertNull(attributes.get("value"));
+        assertNull(attributes.get("styleClass"));
+        assertNull(attributes.get(""));
+    }
+
+    /**
+     * A renderer that composes an attribute's value itself must not also declare it as a pass-through attribute, or the
+     * attribute is written twice on the same element. Both button renderers compose {@code onclick} -- they append the
+     * navigation script to the author's own handler -- so neither table may declare it.
+     */
+    @Test
+    void anAttributeTheRendererComposesIsNotAlsoAPassThroughAttribute() {
+        assertNull(AttributeManager.getAttributes(Key.COMMANDBUTTON).get("onclick"));
+        assertNull(AttributeManager.getAttributes(Key.OUTCOMETARGETBUTTON).get("onclick"));
+    }
+
+    /**
+     * Declaration order is not part of the contract, so a table whose attributes are out of alphabetical order still
+     * resolves every one of them.
+     */
+    @Test
+    void aTableDeclaredOutOfOrderStillResolves() {
+        Attributes attributes = new Attributes(Attribute.attr("title"), Attribute.attr("dir"), Attribute.attr("onclick", "click"));
+
+        assertNotNull(attributes.get("title"));
+        assertNotNull(attributes.get("dir"));
+        assertNotNull(attributes.get("onclick"));
+        assertNull(attributes.get("lang"));
+    }
+}

--- a/impl/src/test/java/jakarta/faces/component/UIComponentBaseComponentMetadataTest.java
+++ b/impl/src/test/java/jakarta/faces/component/UIComponentBaseComponentMetadataTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.lang.reflect.Method;
+
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Every component construction resolves the reflective property metadata of its class, so that lookup is keyed on the
+ * class alone: it is shared by all instances of a class, kept apart between classes, and available without a current
+ * {@link FacesContext} - a component may be constructed outside a request, and its property attributes have to read and
+ * write through to the bean properties there too.
+ */
+class UIComponentBaseComponentMetadataTest {
+
+    @Test
+    void metadataIsSharedPerClassAndDistinctBetweenClasses() {
+        UIPanel firstPanel = new UIPanel();
+        UIPanel secondPanel = new UIPanel();
+        UIOutput output = new UIOutput();
+
+        assertSame(firstPanel.getDescriptorMap(), secondPanel.getDescriptorMap());
+        assertSame(firstPanel.getReadMethodMap(), secondPanel.getReadMethodMap());
+        assertSame(firstPanel.getWriteMethodMap(), secondPanel.getWriteMethodMap());
+        assertNotSame(firstPanel.getDescriptorMap(), output.getDescriptorMap());
+    }
+
+    @Test
+    void propertyAttributesWorkWithoutACurrentFacesContext() throws Exception {
+        Method setCurrentInstance = FacesContext.class.getDeclaredMethod("setCurrentInstance", FacesContext.class);
+        setCurrentInstance.setAccessible(true);
+        setCurrentInstance.invoke(null, (FacesContext) null);
+
+        UIOutput output = new UIOutput();
+        output.getAttributes().put("rendered", false);
+
+        assertEquals(false, output.getAttributes().get("rendered"));
+        assertEquals(false, output.isRendered());
+    }
+}


### PR DESCRIPTION
Continues the view build time work of #5856, this time on two questions the build asked per component whose answers do not depend on the component, plus the structural cleanup that fell out of chasing them.

## Cut two per-component lookups out of the view build

`FacesContext.isPostback()` memoized its answer in the context attributes map, so every call was a string-keyed map lookup — and `ComponentSupport.isBuildingNewComponentTree` asks it once per text or instruction node applied. It is a field now.

`UIComponentBase` reached a class's reflective property metadata through the application map on *every construction*: a ThreadLocal read, two `getApplicationMap` hops, a `ServletContext` attribute lookup and a per-class lookup, all to obtain data that is a pure function of the class. A static `ClassValue` holds it instead, so an entry lives on the `Class` it describes and dies with that class's loader, and constructing a component no longer needs a `FacesContext` at all.

**Measured on 5.0, where `test/perf` lives** (4.0 has no perf suite, so these numbers cannot be reproduced on this branch): Tomcat, the flat views, average of 1000 requests, median of 14 interleaved runs per arm.

| cell | before | after | Δ |
|---|--:|--:|--:|
| flat-build RESTORE_VIEW | 827 | 793 | −4.1% |
| flat-table-nofacets RESTORE_VIEW | 614 | 588 | −4.2% |
| flat-readonly RENDER_RESPONSE | 1338 | 1283 | −4.1% |
| flat suite total | 11349 | 11160 | −1.7% |

No scenario regressed. This is near the bench's noise floor, so it rests on arms alternated across 14 reps plus agreement between two independent rounds and both metrics (`avg_us` and `min_us`); the per-cell figures below ~2% in that run are not decidable and are not quoted here.

## Index the pass-through attribute tables by name

`RenderKitUtils` searched a renderer's `Attribute[]` with `Arrays.binarySearch` for every attribute a component had set, which requires the hand-written tables in `AttributeManager` to be sorted by name. Nothing checks that, and its failure is silent: an attribute declared out of order simply stops rendering, with no exception and no log. `AttributeManager` now hands out an `Attributes` table that answers by name, so declaration order carries no meaning. `Attribute` loses `Comparable`, which existed only to feed that search.

**This is not a speed change.** Keying the tables measures as no gain on the flat views, whose components set one or two attributes each against tables of 3 to 27 entries, where the search was already only a handful of comparisons. Components setting many attributes each may well gain, but the suite has no such view and that shape was not measured. The change earns its place on the invariant, not on speed.

The switch itself was hinted in the code: `renderPassThruAttributesOptimized` carried a standing note that *"this search can be optimized by switching from an array to a `Map<String, Attribute>`. This would change the search time from O(log n) to O(1)."* That comment is now resolved and removed — but its premise turned out not to hold, which is why the paragraph above says what it says: the switch is worth making for the invariant, not for the search time. The method's javadoc, which also described the binary search, is updated to match.

A second hint of the same kind is deliberately left in place: the suggestion of an event-name-to-`Attribute` inverse lookup for the behavior fallback loop further down. That loop only runs when a behavior was not already emitted inline, no scenario measured here exercises it, and contradicting it without a measurement would just be guessing.

## One output change (not a behaviour change)

Saying what a table holds also settles which attributes belong in one: a table holds the properties a renderer emits verbatim, while the ones it gives meaning to are its own to write. `onclick` on `OUTCOMETARGETBUTTON` had drifted across that line. `OutcomeTargetButtonRenderer` composes `onclick` by appending the navigation script to the author's handler, and the table declared `onclick` too, so the generic pass wrote the author's raw value **a second time onto the same element** — whenever `onclick` was set, no client behavior was attached, and no CSP nonce was in play. `COMMANDBUTTON` already omits `onclick` because `ButtonRenderer` composes it the same way; this table omits it now too, and a test pins the constraint for both.

Rendered behaviour was already correct: HTML parsing keeps the first of two identical attributes and drops the second, and the composed value is written first, so browsers were using it. What the duplicate cost was valid markup — a duplicate attribute is a parse error, and not well-formed at all under the XHTML content type. So this changes the emitted bytes for `h:outcomeTargetButton` with an author-set `onclick`, and nothing else; the byte-identical guarantee below covers everything except that element.

This is not a regression, and the fix restores what the original code intended. `AttributeManager` was generated from `standard-html-renderkit.xml` until #4441 removed the code generation, and the generator carried exactly this rule: `if (key.contains("Button") && "onclick".equals(aBean.getPropertyName())) { aBean.setPassThrough(false); }`. So excluding `onclick` for button renderers was always the intent, precisely because those renderers compose it. But the exclusion sat at the end of the per-property loop, *outside* the guard that emits the attribute, and it mutated a `PropertyBean` shared across components — so it only took effect from the second button-keyed component onward, the first one having already had `onclick` written before the flag was cleared. `OutcomeTargetButton` was that first component and kept `onclick`; `CommandButton`, reached later, got the exclusion. De-generating the file froze that artifact into the hand-written table, and walking every commit that has touched it since shows the pair unchanged from then until this PR — so `h:outcomeTargetButton` has emitted the duplicate for as long as the generated list has existed.

`DoctypeRenderer`'s unused `DOCTYPE_ATTRIBUTES` field and the `OUTPUTDOCTYPE` table behind it are dropped as well — nothing rendered a doctype through them, and `DoctypeRenderer` writes those attributes itself from the `Doctype` component. Note master had already deleted that field, so this brings 4.0 and 4.1 into line with it.

## Verification

- 1261 unit tests green on this branch; four new test classes covering the metadata cache, the `isPostback` resolve-once contract, the by-name table lookup (including that an out-of-order table still resolves), and the composed-attribute constraint.
- Full Faces TCK green on the equivalent 5.0 change.
- All 39 `test/perf` pages render byte-identically before/after on 5.0, for everything except the `onclick` fix above.

## What is left

Closes nothing on its own — #5856 stays open. Against MyFaces 5.0.0-SNAPSHOT the flat family now sits at `flat-passthru` render 1.36x, `flat-table-facets` / `flat-table-nofacets` restore 1.43x / 1.38x and `flat-wide` render 1.18x, with every other flat cell at or below parity. Two candidates are identified but unstarted: `UIData.getRowIndex()` resolves through the state helper on every `getClientId()` (~31µs/req on the table restore cells, but it touches saved state), and the per-node build gate in `ComponentSupport.isBuildingNewComponentTree` could be hoisted onto a per-build object the way MyFaces does with `FaceletCompositionContextImpl` — that one is parked until full state saving is removed (jakartaee/faces#2226), which collapses the gate's second clause and changes the target.

Two leads that look compelling in a profile and are **not** worth chasing: `DefaultFaceletContext.ensurePrefix` ranks as the top self-time leaf of the flat render at ~8%, and `UIComponentBase.getNamingContainerAncestor` at ~3.7%. Both are already a field read or a null check, so those shares are inlining attribution artifacts, not work — 8% of that phase would be 245ns per component for a null check. Divide by the per-request operation count before believing a leaf.

## Upmerge note

On 5.0 `jakarta.faces.*` lives in the `faces` submodule, so the `UIComponentBase` half of the first commit has to **move** there on the way up; the upmerge cannot relocate it automatically.

🤖 Generated with Claude Opus 5
