### PR TITLE
Fix flaky FacesContextImplPostbackTest

### DIFF
--- a/impl/src/test/java/com/sun/faces/context/FacesContextImplPostbackTest.java
+++ b/impl/src/test/java/com/sun/faces/context/FacesContextImplPostbackTest.java
@@ -29,6 +29,7 @@ import com.sun.faces.mock.MockHttpServletRequest;
 import com.sun.faces.mock.MockHttpServletResponse;
 import com.sun.faces.mock.MockRenderKit;
 import com.sun.faces.mock.MockServletContext;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,6 +45,8 @@ class FacesContextImplPostbackTest {
 
     @BeforeEach
     void setUp() {
+        // The factories are process-wide, and setFactory is silently ignored once one has been obtained.
+        FactoryFinder.releaseFactories();
         FactoryFinder.setFactory(FactoryFinder.RENDER_KIT_FACTORY, "com.sun.faces.mock.MockRenderKitFactory");
         request = new MockHttpServletRequest();
         facesContext = new FacesContextImpl(
@@ -51,15 +54,16 @@ class FacesContextImplPostbackTest {
                 new LifecycleImpl());
 
         RenderKitFactory renderKitFactory = (RenderKitFactory) FactoryFinder.getFactory(FactoryFinder.RENDER_KIT_FACTORY);
-        try {
-            renderKitFactory.addRenderKit(RenderKitFactory.HTML_BASIC_RENDER_KIT, new MockRenderKit());
-        } catch (IllegalArgumentException alreadyRegistered) {
-            // The factory outlives a single test and rejects a second registration under the same id.
-        }
+        renderKitFactory.addRenderKit(RenderKitFactory.HTML_BASIC_RENDER_KIT, new MockRenderKit());
 
         UIViewRoot viewRoot = new UIViewRoot();
         viewRoot.setRenderKitId(RenderKitFactory.HTML_BASIC_RENDER_KIT);
         facesContext.setViewRoot(viewRoot);
+    }
+
+    @AfterEach
+    void tearDown() {
+        FactoryFinder.releaseFactories();
     }
 
     @Test


### PR DESCRIPTION
FacesContextImplPostbackTest, added in #5929, depends on global FactoryFinder state.

FactoryFinder caches factories per classloader, and `FactoryFinderInstance.addFactory` appends the implementation class name only while the entry is still an unresolved `List`:

```java
Object result = factories.get(factoryName);
if (result instanceof List) {
    ...add(0, implementationClassName);
}
```

Once anything in the JVM has obtained the render kit factory, the entry holds the instance instead, `setFactory` becomes a no-op, and `getFactory` returns whatever the leftover state holds — `null` included. `setUp` then dies on `NullPointerException: Cannot invoke "RenderKitFactory.addRenderKit(...)" because "renderKitFactory" is null`.

`FactoryFinder.releaseFactories()` runs in `@BeforeEach` before the registration, and in a new `@AfterEach` so the test does not leak into its successors, matching what `FactoryFinderTestCase` already does. The `catch (IllegalArgumentException)` around `addRenderKit` is dropped: it only ever swallowed a duplicate registration on a leaked factory.

Verified green over the full impl suite in six run orders — alphabetical, reversealphabetical, filesystem and three randoms. Note that the original failure is not reproducible on demand; it surfaced twice during a reactor build and not in six deliberate attempts at forcing it, so the change rests on the `addFactory` contract above rather than on a red-to-green demonstration.

🤖 Generated with Claude Opus 5
