### PR TITLE
Stop applying a pass-through attribute as an ordinary one too

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/tag/MetaRulesetImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/MetaRulesetImpl.java
@@ -28,6 +28,7 @@ import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.sun.faces.facelets.tag.faces.PassThroughAttributeLibrary;
 import com.sun.faces.util.FacesLogger;
 import com.sun.faces.util.Util;
 
@@ -70,6 +71,9 @@ public class MetaRulesetImpl extends MetaRuleset {
         // setup attributes
         TagAttribute[] attrs = this.tag.getAttributes().getAll();
         for (int i = 0; i < attrs.length; i++) {
+            if (PassThroughAttributeLibrary.NAMESPACES.contains(attrs[i].getNamespace())) {
+                continue;
+            }
             if (attrs[i].getLocalName().equals("class")) {
                 attributes.put("styleClass", attrs[i]);
             } else {

--- a/impl/src/test/java/com/sun/faces/facelets/tag/faces/PassthroughAttributeMetadataTest.java
+++ b/impl/src/test/java/com/sun/faces/facelets/tag/faces/PassthroughAttributeMetadataTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.facelets.tag.faces;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.faces.facelets.tag.MetaRulesetImpl;
+import com.sun.faces.facelets.tag.TagAttributeImpl;
+import com.sun.faces.facelets.tag.TagAttributesImpl;
+
+import jakarta.el.ExpressionFactory;
+import jakarta.faces.component.html.HtmlPanelGroup;
+import jakarta.faces.view.Location;
+import jakarta.faces.view.facelets.FaceletContext;
+import jakarta.faces.view.facelets.Metadata;
+import jakarta.faces.view.facelets.Tag;
+import jakarta.faces.view.facelets.TagAttribute;
+
+/**
+ * A pass-through attribute belongs to the component's pass-through attribute map alone, where
+ * {@code ComponentSupport.copyPassthroughAttributes} puts it. The meta rules key a tag's attributes by local name, so
+ * unless the pass-through namespaces are excluded a {@code p:data-row} is applied as an ordinary attribute as well:
+ * stored a second time under {@code data-row}, listed in {@code attributesThatAreSet} -- which puts it in saved state
+ * and in the pass-through render loop, where it can never match -- and, when its local name is a real property's,
+ * displacing that property's own attribute.
+ */
+class PassthroughAttributeMetadataTest {
+
+    private static final String HTML = "jakarta.faces.html";
+    private static final String PASSTHROUGH = "jakarta.faces.passthrough";
+    private static final String PASSTHROUGH_JCP = "http://xmlns.jcp.org/jsf/passthrough";
+    private static final String ATTRIBUTES_THAT_ARE_SET = "jakarta.faces.component.UIComponentBase.attributesThatAreSet";
+
+    @Test
+    void aPassthroughAttributeIsNotAppliedAsAnOrdinaryAttribute() {
+        HtmlPanelGroup component = apply(attribute(PASSTHROUGH, "data-row", "1"),
+                attribute(PASSTHROUGH_JCP, "data-legacy", "2"));
+
+        assertNull(component.getAttributes().get("data-row"));
+        assertNull(component.getAttributes().get("data-legacy"));
+        // Not containsKey: AttributesMap answers that unconditionally for this key.
+        assertNull(component.getAttributes().get(ATTRIBUTES_THAT_ARE_SET));
+    }
+
+    @Test
+    void anOrdinaryAttributeIsStillApplied() {
+        HtmlPanelGroup component = apply(attribute(HTML, "layout", "block"));
+
+        assertEquals("block", component.getLayout());
+    }
+
+    @Test
+    void aPassthroughAttributeDoesNotDisplaceThePropertyOfTheSameName() {
+        // The rules key attributes by local name, so the pass-through one would otherwise overwrite the property's.
+        HtmlPanelGroup component = apply(attribute(HTML, "layout", "block"), attribute(PASSTHROUGH, "layout", "inline"));
+
+        assertEquals("block", component.getLayout());
+    }
+
+    private static HtmlPanelGroup apply(TagAttribute... attributes) {
+        // A literal property is coerced to the setter's type through the context's expression factory.
+        FaceletContext context = mock(FaceletContext.class);
+        when(context.getExpressionFactory()).thenReturn(ExpressionFactory.newInstance());
+
+        HtmlPanelGroup component = new HtmlPanelGroup();
+        metadata(attributes).applyMetadata(context, component);
+        return component;
+    }
+
+    private static Metadata metadata(TagAttribute... attributes) {
+        Tag tag = new Tag(new Location("test.xhtml", 1, 1), HTML, "panelGroup", "h:panelGroup",
+                new TagAttributesImpl(attributes));
+        MetaRulesetImpl ruleset = new MetaRulesetImpl(tag, HtmlPanelGroup.class);
+        ruleset.addRule(ComponentRule.Instance);
+        return ruleset.finish();
+    }
+
+    private static TagAttribute attribute(String namespace, String localName, String value) {
+        return new TagAttributeImpl(new Location("test.xhtml", 1, 1), namespace, localName, localName, value);
+    }
+}


### PR DESCRIPTION
A pass-through attribute is currently applied twice: once to the component's pass-through attribute map, where it belongs, and once to the component's ordinary attributes map, where it does not.

`MetaRulesetImpl` keys a tag's attributes by local name and never consults the namespace, so `p:data-row` enters the ruleset as `data-row`. `ComponentTagHandlerDelegateImpl.createMetaRuleset` ignores only `binding` and `id`, and `finish()` walks the rules backwards, so `ComponentRule` sees it first: the attribute is literal and `getWriteMethod("data-row")` is null, so it returns a `LiteralAttributeMetadata` whose `applyMetadata` runs `component.getAttributes().put("data-row", value)` on every build — on top of what `ComponentSupport.copyPassthroughAttributes` already did.

Observed on Tomcat with the same WAR and only the implementation swapped, reading the built component back through EL:

| | Mojarra 4.0 | MyFaces 4.1.4 |
|---|---|---|
| `passThroughAttributes['data-row']` | `ROWVAL` | `ROWVAL` |
| `attributes['data-row']` | **`ROWVAL`** | empty |
| `attributesThatAreSet` | **`[data-row, styleClass, data-col]`** | empty |

Both render the same markup; the difference is entirely internal.

## Why it costs

The second write takes `AttributesMap`'s descriptor-miss path, per attribute per build: a `getPropertyDescriptor` lookup that cannot hit, a `contains` scan of `attributesThatAreSet`, a list append and a state-helper write.

Landing in `attributesThatAreSet` has two further effects. The attribute is saved into component state a second time. And `RenderKitUtils.renderPassThruAttributes` iterates exactly that list, so every render walks entries that can never match a renderer attribute — a `knownAttributes.get` miss plus an `isBehaviorEventAttribute` miss each, per attribute per component per render.

## Why it is also wrong

Because the ruleset is keyed by local name alone, a pass-through attribute whose local name is a real property's displaces that property. Before this change `<h:panelGroup layout="block" p:layout="inline"/>` rendered as `inline`. A test pins that.

## Measurements

Isolated buildView (`BuildViewBenchIT`), Tomcat, 407 components each carrying five pass-through attributes, min of three passes:

| | before | after | MyFaces 4.1.4 |
|---|--:|--:|--:|
| ns per build | 487,273 | **315,811** | 286,990 |
| pass-through attributes alone | 206,019 | **67,568** | 69,890 |
| per attribute | 103 ns | **34 ns** | 35 ns |

buildView drops 35%, and the attributes themselves stop costing three times what they cost MyFaces — the remaining 34 ns is the pass-through map write both implementations do.

The render-side effect of the shorter `attributesThatAreSet` list is not measured here.

## Verification

Three unit tests, all failing before the change: the attribute is absent from `getAttributes()` for both pass-through namespaces and `attributesThatAreSet` stays empty; an ordinary attribute is still applied; a pass-through attribute no longer displaces the property of the same name. Full impl suite green. The full TCK was run green against this change ported to 5.0.

🤖 Generated with Claude Opus 5
