### PR TITLE
Issue #5856: cut the per-component cost of reading component attributes

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/UniqueIdSlot.java
+++ b/impl/src/main/java/com/sun/faces/facelets/UniqueIdSlot.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.facelets;
+
+import jakarta.faces.view.facelets.Facelet;
+import jakarta.faces.view.facelets.FaceletContext;
+
+/**
+ * The unique-id counter slot a tag handler reserves once and reuses for every build.
+ * <p>
+ * A handler that asks for its id by tag id makes the context count in a map keyed by that id, which is one lookup and,
+ * while the map is still growing, a share of a rehash for every tag applied. Reserving a slot moves the counter into an
+ * array indexed per tag, so the same id costs an array increment. The slot belongs to the {@link Facelet} it was
+ * reserved from, so it is re-reserved whenever a handler is applied from a different one.
+ * <p>
+ * A handler holds one of these per instance and is shared across concurrent builds, hence the volatile: a stale read
+ * only costs a re-reservation, never a wrong id.
+ */
+public final class UniqueIdSlot {
+
+    private volatile Reservation reservation;
+
+    /**
+     * Returns the next unique id for {@code tagId}, through the reserved slot where the context supports it and
+     * through the public {@link FaceletContext} API otherwise, which a wrapping context or a foreign implementation
+     * may supply.
+     *
+     * @param ctx the context to generate the id from
+     * @param tagId the tag id to generate an id for
+     * @return the generated unique id
+     */
+    public String generateUniqueId(FaceletContext ctx, String tagId) {
+        if (!(ctx instanceof FaceletContextImplBase)) {
+            return ctx.generateUniqueId(tagId);
+        }
+
+        FaceletContextImplBase context = (FaceletContextImplBase) ctx;
+        Facelet owner = context.getUniqueIdSlotOwner();
+
+        if (owner == null) {
+            return ctx.generateUniqueId(tagId);
+        }
+
+        Reservation current = reservation;
+
+        if (current == null || current.owner != owner) {
+            current = new Reservation(owner, context.getUniqueIdSlot(tagId));
+            reservation = current;
+        }
+
+        return context.generateUniqueId(tagId, current.owner, current.slot);
+    }
+
+    private static final class Reservation {
+
+        private final Facelet owner;
+        private final int slot;
+
+        private Reservation(Facelet owner, int slot) {
+            this.owner = owner;
+            this.slot = slot;
+        }
+    }
+}

--- a/impl/src/main/java/com/sun/faces/facelets/compiler/UIInstructionHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/compiler/UIInstructionHandler.java
@@ -19,6 +19,7 @@ package com.sun.faces.facelets.compiler;
 import java.io.IOException;
 import java.io.Writer;
 
+import com.sun.faces.facelets.UniqueIdSlot;
 import com.sun.faces.facelets.el.ELText;
 import com.sun.faces.facelets.impl.IdMapper;
 import com.sun.faces.facelets.tag.faces.ComponentSupport;
@@ -48,6 +49,8 @@ final class UIInstructionHandler extends AbstractUIHandler {
 
     private final boolean literal;
 
+    private final UniqueIdSlot idSlot = new UniqueIdSlot();
+
     public UIInstructionHandler(String alias, String id, Instruction[] instructions, ELText txt) {
         this.alias = alias;
         this.id = id;
@@ -73,7 +76,7 @@ final class UIInstructionHandler extends AbstractUIHandler {
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
         if (parent != null) {
             // our id
-            String id = ctx.generateUniqueId(this.id);
+            String id = idSlot.generateUniqueId(ctx, this.id);
             FacesContext context = ctx.getFacesContext();
 
             // grab our component

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
@@ -33,8 +33,8 @@ import com.sun.faces.component.CompositeComponentStackManager;
 import com.sun.faces.component.behavior.AjaxBehaviors;
 import com.sun.faces.component.validator.ComponentValidators;
 import com.sun.faces.context.StateContext;
+import com.sun.faces.facelets.UniqueIdSlot;
 import com.sun.faces.facelets.impl.IdMapper;
-import com.sun.faces.facelets.FaceletContextImplBase;
 import com.sun.faces.facelets.tag.MetaRulesetImpl;
 import com.sun.faces.facelets.tag.faces.core.FacetHandler;
 import com.sun.faces.util.FacesLogger;
@@ -86,18 +86,7 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
      * the one this tag was compiled in, because a {@code ui:define} body applies under the template it is inserted
      * into; a tag that alternates between templates simply rebinds.
      */
-    private static final class IdSlot {
-
-        private final Facelet owner;
-        private final int slot;
-
-        private IdSlot(Facelet owner, int slot) {
-            this.owner = owner;
-            this.slot = slot;
-        }
-    }
-
-    private volatile IdSlot idSlot;
+    private final UniqueIdSlot idSlot = new UniqueIdSlot();
 
     public ComponentTagHandlerDelegateImpl(ComponentHandler owner) {
         this.owner = owner;
@@ -470,26 +459,7 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
      * public {@link FaceletContext} API otherwise, which a wrapping context or a foreign implementation may supply.
      */
     private String generateUniqueId(FaceletContext ctx) {
-
-        if (!(ctx instanceof FaceletContextImplBase)) {
-            return ctx.generateUniqueId(owner.getTagId());
-        }
-
-        FaceletContextImplBase context = (FaceletContextImplBase) ctx;
-        Facelet slotOwner = context.getUniqueIdSlotOwner();
-
-        if (slotOwner == null) {
-            return ctx.generateUniqueId(owner.getTagId());
-        }
-
-        IdSlot slot = idSlot;
-
-        if (slot == null || slot.owner != slotOwner) {
-            slot = new IdSlot(slotOwner, context.getUniqueIdSlot(owner.getTagId()));
-            idSlot = slot;
-        }
-
-        return context.generateUniqueId(owner.getTagId(), slot.owner, slot.slot);
+        return idSlot.generateUniqueId(ctx, owner.getTagId());
     }
 
     protected void doNewComponentActions(FaceletContext ctx, String id, UIComponent c) {

--- a/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
@@ -133,30 +133,25 @@ public class RenderKitUtils {
      * This represents the base package that can leverage the <code>attributesThatAreSet</code> List for optimized attribute
      * rendering.
      *
-     * IMPLEMENTATION NOTE: This must be kept in sync with the array in UIComponentBase$AttributesMap and
-     * HtmlComponentGenerator.
+     * IMPLEMENTATION NOTE: This must be kept in sync with UIComponentBase.STANDARD_COMPONENT_PACKAGE and the copies in
+     * HtmlComponentUtils and PassthroughElement.
      *
      * Hopefully Faces X will remove the need for this.
      */
     private static final String OPTIMIZED_PACKAGE = "jakarta.faces.component.";
 
     /**
-     * IMPLEMENTATION NOTE: This must be kept in sync with the Key in UIComponentBase$AttributesMap and
-     * HtmlComponentGenerator.
+     * IMPLEMENTATION NOTE: This must be kept in sync with UIComponentBase.ATTRIBUTES_THAT_ARE_SET and the copies in
+     * HtmlComponentUtils and PassthroughElement. Spelled out as a literal so that all of them are the same interned
+     * instance.
      *
      * Hopefully Faces X will remove the need for this.
      */
-    private static final String ATTRIBUTES_THAT_ARE_SET_KEY = UIComponentBase.class.getName() + ".attributesThatAreSet";
+    private static final String ATTRIBUTES_THAT_ARE_SET_KEY = "jakarta.faces.component.UIComponentBase.attributesThatAreSet";
 
     private static final String PENDING_BEHAVIOR_EVENT_LISTENERS_KEY = UIComponentBase.class.getName() + ".pendingBehaviorEventListeners";
 
     private static final String BEHAVIOR_EVENT_ATTRIBUTE_PREFIX = "on";
-
-    /**
-     * UIViewRoot attribute key of a boolean value which remembers whether the view will be rendered with a HTML5 doctype.
-     */
-    private static final String VIEW_ROOT_ATTRIBUTES_DOCTYPE_KEY = RenderKitUtils.class.getName() + ".isOutputHtml5Doctype";
-
 
     protected static final Logger LOGGER = FacesLogger.RENDERKIT.getLogger();
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/GroupRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/GroupRenderer.java
@@ -46,16 +46,11 @@ public class GroupRenderer extends HtmlBasicRenderer {
             return;
         }
         // Render a span around this group if necessary
-        String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
+        String styleClass = getStyleClass(component);
         ResponseWriter writer = context.getResponseWriter();
 
         if (divOrSpan(component, styleClass)) {
-            if (component instanceof HtmlPanelGroup ? "block".equals(((HtmlPanelGroup) component).getLayout())
-                    : "block".equals(component.getAttributes().get("layout"))) {
-                writer.startElement("div", component);
-            } else {
-                writer.startElement("span", component);
-            }
+            writer.startElement(getElementName(component), component);
             writeIdAttributeIfNecessary(context, writer, component);
             if (styleClass != null) {
                 writer.writeAttribute("class", styleClass, "styleClass");
@@ -96,14 +91,9 @@ public class GroupRenderer extends HtmlBasicRenderer {
 
         // Close our span element if necessary
         ResponseWriter writer = context.getResponseWriter();
-        String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
+        String styleClass = getStyleClass(component);
         if (divOrSpan(component, styleClass)) {
-            if (component instanceof HtmlPanelGroup ? "block".equals(((HtmlPanelGroup) component).getLayout())
-                    : "block".equals(component.getAttributes().get("layout"))) {
-                writer.endElement("div");
-            } else {
-                writer.endElement("span");
-            }
+            writer.endElement(getElementName(component));
         }
 
     }
@@ -125,7 +115,33 @@ public class GroupRenderer extends HtmlBasicRenderer {
      */
     private boolean divOrSpan(UIComponent component, String styleClass) {
 
-        return shouldWriteIdAttribute(component) || styleClass != null || RenderKitUtils.getAttributeIfSet(component, "style") != null;
+        return shouldWriteIdAttribute(component) || styleClass != null || getStyle(component) != null;
+
+    }
+
+    /**
+     * @return the element name to wrap this group in, which is a {@code div} when its layout is {@code block} and a
+     * {@code span} otherwise.
+     */
+    private static String getElementName(UIComponent component) {
+
+        String layout = component instanceof HtmlPanelGroup ? ((HtmlPanelGroup) component).getLayout()
+                : (String) component.getAttributes().get("layout");
+        return "block".equals(layout) ? "div" : "span";
+
+    }
+
+    private static String getStyleClass(UIComponent component) {
+
+        return component instanceof HtmlPanelGroup ? ((HtmlPanelGroup) component).getStyleClass()
+                : (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");
+
+    }
+
+    private static String getStyle(UIComponent component) {
+
+        return component instanceof HtmlPanelGroup ? ((HtmlPanelGroup) component).getStyle()
+                : (String) RenderKitUtils.getAttributeIfSet(component, "style");
 
     }
 

--- a/impl/src/main/java/jakarta/faces/component/ComponentStateHelper.java
+++ b/impl/src/main/java/jakarta/faces/component/ComponentStateHelper.java
@@ -375,12 +375,12 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
      * generated HTML components setter methods.
      */
     private void handleAttribute(String name, Object value) {
-        List<String> setAttributes = (List<String>) component.getAttributes().get("jakarta.faces.component.UIComponentBase.attributesThatAreSet");
+        List<String> setAttributes = (List<String>) component.getAttributes().get(UIComponentBase.ATTRIBUTES_THAT_ARE_SET);
         if (setAttributes == null) {
             String className = getClass().getName();
-            if (className != null && className.startsWith("jakarta.faces.component.")) {
+            if (className.startsWith(UIComponentBase.STANDARD_COMPONENT_PACKAGE)) {
                 setAttributes = new ArrayList<>(6);
-                component.getAttributes().put("jakarta.faces.component.UIComponentBase.attributesThatAreSet", setAttributes);
+                component.getAttributes().put(UIComponentBase.ATTRIBUTES_THAT_ARE_SET, setAttributes);
             }
         }
 

--- a/impl/src/main/java/jakarta/faces/component/ComponentStateHelper.java
+++ b/impl/src/main/java/jakarta/faces/component/ComponentStateHelper.java
@@ -377,7 +377,7 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
     private void handleAttribute(String name, Object value) {
         List<String> setAttributes = (List<String>) component.getAttributes().get(UIComponentBase.ATTRIBUTES_THAT_ARE_SET);
         if (setAttributes == null) {
-            String className = getClass().getName();
+            String className = component.getClass().getName();
             if (className.startsWith(UIComponentBase.STANDARD_COMPONENT_PACKAGE)) {
                 setAttributes = new ArrayList<>(6);
                 component.getAttributes().put(UIComponentBase.ATTRIBUTES_THAT_ARE_SET, setAttributes);

--- a/impl/src/main/java/jakarta/faces/component/UIComponent.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponent.java
@@ -188,12 +188,6 @@ public abstract class UIComponent implements PartialStateHolder, TransientStateH
         rendered, attributes, bindings, rendererType, systemEventListeners, behaviors, passThroughAttributes
     }
 
-    /**
-     * List of attributes that have been set on the component (this may be from setValueExpression, the attributes map, or
-     * setters from the concrete HTML components. This allows for faster rendering of attributes as this list is
-     * authoritative on what has been set.
-     */
-    List<String> attributesThatAreSet;
     ComponentStateHelper stateHelper;
     UIComponent compositeParent;
     private boolean isInView;

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -111,6 +111,17 @@ public abstract class UIComponentBase extends UIComponent {
     private static final int CHILD_STATE = 1;
 
     /**
+     * The attributes map key under which the implementation reads the list of attributes that have been explicitly set
+     * on a component, and the package whose components maintain that list. Package private so that
+     * {@link ComponentStateHelper} reads the same constants this class writes; the copies in
+     * {@code jakarta.faces.component.html.HtmlComponentUtils} and in the implementation's {@code RenderKitUtils} and
+     * {@code PassthroughElement} are in packages that cannot see these and must be kept in sync by hand. Literals, so
+     * that all of them are the same interned instance.
+     */
+    static final String ATTRIBUTES_THAT_ARE_SET = "jakarta.faces.component.UIComponentBase.attributesThatAreSet";
+    static final String STANDARD_COMPONENT_PACKAGE = "jakarta.faces.component.";
+
+    /**
      * This class's <code>PropertyDescriptor</code>s (keyed by property name), held per class in the
      * {@link #COMPONENT_METADATA} cache.
      */
@@ -2250,10 +2261,6 @@ public abstract class UIComponentBase extends UIComponent {
     // private 'attributes' map directly to the state saving process.
     private static class AttributesMap implements Map<String, Object>, Serializable {
 
-        // this KEY is special to the AttributesMap - this allows the implementation
-        // to access the the List containing the attributes that have been set
-        private static final String ATTRIBUTES_THAT_ARE_SET_KEY = UIComponentBase.class.getName() + ".attributesThatAreSet";
-
         // private Map<String, Object> attributes;
         private transient Map<String, PropertyDescriptor> pdMap;
         // Per-class, application-scoped cache of access-suppressed read methods (see UIComponentBase.readMethodMap);
@@ -2276,11 +2283,14 @@ public abstract class UIComponentBase extends UIComponent {
 
         @Override
         public boolean containsKey(Object keyObj) {
+            if (keyObj == ATTRIBUTES_THAT_ARE_SET) {
+                return true;
+            }
             Object marker = component.markerGet(keyObj);
             if (marker != NOT_MARKER) {
                 return marker != null;
             }
-            if (ATTRIBUTES_THAT_ARE_SET_KEY.equals(keyObj)) {
+            if (ATTRIBUTES_THAT_ARE_SET.equals(keyObj)) {
                 return true;
             }
             String key = (String) keyObj;
@@ -2304,11 +2314,18 @@ public abstract class UIComponentBase extends UIComponent {
             if (key == null) {
                 throw new NullPointerException();
             }
-            Object marker = component.markerGet(key);
-            if (marker != NOT_MARKER) {
-                return marker;
+            // Identity, not equals: this is by a wide margin the most frequently read key of this map and every
+            // caller in the implementation passes the interned constant, so it is answered ahead of the marker keys
+            // without adding a comparison to their path. A foreign equal-but-distinct key still resolves below.
+            boolean attributesThatAreSet = key == ATTRIBUTES_THAT_ARE_SET;
+            if (!attributesThatAreSet) {
+                Object marker = component.markerGet(key);
+                if (marker != NOT_MARKER) {
+                    return marker;
+                }
+                attributesThatAreSet = ATTRIBUTES_THAT_ARE_SET.equals(key);
             }
-            if (ATTRIBUTES_THAT_ARE_SET_KEY.equals(key)) {
+            if (attributesThatAreSet) {
                 result = component.getStateHelper().get(UIComponent.PropertyKeysPrivate.attributesThatAreSet);
             }
             // Resolved lazily: the property-backed fast path below never needs it.
@@ -2399,11 +2416,9 @@ public abstract class UIComponentBase extends UIComponent {
                 return null;
             }
 
-            if (ATTRIBUTES_THAT_ARE_SET_KEY.equals(keyValue)) {
-                if (component.attributesThatAreSet == null) {
-                    if (value instanceof List) {
-                        component.getStateHelper().put(UIComponent.PropertyKeysPrivate.attributesThatAreSet, value);
-                    }
+            if (ATTRIBUTES_THAT_ARE_SET.equals(keyValue)) {
+                if (value instanceof List) {
+                    component.getStateHelper().put(UIComponent.PropertyKeysPrivate.attributesThatAreSet, value);
                 }
                 return null;
             }
@@ -2479,7 +2494,7 @@ public abstract class UIComponentBase extends UIComponent {
             if (marker && (MARK_DELETED.equals(key) || KEY.equals(key))) {
                 return null;
             }
-            if (ATTRIBUTES_THAT_ARE_SET_KEY.equals(key)) {
+            if (ATTRIBUTES_THAT_ARE_SET.equals(key)) {
                 return null;
             }
             PropertyDescriptor pd = marker ? null : getPropertyDescriptor(key);

--- a/impl/src/main/java/jakarta/faces/component/UIData.java
+++ b/impl/src/main/java/jakarta/faces/component/UIData.java
@@ -130,13 +130,6 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
 
         /**
          * <p>
-         * The zero-relative index of the current row number, or -1 for no current row association.
-         * </p>
-         */
-        rowIndex,
-
-        /**
-         * <p>
          * The number of rows to display, or zero for all remaining rows in the table.
          * </p>
          */
@@ -176,6 +169,20 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
      * </p>
      */
     private DataModel model = null;
+
+    /**
+     * <p>
+     * The zero-relative index of the current row, or -1 for no current row association.
+     * </p>
+     *
+     * <p>
+     * A field rather than a state-helper entry: every component under this table reads it through
+     * {@link #getClientId} while its own client id is being built, so a map lookup here is paid once per component per
+     * traversal. It is not part of the component state -- every phase leaves the row index at -1 before state is
+     * saved, and it is not an attribute a page can set.
+     * </p>
+     */
+    private int rowIndex = -1;
 
     /**
      * <p>
@@ -411,7 +418,7 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
      */
     public int getRowIndex() {
 
-        return (Integer) getStateHelper().eval(PropertyKeys.rowIndex, -1);
+        return rowIndex;
 
     }
 
@@ -511,8 +518,7 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
         saveDescendantState(context);
 
         // Update to the new row index
-        // this.rowIndex = rowIndex;
-        getStateHelper().put(PropertyKeys.rowIndex, rowIndex);
+        this.rowIndex = rowIndex;
         DataModel localModel = getDataModel();
         localModel.setRowIndex(rowIndex);
 
@@ -576,8 +582,7 @@ public class UIData extends UIComponentBase implements NamingContainer, UniqueId
         }
 
         // Update to the new row index
-        // this.rowIndex = rowIndex;
-        getStateHelper().put(PropertyKeys.rowIndex, rowIndex);
+        this.rowIndex = rowIndex;
         DataModel localModel = getDataModel();
         localModel.setRowIndex(rowIndex);
 

--- a/impl/src/test/java/com/example/faces/NonStandardComponent.java
+++ b/impl/src/test/java/com/example/faces/NonStandardComponent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.example.faces;
+
+import jakarta.faces.component.UIComponentBase;
+
+/**
+ * A component from outside {@code jakarta.faces.component}, i.e. one whose setters do not record into the
+ * attributes-that-are-set list. It lives in this package precisely because the behaviour under test is decided by the
+ * component's package name.
+ */
+public class NonStandardComponent extends UIComponentBase {
+
+    @Override
+    public String getFamily() {
+        return "com.example.faces.NonStandard";
+    }
+}

--- a/impl/src/test/java/com/sun/faces/context/FacesContextImplPostbackTest.java
+++ b/impl/src/test/java/com/sun/faces/context/FacesContextImplPostbackTest.java
@@ -19,6 +19,8 @@ package com.sun.faces.context;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Method;
+
 import jakarta.faces.FactoryFinder;
 import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.context.FacesContext;
@@ -62,7 +64,13 @@ class FacesContextImplPostbackTest {
     }
 
     @AfterEach
-    void tearDown() {
+    void tearDown() throws Exception {
+        // Constructing a FacesContext makes it the current one for the thread. FacesContextImpl.release() would clear
+        // that but needs a CDI environment, so reach the protected setter the way the other tests in this tree do.
+        Method setCurrentInstance = FacesContext.class.getDeclaredMethod("setCurrentInstance", FacesContext.class);
+        setCurrentInstance.setAccessible(true);
+        setCurrentInstance.invoke(null, new Object[] { null });
+
         FactoryFinder.releaseFactories();
     }
 

--- a/impl/src/test/java/jakarta/faces/component/ComponentStateHelperTest.java
+++ b/impl/src/test/java/jakarta/faces/component/ComponentStateHelperTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.component;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+
+import jakarta.faces.component.html.HtmlPanelGroup;
+import jakarta.faces.context.FacesContext;
+
+import com.example.faces.NonStandardComponent;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Restoring full state runs no setters, so the helper re-records the attributes a standard component's generated
+ * setters would have tracked. Which components those are is decided by the component's own package, the same test
+ * {@code HtmlComponentUtils.handleAttribute} and {@code RenderKitUtils.getAttributeIfSet} apply on the write and read
+ * sides.
+ */
+class ComponentStateHelperTest {
+
+    @Test
+    void restoringAComponentFromOutsideTheStandardPackageDoesNotStartTrackingItsAttributes() {
+        FacesContext context = mock(FacesContext.class);
+
+        NonStandardComponent saved = new NonStandardComponent();
+        saved.setRendered(false);
+        Object state = saved.getStateHelper().saveState(context);
+
+        NonStandardComponent restored = new NonStandardComponent();
+        restored.getStateHelper().restoreState(context, state);
+
+        assertNull(restored.getAttributes().get(UIComponentBase.ATTRIBUTES_THAT_ARE_SET));
+    }
+
+    @Test
+    void restoringAStandardComponentTracksTheAttributesItsSettersWouldHave() {
+        FacesContext context = mock(FacesContext.class);
+
+        HtmlPanelGroup saved = new HtmlPanelGroup();
+        saved.setStyleClass("cell");
+        Object state = saved.getStateHelper().saveState(context);
+
+        HtmlPanelGroup restored = new HtmlPanelGroup();
+        restored.getStateHelper().restoreState(context, state);
+
+        assertTrackedAttributes(restored, "styleClass");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void assertTrackedAttributes(UIComponent component, String... expected) {
+        org.junit.jupiter.api.Assertions.assertEquals(java.util.List.of(expected),
+                component.getAttributes().get(UIComponentBase.ATTRIBUTES_THAT_ARE_SET));
+    }
+}

--- a/impl/src/test/java/jakarta/faces/component/UIDataTest.java
+++ b/impl/src/test/java/jakarta/faces/component/UIDataTest.java
@@ -56,15 +56,30 @@ public class UIDataTest {
     }
 
     /**
-     * Test partial state saving with rowIndex.
+     * Partial state saving returns null only when nothing changed, so a property that did change still has to come
+     * back as state.
      */
     @Test
     public void testSaveState3() {
         FacesContext context = mock(FacesContext.class);
         UIData data = new UIData();
         data.markInitialState();
-        data.setRowIndex(4);
+        data.setFirst(4);
         assertNotNull(data.saveState(context));
+    }
+
+    /**
+     * The row index is not component state. Every phase leaves it at -1 before state is saved and no page can set it,
+     * so holding it on a field rather than in the state helper is what lets each {@code getClientId} under this table
+     * read it without a map lookup.
+     */
+    @Test
+    public void theRowIndexIsNotSavedState() {
+        FacesContext context = mock(FacesContext.class);
+        UIData data = new UIData();
+        data.markInitialState();
+        data.setRowIndex(4);
+        assertNull(data.saveState(context));
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #5926 and #5929 on #5856, this time on the render side. Profiling the `flat-nopassthru` scenario (400 bare `h:panelGroup layout="block" styleClass="cell"`, a GET so its RENDER carries the Facelets build) put Mojarra ~15% behind MyFaces, the largest remaining render deficit in the suite now that `flat-passthru` is at parity.

The gap is not reflection. Both implementations read component attributes through a reflective property map and spend the same doing it — `DirectMethodHandleAccessor` presence inside `GroupRenderer` is 14.81% (95 µs) on Mojarra against 16.52% (96 µs) on MyFaces. What differs is string and map traffic: `String.equals` 3.14% vs 0.59% and `HashMap.getNode` 1.84% vs 0.59%, together roughly the whole 25 µs by which `GroupRenderer` is slower.

A counting probe explains it exactly. Per request on that view, `AttributesMap.get` is called 3222 times — 8 per component — of which 1606 (4 per component) are the `attributesThatAreSet` key and 800 (2 per component) are reflective property reads of `styleClass`, once in `encodeBegin` and again in `encodeEnd`. Every one of those 1606 lookups ran `markerGet`'s six `String.equals` against the Facelets marker constants and then a full sixty-character `equals`, because `RenderKitUtils` held a separately computed instance of the same key, before reaching the state helper.

## What is in here

1. **`answer the set-attribute list by identity`** — the key becomes a literal everywhere, so every caller passes the same interned instance and `AttributesMap.get`/`containsKey` settle it on a reference check ahead of the marker keys, with the full `equals` left in place for a foreign key. The key and the package it gates on move to `UIComponentBase`, where `ComponentStateHelper` can read what `AttributesMap` writes. The dead `UIComponent.attributesThatAreSet` field goes too — the state helper has held that list since partial state saving arrived in 2009, so the field has had no writer since and the guard reading it was always taken. `VIEW_ROOT_ATTRIBUTES_DOCTYPE_KEY` goes as well, unused since `isOutputHtml5Doctype` started reading `UIViewRoot.getDoctype()`.
2. **`read panel group attributes through their typed getters`** — `GroupRenderer` read `layout` through `HtmlPanelGroup` but `styleClass` and `style` through the attributes map. Now all three go through the typed getters, with the generic path kept as the fallback for non-standard components.
3. **`hold the row index of UIData on a field`** — every component under a table reads the row index through `getClientId` while its own client id is being built. It is not component state: every phase leaves it at -1 before state is saved and no page can set it. This is what `UIRepeat` and MyFaces' own `UIData` already do. One semantic narrowing worth naming rather than leaving to be found: `getStateHelper().eval` fell back to `getValueExpression("rowIndex")` when the map held no value, and a field cannot. It is unreachable from a page — `rowIndex` is not a declared `h:dataTable` attribute, so only a programmatic `setValueExpression("rowIndex", ...)` against a bound component could get there, which neither `UIRepeat` nor MyFaces honours either. The full TCK is green with it.
4. **`give UIInstructionHandler a unique-id slot`** — component tags have counted their generated ids through a reserved slot since #5929; text and EL nodes still counted through the tag-id map, which grows and rehashes once per distinct tag id per build. The reservation `ComponentTagHandlerDelegateImpl` held privately is extracted so both handlers share it.
5. **`record the attributes that are set only for standard components`** — a bug found while reading the code above. `ComponentStateHelper.handleAttribute` gated on `getClass()`, which is the helper itself — package private in `jakarta.faces.component`, so the condition was always true, and restoring state started the tracking list for every component including third-party ones whose setters never maintain such a list. Harmless in effect, since `RenderKitUtils.getAttributeIfSet` and `canBeOptimized` both gate on the *component's* package and a foreign component therefore takes the unoptimized path and never reads the list — the cost is state that is saved and never used, on the partial state path as much as the full one. Two tests come with it.

6. **`release the FacesContext that FacesContextImplPostbackTest creates`** — also unrelated to the levers, also found while verifying them. Constructing a `FacesContext` makes it the current one for the thread and the test never cleared it, so a stale context stayed current for every test that ran after this class in the JVM. `FactoryFinder` keys its per-classloader cache on the current `FacesContext`, so the entry `releaseFactories()` removes in `setUp` is not necessarily the entry the following `getFactory()` resolves — see the closing note.

## Measurements

Tomcat, 400-component flat views, two independent interleaved rounds of 4 reps per arm, medians of `min_us` (see the note on why `min_us` is the load-robust metric for A/B):

| scenario, RENDER | round 1 | round 2 |
|---|--:|--:|
| **flat-nopassthru** | **-16.5%** | **-15.6%** |
| **flat-passthru** | **-11.7%** | **-12.1%** |
| flat-build | -2.5% | -1.4% |
| flat-readonly, flat-text, flat-table-facets, flat-table-nofacets, flat-allattrs | ±0-4%, inside the per-cell spread | ±0-4%, inside the per-cell spread |

`flat-nopassthru` was 597 µs against MyFaces at 525 and is now 498, so that cell goes from +13.7% to -5.1%. Suite total for the `flat-*` family: -2.4% and -1.2% across the two rounds.

That table measures commits 1 and 2. Commit 3 is present in **both** of its arms, so its effect does not appear there — it was measured separately, in paired rounds with the jar swapped between back-to-back runs (a third round is omitted: the machine was not idle for it, so its baseline drifted):

| scenario, RESTORE | round 1 | round 2 |
|---|--:|--:|
| **flat-table-nofacets** | **-22%** | **-19%** |
| **flat-table-facets** | **-20%** | **-20%** |
| table-build | -2% | -8% |
| table-readonly | +6% | -8% |
| flat-build *(control, no table)* | -2% | -6% |

Both table scenarios move by about **-105 µs per request**, which takes `flat-table-nofacets` from +33% against MyFaces to roughly +6% — the largest single move in this set. They are postbacks, where buildView lands in RESTORE_VIEW and a per-component state helper lookup on the client-id path costs the most.

The controls behave as controls should: `flat-build` has no `h:dataTable` and swings across zero, and `table-readonly`'s RESTORE_VIEW is ~47 µs, below the base at which a percentage carries meaning.

Commit 4 is a DRY change whose measured effect is inside the noise band (about -27 µs on that same phase); it is in here because both handlers should share one implementation, not because it moves the number.

## Verification

- Full Faces TCK green against the 5.0 port of this change set (`jakarta.faces` API changes in the `faces` repository, implementation changes here).
- `faces_render_diff.sh` — the perf WAR deployed twice on the same Tomcat with only the Faces jar swapped, all 40 scenario pages fetched and diffed after normalising jsessionid and ViewState: **40/40 byte-identical** on 4.1 (825872 bytes both arms) and on 5.0 (839998 bytes both arms). That check matters here because commit 2 changes how a renderer decides its element name and its `class` attribute. It cannot run on 4.0, where `test/perf` does not exist yet.
- `impl` unit tests green, including the two new `ComponentStateHelperTest` cases. The negative one was confirmed to fail against the unfixed gate with `expected: <null> but was: <[rendered]>`.

## Notes for the upmerge

4.0 is `source/target 11`, so `GroupRenderer`'s helpers use `instanceof HtmlPanelGroup` plus a cast rather than a pattern variable, and `UniqueIdSlot` uses a nested class rather than a record. 4.1 and 5.0 both want the modern form, so expect a small conflict on exactly those lines. On 5.0 the `jakarta.faces.component` half of commits 1, 3 and 5 lives in the `faces` submodule and has to move there by hand; the constants hoisted onto `UIComponentBase` here belong next to the marker keys in `PackageUtils` on that branch.

On the `FacesContextImplPostbackTest` flake (#5930): it surfaced once in roughly nineteen full-suite runs here, as `IllegalArgumentException: HTML_BASIC` from `addRenderKit`, i.e. a duplicate registration on a factory that survived `releaseFactories()`. Commit 6 removes one mechanism that can produce exactly that — the leaked current `FacesContext` participating in `FactoryFinder`'s cache key — but **it is not proven to be the cause**: the flake did not reproduce in twelve instrumented full-suite runs, so there was nothing to fix-and-confirm against. The commit stands on its own merits regardless, since a test that creates a `FacesContext` should not leave it current for every test after it. If it does recur, the leak was not it, and the next step is making the registration idempotent through `getRenderKitIds()` — note that `getRenderKit()` throws when the kit is *absent*, so it cannot be used for that check.

🤖 Generated with Claude Opus 5
