### PR TITLE
Issue #5856: cut the per-component id cost of a view build

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/FaceletContextImplBase.java
+++ b/impl/src/main/java/com/sun/faces/facelets/FaceletContextImplBase.java
@@ -18,6 +18,8 @@ package com.sun.faces.facelets;
 
 import java.io.IOException;
 
+import com.sun.faces.facelets.impl.IdMapper;
+
 import jakarta.el.ELException;
 import jakarta.faces.FacesException;
 import jakarta.faces.component.UIComponent;
@@ -66,6 +68,19 @@ public abstract class FaceletContextImplBase extends FaceletContext {
      */
     public String generateUniqueId(String base, Facelet owner, int slot) {
         return generateUniqueId(base);
+    }
+
+    /**
+     * Returns the alias the {@link IdMapper} in effect for this build gives to the given id, or the id itself when no
+     * mapper is in effect. The mapper is fixed for the duration of a build, so an implementation that resolves it once
+     * answers this without the lookup in {@link jakarta.faces.context.FacesContext#getAttributes()} that this default
+     * performs per call.
+     *
+     * @param id the id to alias
+     * @return the aliased id
+     */
+    public String getAliasedId(String id) {
+        return IdMapper.getAliasedId(getFacesContext(), id);
     }
 
     /**

--- a/impl/src/main/java/com/sun/faces/facelets/compiler/UIInstructionHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/compiler/UIInstructionHandler.java
@@ -21,7 +21,6 @@ import java.io.Writer;
 
 import com.sun.faces.facelets.UniqueIdSlot;
 import com.sun.faces.facelets.el.ELText;
-import com.sun.faces.facelets.impl.IdMapper;
 import com.sun.faces.facelets.tag.faces.ComponentSupport;
 import com.sun.faces.facelets.util.FastWriter;
 
@@ -107,8 +106,7 @@ final class UIInstructionHandler extends AbstractUIHandler {
                 c = new UIInstructions(txt, applied);
                 // mark it owned by a facelet instance
                 String uid;
-                IdMapper mapper = IdMapper.getMapper(ctx.getFacesContext());
-                String mid = mapper != null ? mapper.getAliasedId(id) : id;
+                String mid = ComponentSupport.getAliasedId(ctx, id);
                 UIComponent ancestorNamingContainer = parent.getNamingContainer();
                 if (null != ancestorNamingContainer && ancestorNamingContainer instanceof UniqueIdVendor) {
                     uid = ((UniqueIdVendor) ancestorNamingContainer).createUniqueId(ctx.getFacesContext(), mid);

--- a/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFaceletContext.java
+++ b/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFaceletContext.java
@@ -87,6 +87,12 @@ final class DefaultFaceletContext extends FaceletContextImplBase {
     private final Map<Integer, Integer> prefixes;
     private String prefix;
     private final StringBuilder uniqueIdBuilder = new StringBuilder(30);
+    /**
+     * The {@link IdMapper} in effect for this build, or {@code null} when ids are not aliased. {@link DefaultFacelet}
+     * installs the outermost Facelet's mapper before it constructs the outermost context and removes it only once the
+     * whole build is done, so it does not change while any context in the chain is alive.
+     */
+    private final IdMapper idMapper;
 
     public DefaultFaceletContext(DefaultFaceletContext ctx, DefaultFacelet facelet) {
         this.ctx = ctx.ctx;
@@ -101,6 +107,7 @@ final class DefaultFaceletContext extends FaceletContextImplBase {
         faceletHierarchy.addAll(ctx.faceletHierarchy);
         faceletHierarchy.add(facelet);
         this.facelet = facelet;
+        idMapper = ctx.idMapper;
         faces.getAttributes().put(FaceletContext.FACELET_CONTEXT_KEY, this);
     }
 
@@ -119,7 +126,13 @@ final class DefaultFaceletContext extends FaceletContextImplBase {
             varMapper = new DefaultVariableMapper();
         }
         fnMapper = ctx.getFunctionMapper();
+        idMapper = IdMapper.getMapper(faces);
         this.faces.getAttributes().put(FaceletContext.FACELET_CONTEXT_KEY, this);
+    }
+
+    @Override
+    public String getAliasedId(String id) {
+        return idMapper != null ? idMapper.getAliasedId(id) : id;
     }
 
     /*

--- a/impl/src/main/java/com/sun/faces/facelets/impl/IdMapper.java
+++ b/impl/src/main/java/com/sun/faces/facelets/impl/IdMapper.java
@@ -63,6 +63,21 @@ public class IdMapper {
 
     }
 
+    /**
+     * Returns the alias the mapper in effect for the current build gives to the given id, or the id itself when no
+     * mapper is in effect.
+     *
+     * @param ctx the current FacesContext
+     * @param id the id to alias
+     * @return the aliased id
+     */
+    public static String getAliasedId(FacesContext ctx, String id) {
+
+        IdMapper mapper = getMapper(ctx);
+        return mapper != null ? mapper.getAliasedId(id) : id;
+
+    }
+
     // ---------------------------------------------------------- Nested Classes
 
     private static final class IdGen implements Cache.Factory<String, String> {

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentSupport.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentSupport.java
@@ -32,6 +32,8 @@ import java.util.Set;
 
 import com.sun.faces.RIConstants;
 import com.sun.faces.context.StateContext;
+import com.sun.faces.facelets.FaceletContextImplBase;
+import com.sun.faces.facelets.impl.IdMapper;
 import com.sun.faces.facelets.tag.TagAttributesImpl;
 import com.sun.faces.facelets.tag.faces.core.FacetHandler;
 import com.sun.faces.util.Util;
@@ -231,6 +233,23 @@ public final class ComponentSupport {
         return context.getAttributes().get(PartialStateSaving) == Boolean.TRUE;
     }
     
+    /**
+     * Returns the alias the {@link IdMapper} in effect for this build gives to the given id, or the id itself when no
+     * mapper is in effect. Answered from the context where it holds the mapper itself, and through the
+     * {@link FacesContext} attributes otherwise, which a wrapping context or a foreign implementation may supply.
+     *
+     * @param ctx the context being built under
+     * @param id the id to alias
+     * @return the aliased id
+     */
+    public static String getAliasedId(FaceletContext ctx, String id) {
+        if (ctx instanceof FaceletContextImplBase) {
+            return ((FaceletContextImplBase) ctx).getAliasedId(id);
+        }
+
+        return IdMapper.getAliasedId(ctx.getFacesContext(), id);
+    }
+
     /**
      * By TagId, find Child
      *

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
@@ -34,7 +34,6 @@ import com.sun.faces.component.behavior.AjaxBehaviors;
 import com.sun.faces.component.validator.ComponentValidators;
 import com.sun.faces.context.StateContext;
 import com.sun.faces.facelets.UniqueIdSlot;
-import com.sun.faces.facelets.impl.IdMapper;
 import com.sun.faces.facelets.tag.MetaRulesetImpl;
 import com.sun.faces.facelets.tag.faces.core.FacetHandler;
 import com.sun.faces.util.FacesLogger;
@@ -431,8 +430,7 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
         if (this.id != null && !(this.id.isLiteral() && IterationIdManager.registerLiteralId(ctx, this.id.getValue()))) {
             c.setId(this.id.getValue(ctx));
         } else {
-            IdMapper mapper = IdMapper.getMapper(ctx.getFacesContext());
-            String mid = mapper != null ? mapper.getAliasedId(id) : id;
+            String mid = ComponentSupport.getAliasedId(ctx, id);
             UIComponent ancestorNamingContainer = parent.getNamingContainer();
             if (ancestorNamingContainer instanceof UniqueIdVendor) {
                 c.setId(((UniqueIdVendor) ancestorNamingContainer).createUniqueId(ctx.getFacesContext(), mid));

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -111,6 +111,13 @@ public abstract class UIComponentBase extends UIComponent {
     private static final int CHILD_STATE = 1;
 
     /**
+     * Highest code point {@link #isIdStart(char)} and {@link #isIdPart(char)} answer without consulting
+     * {@link Character}: at or below it, {@code Character.isLetter} matches exactly {@code a-zA-Z} and
+     * {@code Character.isDigit} exactly {@code 0-9}.
+     */
+    private static final char MAX_ASCII = 0x7F;
+
+    /**
      * The attributes map key under which the implementation reads the list of attributes that have been explicitly set
      * on a component, and the package whose components maintain that list. Package private so that
      * {@link ComponentStateHelper} reads the same constants this class writes; the copies in
@@ -3802,18 +3809,24 @@ public abstract class UIComponentBase extends UIComponent {
             throw new IllegalArgumentException("Empty id attribute is not allowed");
         }
 
-        for (int i = 0; i < idLength; i++) {
-            char c = id.charAt(i);
-            if (i == 0) {
-                if (!isLetter(c) && c != '_') {
-                    throw new IllegalArgumentException(id);
-                }
-            } else {
-                if (!isLetter(c) && !isDigit(c) && c != '-' && c != '_') {
-                    throw new IllegalArgumentException(id);
-                }
+        if (!isIdStart(id.charAt(0))) {
+            throw new IllegalArgumentException(id);
+        }
+
+        for (int i = 1; i < idLength; i++) {
+            if (!isIdPart(id.charAt(i))) {
+                throw new IllegalArgumentException(id);
             }
         }
+    }
+
+    private static boolean isIdStart(char c) {
+        return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c == '_' || c > MAX_ASCII && isLetter(c);
+    }
+
+    private static boolean isIdPart(char c) {
+        return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '-' || c == '_'
+                || c > MAX_ASCII && (isLetter(c) || isDigit(c));
     }
 
     private UIComponent findBaseComponent(String expression, final char sepChar) {

--- a/impl/src/test/java/com/sun/faces/facelets/impl/FaceletContextIdMapperTest.java
+++ b/impl/src/test/java/com/sun/faces/facelets/impl/FaceletContextIdMapperTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.facelets.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.el.ELContext;
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * A build aliases every generated id through the {@link IdMapper} the outermost Facelet installed, so the alias a tag
+ * gets may not depend on which Facelet in the build is applying it, nor on the context resolving the mapper again for
+ * every tag.
+ */
+class FaceletContextIdMapperTest {
+
+    private final FacesContext faces = mock(FacesContext.class);
+
+    FaceletContextIdMapperTest() {
+        when(faces.getAttributes()).thenReturn(new HashMap<>());
+        when(faces.getELContext()).thenReturn(mock(ELContext.class));
+    }
+
+    @Test
+    void anIdIsAliasedThroughTheMapperInstalledForTheBuild() {
+        IdMapper mapper = new IdMapper();
+        IdMapper.setMapper(faces, mapper);
+
+        DefaultFaceletContext context = new DefaultFaceletContext(faces, null);
+
+        assertEquals(mapper.getAliasedId("j_id7"), context.getAliasedId("j_id7"));
+        assertNotEquals("j_id7", context.getAliasedId("j_id7"), "the mapper does alias");
+    }
+
+    @Test
+    void anIncludedFaceletAliasesThroughTheOutermostBuildsMapper() {
+        IdMapper.setMapper(faces, new IdMapper());
+
+        DefaultFaceletContext outer = new DefaultFaceletContext(faces, null);
+        DefaultFaceletContext included = new DefaultFaceletContext(outer, null);
+
+        assertEquals(outer.getAliasedId("j_id7"), included.getAliasedId("j_id7"));
+    }
+
+    @Test
+    void withoutAMapperAnIdIsItsOwnAlias() {
+        DefaultFaceletContext context = new DefaultFaceletContext(faces, null);
+
+        assertEquals("j_id7", context.getAliasedId("j_id7"));
+    }
+}

--- a/impl/src/test/java/jakarta/faces/component/UIComponentIdValidationTest.java
+++ b/impl/src/test/java/jakarta/faces/component/UIComponentIdValidationTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.faces.component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.faces.component.html.HtmlPanelGroup;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * An id is valid when it starts with a letter or an underscore and continues with letters, digits, hyphens or
+ * underscores, where letter and digit mean what {@link Character#isLetter(char)} and {@link Character#isDigit(char)}
+ * mean. Almost every id a build validates is ASCII, which the check answers without consulting {@link Character}, so
+ * these pin the two down to the same verdicts on both sides of that boundary.
+ */
+class UIComponentIdValidationTest {
+
+    private static final char ARABIC_INDIC_DIGIT_ZERO = '٠';
+    private static final char E_ACUTE = 'é';
+    private static final char EURO_SIGN = '€';
+
+    @ParameterizedTest
+    @ValueSource(strings = { "_", "a", "Z", "j_id_2c", "form-1", "_1", "é", "aé", "a٠" })
+    void anIdOfLettersDigitsHyphensAndUnderscoresIsAccepted(String id) {
+        UIComponent component = new HtmlPanelGroup();
+
+        component.setId(id);
+
+        assertEquals(id, component.getId());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "", "1abc", "-abc", "a*c", " abc", "a c", "a.c", "a:c" })
+    void anIdOutsideThatAlphabetIsRejected(String id) {
+        UIComponent component = new HtmlPanelGroup();
+
+        assertThrows(IllegalArgumentException.class, () -> component.setId(id));
+    }
+
+    @Test
+    void aNonAsciiDigitIsRejectedAsTheFirstCharacterButAcceptedAfterIt() {
+        UIComponent component = new HtmlPanelGroup();
+
+        assertThrows(IllegalArgumentException.class, () -> component.setId(String.valueOf(ARABIC_INDIC_DIGIT_ZERO)));
+
+        component.setId(E_ACUTE + String.valueOf(ARABIC_INDIC_DIGIT_ZERO));
+    }
+
+    @Test
+    void aNonAsciiCharacterThatIsNeitherLetterNorDigitIsRejected() {
+        UIComponent component = new HtmlPanelGroup();
+
+        assertThrows(IllegalArgumentException.class, () -> component.setId(String.valueOf(EURO_SIGN)));
+        assertThrows(IllegalArgumentException.class, () -> component.setId("a" + EURO_SIGN));
+    }
+}


### PR DESCRIPTION
#5856 

Follow-up to #5933 on the same issue. `RESTORE_VIEW` on a postback is 83% Facelets rebuild (state restore itself does not register in a JFR profile), and the per-component id path is 13% of that. This takes two levers off it. Both are generic view-build wins, so they also pay on the render-side build.

### `UIComponentBase.validateId` — ASCII fast path

Every generated id (`j_id_2c` and friends) was classified with `Character.isLetter`/`isDigit`, i.e. full Unicode lookup via `Character.getType`, which showed up at 1.2% self-time in the profile with the whole check at 3.6% of the phase. Ids are ASCII by construction, so `a-zA-Z0-9-_` is now answered directly and `Character` is consulted only above `0x7F`, where it still decides — at or below it `isLetter` matches exactly `a-zA-Z` and `isDigit` exactly `0-9`, so the verdicts are unchanged. The `i == 0` test also moves out of the loop.

### `IdMapper` off the per-component path

`IdMapper.getMapper(ctx)` is a `Util.notNull` plus a lookup in the `FacesContext` attributes map, and it ran once per component tag *and* once per text node — 4.6% of the phase. But `DefaultFacelet.apply` installs the mapper immediately before it constructs the `DefaultFaceletContext` and removes it only once the whole build is done, so it cannot change while any context in the chain is alive. `DefaultFaceletContext` now holds it as a field (inherited through the nested-context constructor) and answers a new `FaceletContextImplBase.getAliasedId(String)` from it. A wrapping context or a foreign `FaceletContext` implementation keeps the old map lookup, via `ComponentSupport.getAliasedId(FaceletContext, String)`.

### Measurements

Two independent interleaved A/B rounds, Tomcat, 4 reps per arm, 4000 requests per scenario, medians of `avg_us`:

| cell | round 1 | round 2 |
|---|--:|--:|
| flat-table-nofacets RESTORE_VIEW | -3.4% | -5.1% |
| flat-table-facets RESTORE_VIEW | -2.4% | -3.0% |
| flat-build RESTORE_VIEW | -4.6% | -3.2% |
| suite total | -1.1% | -1.5% |

Nothing with a mechanism regressed. Round 2 also carried a `validateId`-only arm: it accounts for most of the movement on the `flat-table-*` cells, with the `IdMapper` hoist worth roughly a further point. Per-lever attribution is only weakly resolved at this noise floor, so treat that split as indicative.

Note that `min_us` is the wrong metric for `RESTORE_VIEW` on the postback scenarios: `PerfBenchIT` issues one GET before the postback block, and that GET's restore (~23µs against ~450µs) is always the minimum, so the column measures the GET.

### Verification

- 1289 unit tests green, including two new ones. `UIComponentIdValidationTest` pins the id alphabet on both sides of the ASCII boundary (a non-ASCII letter is accepted, a non-ASCII digit is rejected as the first character but accepted after it, a non-ASCII character that is neither is rejected). `FaceletContextIdMapperTest` pins that an included Facelet aliases through the outermost build's mapper and that an id is its own alias when no mapper is installed.
- Render output byte-identical across all 40 `test/perf` views (837k bytes both arms), which is the real check here since both levers feed generated component ids.
- Full Faces TCK green against the 5.0 port of this change.

🤖 Generated with Claude Opus 5
