### PR TITLE
Lazily allocate HtmlResponseWriter CDATA buffers

### DIFF
--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/HtmlResponseWriter.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/HtmlResponseWriter.java
@@ -125,14 +125,15 @@ public class HtmlResponseWriter extends ResponseWriter {
     // Enables scripts to be included in attribute values
     private Boolean isScriptInAttributeValueEnabled;
 
-    // Internal buffer used when outputting properly escaped CData information.
-    //
+    // Internal buffers used when outputting properly escaped CData information. Lazily allocated on first
+    // CDATA/script/style write: a plain page never enters the writingCdata path, so eagerly allocating these
+    // (~1.1KB) on every writer — and several writers are created per render — is pure allocation pressure.
     private final static int cdataBufferSize = 1024;
-    private char[] cdataBuffer = new char[cdataBufferSize];
+    private char[] cdataBuffer;
     private int cdataBufferLength = 0;
     // Secondary cdata buffer, used for writeText
     private final static int cdataTextBufferSize = 128;
-    private char[] cdataTextBuffer = new char[cdataTextBufferSize];
+    private char[] cdataTextBuffer;
 
     /**
      * The pass-through attributes of the element currently being started. This aliases the component's own map, so it
@@ -878,13 +879,15 @@ public class HtmlResponseWriter extends ResponseWriter {
             if (textLen > cdataTextBufferSize) {
                 writeEscaped(textStr.toCharArray(), 0, textLen);
             } else if (textLen >= 16) { // >16, < cdataTextBufferSize
-                textStr.getChars(0, textLen, cdataTextBuffer, 0);
-                writeEscaped(cdataTextBuffer, 0, textLen);
+                char[] buf = cdataTextBuffer();
+                textStr.getChars(0, textLen, buf, 0);
+                writeEscaped(buf, 0, textLen);
             } else { // <16
+                char[] buf = cdataTextBuffer();
                 for (int i = 0; i < textLen; i++) {
-                    cdataTextBuffer[i] = textStr.charAt(i);
+                    buf[i] = textStr.charAt(i);
                 }
-                writeEscaped(cdataTextBuffer, 0, textLen);
+                writeEscaped(buf, 0, textLen);
             }
         }
     }
@@ -1296,7 +1299,7 @@ public class HtmlResponseWriter extends ResponseWriter {
         if (cbuf.length >= cdataBufferSize) { // bigger than the buffer, direct write
             writer.write(cbuf);
         }
-        System.arraycopy(cbuf, 0, cdataBuffer, cdataBufferLength, cbuf.length);
+        System.arraycopy(cbuf, 0, cdataBuffer(), cdataBufferLength, cbuf.length);
         cdataBufferLength = cdataBufferLength + cbuf.length;
     }
 
@@ -1307,8 +1310,25 @@ public class HtmlResponseWriter extends ResponseWriter {
         if (cdataBufferLength + 1 >= cdataBufferSize) {
             flushBuffer();
         }
-        cdataBuffer[cdataBufferLength] = c;
+        cdataBuffer()[cdataBufferLength] = c;
         cdataBufferLength++;
+    }
+
+    /*
+     * lazily-allocated CDATA buffers; only touched on the writingCdata path
+     */
+    private char[] cdataBuffer() {
+        if (cdataBuffer == null) {
+            cdataBuffer = new char[cdataBufferSize];
+        }
+        return cdataBuffer;
+    }
+
+    private char[] cdataTextBuffer() {
+        if (cdataTextBuffer == null) {
+            cdataTextBuffer = new char[cdataTextBufferSize];
+        }
+        return cdataTextBuffer;
     }
 
     /*


### PR DESCRIPTION
#5856 

### What

Allocate `HtmlResponseWriter`'s two CDATA buffers on first use instead of in field initializers.

`cdataBuffer` (1KB) and `cdataTextBuffer` (128B) are only touched on the `writingCdata` path — `<script>`/`<style>`/CDATA and ajax-partial content. A plain page never enters it, so every writer was paying ~1.1KB of `char[]` for buffers it would not use, and several writers are built per render: the main one, the `WriteBehindStateWriter` clone, and one per `MenuRenderer` select (which clones the whole writer just to buffer its options for the size count).

`flushBuffer` still reads the field raw — that is safe because it returns early on `cdataBufferLength == 0`, so it only reaches the buffer after a write allocated it.

### Measurements

Tomcat, `test/perf` `flat-allattrs`, 8000 runs, JFR allocation profile of RENDER_RESPONSE:

| | before | after |
|---|--:|--:|
| `cloneWithWriter` | 155.4 MB | 27.0 MB |
| `char[]` | 406.7 MB | 251.1 MB |
| RENDER total | 2501 MB | 2379 MB |

Roughly 16KB per request. **Wall time is unchanged** — 4 interleaved jar-swapped reps put `flat-allattrs` render at +0.5% on `min_us` with a 2.5% spread, and the suite total at +0.1%. This reduces allocation pressure and GC frequency; it is not a throughput win and should not be read as one.

1289 impl unit tests green.

### Note

This is a backport of e43da38d04, which landed on master in July and never reached 4.0 or 4.1. The content is identical. Once this upmerges 4.0 → 4.1 → master, the master merge will collide with the commit already there; take either side, they are the same change.

🤖 Generated with Claude Opus 5
