### PR TITLE
UIValidateWholeBean avoid multiple copy of UIComponent children

### DIFF
--- a/impl/src/main/java/com/sun/faces/ext/component/UIValidateWholeBean.java
+++ b/impl/src/main/java/com/sun/faces/ext/component/UIValidateWholeBean.java
@@ -139,7 +139,7 @@ public class UIValidateWholeBean extends UIInput implements PartialStateHolder {
 
     private static void misplacedComponentCheck(UIComponent parentComponent, String clientId) throws IllegalArgumentException {
         try {
-            reverse(parentComponent.getChildren()).stream().forEach((UIComponent childComponent) -> {
+            for (UIComponent childComponent : reverse(parentComponent.getChildren())) {
                 if (childComponent.isRendered()) {
                     if (childComponent instanceof EditableValueHolder && !(childComponent instanceof UIValidateWholeBean)) {
                         throw new IllegalArgumentException(ERROR_MISPLACED_COMPONENT);
@@ -151,7 +151,7 @@ public class UIValidateWholeBean extends UIInput implements PartialStateHolder {
                         }
                     }
                 }
-            });
+            }
         } catch (BreakException be) {
             // STOP
         }

--- a/impl/src/main/java/com/sun/faces/util/Util.java
+++ b/impl/src/main/java/com/sun/faces/util/Util.java
@@ -56,6 +56,7 @@ import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -737,15 +738,18 @@ public class Util {
         return null;
     }
 
-    public static <T> List<T> reverse(List<T> list) {
-        int length = list.size();
-        List<T> result = new ArrayList<>(length);
-
-        for (int i = length - 1; i >= 0; i--) {
-            result.add(list.get(i));
-        }
-
-        return result;
+    /**
+     * @deprecated use Java 21 List#reversed()
+     * @return a view of the passed {@link List} with all the elements in reverse order
+     */
+    @Deprecated(forRemoval = true, since = "5.0")
+    public static <T> Iterable<T> reverse(final List<T> list) {
+        return () -> new Iterator<T>() {
+            private final ListIterator<T> li = list.listIterator(list.size());
+            @Override public boolean hasNext() { return li.hasPrevious(); }
+            @Override public T next() { return li.previous(); }
+            @Override public void remove() { li.remove(); }
+        };
     }
 
     /**


### PR DESCRIPTION
UIValidateWholeBean avoid multiple copy of UIComponent children

Util.reverse
 - return a reversed view of the List (no copy)
 - deprecated because is superseeded by Java 21 List.reversed
