### PR TITLE
Record restored attributes where the setters would have put them

### DIFF
--- a/impl/src/main/java/jakarta/faces/component/ComponentStateHelper.java
+++ b/impl/src/main/java/jakarta/faces/component/ComponentStateHelper.java
@@ -372,7 +372,7 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
 
     /*
      * Because our renderers optimize we need to make sure that upon restore we mimic the handleAttribute of our standard
-     * generated HTML components setter methods.
+     * generated HTML components setter methods -- including where in the list it records a name, not only that it does.
      */
     private void handleAttribute(String name, Object value) {
         List<String> setAttributes = (List<String>) component.getAttributes().get(UIComponentBase.ATTRIBUTES_THAT_ARE_SET);
@@ -390,10 +390,38 @@ class ComponentStateHelper implements StateHelper, TransientStateHelper {
                 if (valueExpression == null) {
                     setAttributes.remove(name);
                 }
-            } else if (!setAttributes.contains(name)) {
-                setAttributes.add(name);
+            } else {
+                int index = insertionPoint(setAttributes, name);
+                if (index >= 0) {
+                    setAttributes.add(index, name);
+                }
             }
         }
+    }
+
+    /**
+     * Returns the index at which {@code name} belongs for the recorded attributes to stay in natural order, or -1 when
+     * it is recorded already.
+     * <p>
+     * Mirrors {@code jakarta.faces.component.html.HtmlComponentUtils.insertionPoint}, which is package-private to a
+     * package this one cannot see. The two must agree: a name recorded here in a different position than the setter
+     * would have put it makes a component restored from full state render its attributes in a different order than the
+     * same component built from the view.
+     */
+    private static int insertionPoint(List<String> setAttributes, String name) {
+        int index = setAttributes.size();
+
+        for (int i = 0; i < setAttributes.size(); i++) {
+            int order = setAttributes.get(i).compareTo(name);
+            if (order == 0) {
+                return -1;
+            }
+            if (order > 0 && i < index) {
+                index = i;
+            }
+        }
+
+        return index;
     }
 
     /**

--- a/impl/src/test/java/jakarta/faces/component/ComponentStateHelperTest.java
+++ b/impl/src/test/java/jakarta/faces/component/ComponentStateHelperTest.java
@@ -16,9 +16,15 @@
 
 package jakarta.faces.component;
 
+import static java.util.Comparator.comparing;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.faces.component.html.HtmlOutputText;
 import jakarta.faces.component.html.HtmlPanelGroup;
 import jakarta.faces.context.FacesContext;
 
@@ -61,9 +67,60 @@ class ComponentStateHelperTest {
         assertTrackedAttributes(restored, "styleClass");
     }
 
-    @SuppressWarnings("unchecked")
+    /**
+     * Rendering emits the tracked attributes in the order of this list, so restoring full state must record them where
+     * the setters would have. Otherwise the same component renders its attributes in one order when the view builds it
+     * and another when a postback restores it, under {@code partialStateSaving=false}.
+     * <p>
+     * The saved entries are replayed in the iteration order of the state map, so the tracked list may be rebuilt from
+     * the individual properties before the saved copy of the list itself is merged in. This moves that copy last to
+     * exercise that path, which is otherwise reached or not depending on where the key happens to hash.
+     */
+    @Test
+    void restoringFullStateRecordsTheAttributesInTheOrderTheSettersWouldHave() {
+        FacesContext context = mock(FacesContext.class);
+
+        HtmlOutputText built = new HtmlOutputText();
+        built.setTitle("t");
+        built.setDir("ltr");
+        built.setStyle("color:#000");
+        built.setLang("en");
+
+        HtmlOutputText restored = new HtmlOutputText();
+        restored.getStateHelper().restoreState(context, trackedListLast(built.getStateHelper().saveState(context)));
+
+        assertEquals(trackedAttributes(built), trackedAttributes(restored));
+    }
+
+    /**
+     * Returns the saved state with the {@code attributesThatAreSet} entry moved to the end, so restoring replays every
+     * property before it.
+     */
+    private static Object[] trackedListLast(Object state) {
+        Object[] saved = (Object[]) state;
+        List<Object[]> entries = new ArrayList<>();
+
+        for (int i = 0; i < (saved.length - 1) / 2; i++) {
+            entries.add(new Object[] { saved[i * 2], saved[i * 2 + 1] });
+        }
+
+        entries.sort(comparing(entry -> UIComponent.PropertyKeysPrivate.attributesThatAreSet.equals(entry[0])));
+
+        Object[] reordered = new Object[saved.length];
+        for (int i = 0; i < entries.size(); i++) {
+            reordered[i * 2] = entries.get(i)[0];
+            reordered[i * 2 + 1] = entries.get(i)[1];
+        }
+        reordered[saved.length - 1] = saved[saved.length - 1];
+        return reordered;
+    }
+
     private static void assertTrackedAttributes(UIComponent component, String... expected) {
-        org.junit.jupiter.api.Assertions.assertEquals(java.util.List.of(expected),
-                component.getAttributes().get(UIComponentBase.ATTRIBUTES_THAT_ARE_SET));
+        assertEquals(List.of(expected), trackedAttributes(component));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> trackedAttributes(UIComponent component) {
+        return (List<String>) component.getAttributes().get(UIComponentBase.ATTRIBUTES_THAT_ARE_SET);
     }
 }


### PR DESCRIPTION
### The bug

A standard component's pass-through attributes are emitted in the order of its `attributesThatAreSet` list. #5926 removed the per-render `Collections.sort(setAttributes)` and made the writers keep the list in natural order instead — but only updated one of them. `ComponentStateHelper.handleAttribute`, which re-records the list when full state saving restores a component without running its setters, still appends.

So the two writers disagree. A component built from the view lists its attributes sorted; the same component restored from full state lists them in whatever order its state entries happened to be replayed in, and renders its HTML attributes in that order.

With `partialStateSaving=false`, an `h:outputText` carrying `dir`, `lang`, `style` and `title`:

| | rendered |
|---|---|
| initial request | `dir lang role style title` |
| postback | `role title style lang dir` |

Same view, same component, different markup.

Whether it bites is a coin flip: `restoreState` replays the saved entries in the state map's iteration order, so if the `attributesThatAreSet` entry happens to come first, every later `handleAttribute` finds its name already present and appends nothing. That is also why it went unnoticed.

### The fix

Mirror the insertion the setters use, so both writers record a name in the same place.

`HtmlComponentUtils.insertionPoint` is package-private to `jakarta.faces.component.html`, which `jakarta.faces.component` cannot see, so the rule is repeated rather than shared — the same wall that already forces the `ATTRIBUTES_THAT_ARE_SET` constant to be duplicated across those packages. The javadoc on each says the two must agree.

### Coverage

`ComponentStateHelperTest.restoringFullStateRecordsTheAttributesInTheOrderTheSettersWouldHave` builds a component through its setters, saves, restores, and asserts the tracked order matches.

It moves the saved `attributesThatAreSet` entry to the end first, so the properties are replayed before it — otherwise the test passes on unfixed code, depending on where the key happens to hash. Without the fix it fails with `[style, lang, dir, title]` against the expected `[dir, lang, style, title]`.

Full impl suite green: 1290 tests.

### Scope

Not in any release — #5926 is unreleased on 4.0, 4.1 and master, so nothing shipped is affected. This changes only where the restore path records a name; emission order is unchanged (still sorted), and no rendered output changes for the partial-state-saving default.

The end-to-end symptom above was captured on the 5.0 branch, which has no `test/perf` equivalent here to reproduce it on; the restore-mimic is byte-identical between the branches.

🤖 Generated with Claude Opus 5
