### PR TITLE
Walk the form by index in f:validateWholeBean's placement check

### DIFF
--- a/impl/src/main/java/com/sun/faces/ext/component/UIValidateWholeBean.java
+++ b/impl/src/main/java/com/sun/faces/ext/component/UIValidateWholeBean.java
@@ -16,7 +16,6 @@
 
 package com.sun.faces.ext.component;
 
-import static com.sun.faces.util.Util.reverse;
 import static jakarta.faces.validator.BeanValidator.EMPTY_VALIDATION_GROUPS_PATTERN;
 import static jakarta.faces.validator.BeanValidator.ENABLE_VALIDATE_WHOLE_BEAN_PARAM_NAME;
 import static jakarta.faces.validator.BeanValidator.VALIDATION_GROUPS_DELIMITER;
@@ -134,27 +133,41 @@ public class UIValidateWholeBean extends UIInput implements PartialStateHolder {
             throw new IllegalArgumentException(ERROR_MISSING_FORM);
         }
 
-        misplacedComponentCheck(parent, getClientId());
+        misplacedComponentCheck(parent);
     }
 
-    private static void misplacedComponentCheck(UIComponent parentComponent, String clientId) throws IllegalArgumentException {
-        try {
-            reverse(parentComponent.getChildren()).stream().forEach((UIComponent childComponent) -> {
-                if (childComponent.isRendered()) {
-                    if (childComponent instanceof EditableValueHolder && !(childComponent instanceof UIValidateWholeBean)) {
-                        throw new IllegalArgumentException(ERROR_MISPLACED_COMPONENT);
-                    } else {
-                        if (!childComponent.getClientId().equals(clientId)) {
-                            misplacedComponentCheck(childComponent, clientId);
-                        } else {
-                            throw new BreakException();
-                        }
-                    }
-                }
-            });
-        } catch (BreakException be) {
-            // STOP
+    /**
+     * Walks the form backwards looking for a rendered input placed after this component, which whole-bean validation
+     * cannot see the submitted value of, and stops as soon as it reaches this component itself: everything before it is
+     * in the right place by definition.
+     *
+     * @return whether this component was reached, which ends the walk for the caller too
+     * @throws IllegalArgumentException when a rendered input sits after this component
+     */
+    private boolean misplacedComponentCheck(UIComponent parentComponent) throws IllegalArgumentException {
+        List<UIComponent> children = parentComponent.getChildren();
+
+        for (int i = children.size() - 1; i >= 0; i--) {
+            UIComponent childComponent = children.get(i);
+
+            if (!childComponent.isRendered()) {
+                continue;
+            }
+
+            if (childComponent == this) {
+                return true;
+            }
+
+            if (childComponent instanceof EditableValueHolder && !(childComponent instanceof UIValidateWholeBean)) {
+                throw new IllegalArgumentException(ERROR_MISPLACED_COMPONENT);
+            }
+
+            if (misplacedComponentCheck(childComponent)) {
+                return true;
+            }
         }
+
+        return false;
     }
 
     public static <C extends UIComponent> C getClosestParent(UIComponent component, Class<C> parentType) {
@@ -275,7 +288,4 @@ public class UIValidateWholeBean extends UIInput implements PartialStateHolder {
         }
     }
 
-    private static class BreakException extends RuntimeException {
-        private static final long serialVersionUID = 1L;
-    }
 }

--- a/impl/src/main/java/com/sun/faces/util/Util.java
+++ b/impl/src/main/java/com/sun/faces/util/Util.java
@@ -712,17 +712,6 @@ public class Util {
         return null;
     }
 
-    public static <T> List<T> reverse(List<T> list) {
-        int length = list.size();
-        List<T> result = new ArrayList<>(length);
-
-        for (int i = length - 1; i >= 0; i--) {
-            result.add(list.get(i));
-        }
-
-        return result;
-    }
-
     /**
      * Returns <code>true</code> if the given string starts with one of the given prefixes.
      *

--- a/impl/src/test/java/com/sun/faces/ext/component/UIValidateWholeBeanTest.java
+++ b/impl/src/test/java/com/sun/faces/ext/component/UIValidateWholeBeanTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.ext.component;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIForm;
+import jakarta.faces.component.UIInput;
+import jakarta.faces.component.UIPanel;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@code f:validateWholeBean} validates a bean whose properties the inputs before it have already applied, so a
+ * rendered input placed after it would not be part of what it validates. It rejects that at render time by walking the
+ * form backwards from the last child until it reaches itself.
+ */
+class UIValidateWholeBeanTest {
+
+    @Test
+    void anInputAfterTheValidatorIsRejected() {
+        UIForm form = new UIForm();
+        UIValidateWholeBean validator = new UIValidateWholeBean();
+        form.getChildren().add(new UIInput());
+        form.getChildren().add(validator);
+        form.getChildren().add(new UIInput());
+
+        assertThrows(IllegalArgumentException.class, () -> validator.encodeBegin(null));
+    }
+
+    @Test
+    void inputsBeforeTheValidatorAreAccepted() {
+        UIForm form = new UIForm();
+        UIValidateWholeBean validator = new UIValidateWholeBean();
+        form.getChildren().add(new UIInput());
+        form.getChildren().add(new UIInput());
+        form.getChildren().add(validator);
+
+        assertDoesNotThrow(() -> validator.encodeBegin(null));
+    }
+
+    /**
+     * The walk recurses into containers, so an input nested behind one still counts as placed after the validator.
+     */
+    @Test
+    void anInputNestedInAContainerAfterTheValidatorIsRejected() {
+        UIForm form = new UIForm();
+        UIValidateWholeBean validator = new UIValidateWholeBean();
+        UIPanel panel = new UIPanel();
+        panel.getChildren().add(new UIInput());
+        form.getChildren().add(new UIInput());
+        form.getChildren().add(validator);
+        form.getChildren().add(panel);
+
+        assertThrows(IllegalArgumentException.class, () -> validator.encodeBegin(null));
+    }
+
+    /**
+     * A container holding exactly one child is the case a reverse walk is most likely to get wrong off by one, and it
+     * is a common panelGroup/panelGrid shape, so it gets its own test rather than relying on the nested case above.
+     */
+    @Test
+    void aSingleChildContainerAfterTheValidatorIsStillWalked() {
+        UIForm form = new UIForm();
+        UIValidateWholeBean validator = new UIValidateWholeBean();
+        UIPanel panel = new UIPanel();
+        panel.getChildren().add(new UIInput());
+        form.getChildren().add(validator);
+        form.getChildren().add(panel);
+
+        assertThrows(IllegalArgumentException.class, () -> validator.encodeBegin(null));
+    }
+
+    /**
+     * The first child of the form is the last one the backwards walk reaches, so it is the one an off-by-one drops.
+     */
+    @Test
+    void anInputAsTheVeryFirstChildIsNotMistakenForBeingAfterTheValidator() {
+        UIForm form = new UIForm();
+        UIValidateWholeBean validator = new UIValidateWholeBean();
+        form.getChildren().add(new UIInput());
+        form.getChildren().add(validator);
+
+        assertDoesNotThrow(() -> validator.encodeBegin(null));
+    }
+
+    @Test
+    void anUnrenderedInputAfterTheValidatorIsIgnored() {
+        UIForm form = new UIForm();
+        UIValidateWholeBean validator = new UIValidateWholeBean();
+        UIComponent hidden = new UIInput();
+        hidden.setRendered(false);
+        form.getChildren().add(validator);
+        form.getChildren().add(hidden);
+
+        assertDoesNotThrow(() -> validator.encodeBegin(null));
+    }
+
+    @Test
+    void aValidatorOutsideAFormIsRejected() {
+        UIValidateWholeBean validator = new UIValidateWholeBean();
+        new UIPanel().getChildren().add(validator);
+
+        assertThrows(IllegalArgumentException.class, () -> validator.encodeBegin(null));
+    }
+}


### PR DESCRIPTION
An alternative to #5936, which set out to stop `f:validateWholeBean`'s placement check from copying the form's children. It does, and this takes the same goal further by removing the need for the utility altogether.

### What the check was doing

`misplacedComponentCheck` walks the form backwards looking for a rendered input placed after `f:validateWholeBean`. Per form, per render, it copied the children into a new `ArrayList`, streamed that, built every child's client id to compare against its own, and ended the walk by throwing `BreakException` — which does not override `fillInStackTrace`, and which is the *normal* exit, since reaching itself is how the walk terminates.

### What this does

Iterates the children by index, compares by identity, and reports reaching itself as a return value. `Util.reverse` and `BreakException` are left without callers and are deleted.

| per form, per render | before | #5936 | this |
|---|---|---|---|
| `ArrayList` copy per level | ✗ | removed | removed |
| `Stream` + lambda per level | ✗ | removed | removed |
| `BreakException` with stack trace on the normal exit | ✗ | ✗ | removed |
| `getClientId()` per child walked | ✗ | ✗ | removed |

I have **not** benchmarked the relative sizes of those four. My reasoning is that the copy is the cheapest of them — one array allocation plus N reference writes — while `fillInStackTrace` on every successful walk and a naming-container walk plus string build per child are each larger. That ordering is mechanism reasoning, not measurement; this path isn't in the perf suite, so measuring it would need a purpose-built harness.

### Correctness

Beyond the allocation, this avoids `ListIterator` entirely. `UIComponentBase.ChildrenListIterator.hasPrevious()` returns `index > 1`, where the `ListIterator` contract requires `index > 0`, so a backwards walk through it never yields the child at index 0 and a single-child container yields nothing at all. That is a long-standing latent bug — nothing in the tree walked children backwards through `listIterator` before — and it is orthogonal to this change, which simply doesn't rely on that iterator.

### Tests

Seven cases covering: an input after the validator, inputs before it, an input nested in a container after it, a single-child container after it, an input as the very first child, an unrendered input after it, and a validator outside a form.

They run without a `FacesContext`, which is only possible because the walk no longer builds client ids — a side benefit of the change worth noting on its own.

Full impl suite green: 1296 tests.

### Trade-offs

- This deletes `Util.reverse` rather than keeping it. It had exactly one caller. If a second one ever appears the utility has to come back, and #5936's lazy version would have served it; with no other callers today I think removing it is the better trade, but it is a trade.
- Deleting a `public static` method from `com.sun.faces.util.Util` is a bigger binary-compatibility change than altering its return type. That only matters if the package is treated as API rather than implementation — if it is, this PR is the worse offender of the two and should keep the method as a deprecated delegate instead. Happy to do that if maintainers prefer.

🤖 Generated with Claude Opus 5
