### PR TITLE
Split on a literal delimiter instead of through a Pattern cache

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/ApplicationAssociate.java
+++ b/impl/src/main/java/com/sun/faces/application/ApplicationAssociate.java
@@ -258,7 +258,7 @@ public class ApplicationAssociate {
             resourceCache = new ResourceCache();
         }
 
-        resourceManager = new ResourceManager(applicationMap, resourceCache);
+        resourceManager = new ResourceManager(resourceCache);
         namedEventManager = new NamedEventManager();
         applicationStateInfo = new ApplicationStateInfo();
 
@@ -331,8 +331,7 @@ public class ApplicationAssociate {
 
         FacesContext ctx = FacesContext.getCurrentInstance();
 
-        Map<String, Object> appMap = ctx.getExternalContext().getApplicationMap();
-        compiler = createCompiler(appMap, webConfig);
+        compiler = createCompiler(webConfig);
         faceletFactory = createFaceletFactory(ctx, compiler, webConfig);
     }
 
@@ -649,10 +648,10 @@ public class ApplicationAssociate {
         return toReturn;
     }
 
-    protected Compiler createCompiler(Map<String, Object> appMap, WebConfiguration webConfig) {
+    protected Compiler createCompiler(WebConfiguration webConfig) {
         Compiler newCompiler = new SAXCompiler();
 
-        loadDecorators(appMap, newCompiler);
+        loadDecorators(newCompiler);
 
         // Skip params?
         newCompiler.setTrimmingComments(webConfig.isOptionEnabled(FaceletsSkipComments));
@@ -662,11 +661,11 @@ public class ApplicationAssociate {
         return newCompiler;
     }
 
-    protected void loadDecorators(Map<String, Object> appMap, Compiler newCompiler) {
+    protected void loadDecorators(Compiler newCompiler) {
         String decoratorsParamValue = webConfig.getOptionValue(FaceletsDecorators);
 
         if (decoratorsParamValue != null) {
-            for (String decorator : split(appMap, decoratorsParamValue.trim(), ";")) {
+            for (String decorator : split(decoratorsParamValue.trim(), ";")) {
                 try {
                     newCompiler
                             .addTagDecorator((TagDecorator) forName(decorator).getDeclaredConstructor().newInstance());

--- a/impl/src/main/java/com/sun/faces/application/NavigationHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/NavigationHandlerImpl.java
@@ -119,6 +119,8 @@ public class NavigationHandlerImpl extends ConfigurableNavigationHandler {
      * Flag indicated the current mode.
      */
     private boolean development;
+    /** Query strings reach here both raw and HTML-escaped, so both forms of the parameter separator are matched. */
+    private static final Pattern QUERY_STRING_SEPARATOR = Pattern.compile("&amp;|&");
     private static final Pattern REDIRECT_EQUALS_TRUE = Pattern.compile("(.*)(faces-redirect=true)(.*)");
     private static final Pattern INCLUDE_VIEW_PARAMS_EQUALS_TRUE = Pattern.compile("(.*)(includeViewParams=true)(.*)");
 
@@ -863,11 +865,9 @@ public class NavigationHandlerImpl extends ConfigurableNavigationHandler {
             }
 
             if (queryString != null && queryString.length() > 0) {
-                Map<String, Object> appMap = context.getExternalContext().getApplicationMap();
-
-                String[] queryElements = Util.split(appMap, queryString, "&amp;|&");
+                String[] queryElements = QUERY_STRING_SEPARATOR.split(queryString);
                 for (int i = 0, len = queryElements.length; i < len; i++) {
-                    String[] elements = Util.split(appMap, queryElements[i], "=", 2);
+                    String[] elements = Util.split(queryElements[i], "=", 2);
                     if (elements.length == 2) {
                         String rightHandSide = elements[1];
                         String sanitized = null != rightHandSide && 2 < rightHandSide.length() ? rightHandSide.trim() : "";

--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
@@ -107,7 +107,7 @@ public class ResourceHandlerImpl extends ResourceHandler {
         webconfig = WebConfiguration.getInstance();
         ExternalContext extContext = FacesContext.getCurrentInstance().getExternalContext();
         manager = ApplicationAssociate.getInstance(extContext).getResourceManager();
-        initExclusions(extContext.getApplicationMap());
+        initExclusions();
         initMaxAge();
         cspEnabled = webconfig.isOptionEnabled(WebConfiguration.BooleanWebContextInitParameter.CspNonceEnabled);
         if (cspEnabled) {
@@ -609,7 +609,7 @@ public class ResourceHandlerImpl extends ResourceHandler {
     }
 
     /**
-     * @param excludedExtensions the excluded file extensions as returned by {@link #parseExcludedExtensions(Map, String)}
+     * @param excludedExtensions the excluded file extensions as returned by {@link #parseExcludedExtensions(String)}
      * @param resourceId the normalized request path as returned by
      * {@link #normalizeResourceRequest(jakarta.faces.context.FacesContext)}
      * @return <code>true</code> if the request matces an excluded resource, otherwise <code>false</code>
@@ -628,8 +628,8 @@ public class ResourceHandlerImpl extends ResourceHandler {
      * Initialize the exclusions for this application. If no explicit exclusions are configured, the defaults of
      * {@link ResourceHandler#RESOURCE_EXCLUDES_DEFAULT_VALUE} will be used.
      */
-    private void initExclusions(Map<String, Object> appMap) {
-        excludedExtensions = parseExcludedExtensions(appMap, webconfig.getOptionValue(ResourceExcludes));
+    private void initExclusions() {
+        excludedExtensions = parseExcludedExtensions(webconfig.getOptionValue(ResourceExcludes));
     }
 
     /**
@@ -637,8 +637,8 @@ public class ResourceHandlerImpl extends ResourceHandler {
      * @param excludesParam the space separated list of file extensions, including the leading '.' character
      * @return the excluded file extensions, without empty entries, as an empty entry would exclude every resource
      */
-    static String[] parseExcludedExtensions(Map<String, Object> appMap, String excludesParam) {
-        return Stream.of(Util.split(appMap, excludesParam, " ")).filter(extension -> !extension.isEmpty()).toArray(String[]::new);
+    static String[] parseExcludedExtensions(String excludesParam) {
+        return Stream.of(Util.split(excludesParam, " ")).filter(extension -> !extension.isEmpty()).toArray(String[]::new);
     }
 
     private void initMaxAge() {

--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceHelper.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceHelper.java
@@ -36,7 +36,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -515,8 +514,7 @@ public abstract class ResourceHelper {
      */
     private VersionInfo getVersion(String pathElement, boolean isResource) {
 
-        Map<String, Object> appMap = FacesContext.getCurrentInstance().getExternalContext().getApplicationMap();
-        String[] pathElements = Util.split(appMap, pathElement, "/");
+        String[] pathElements = Util.split(pathElement, "/");
         String path = pathElements[pathElements.length - 1];
 
         String extension = null;
@@ -737,9 +735,8 @@ public abstract class ResourceHelper {
                     String message = MessageUtils.getExceptionMessageString(MessageUtils.INVALID_RESOURCE_FORMAT_COLON_ERROR, expressionBody);
                     throw new ELException(message);
                 }
-                Map<String, Object> appMap = FacesContext.getCurrentInstance().getExternalContext().getApplicationMap();
 
-                String[] parts = Util.split(appMap, expressionBody, ":");
+                String[] parts = Util.split(expressionBody, ":");
                 if (null == parts[0] || null == parts[1]) {
                     String message = MessageUtils.getExceptionMessageString(MessageUtils.INVALID_RESOURCE_FORMAT_NO_LIBRARY_NAME_ERROR, expressionBody);
                     throw new ELException(message);

--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceManager.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceManager.java
@@ -21,10 +21,8 @@ import static com.sun.faces.util.Util.ensureLeadingSlash;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import java.util.concurrent.locks.ReentrantLock;
@@ -92,25 +90,14 @@ public class ResourceManager {
 
     // ------------------------------------------------------------ Constructors
 
-    /*
-     * This ctor is only ever called by test code.
-     */
-
-    public ResourceManager(ResourceCache cache) {
-        this.cache = cache;
-        Map<String, Object> throwAwayMap = new HashMap<>();
-        initCompressableTypes(throwAwayMap);
-    }
-
     /**
      * Constructs a new <code>ResourceManager</code>. Note: if the current {@link ProjectStage} is
      * {@link ProjectStage#Development} caching or {@link ResourceInfo} instances will not occur.
-     * @param appMap the application map
      * @param cache the resource cache
      */
-    public ResourceManager(Map<String, Object> appMap, ResourceCache cache) {
+    public ResourceManager(ResourceCache cache) {
         this.cache = cache;
-        initCompressableTypes(appMap);
+        initCompressableTypes();
     }
 
     // ------------------------------------------------------ Public Methods
@@ -606,12 +593,12 @@ public class ResourceManager {
     /**
      * Init <code>compressableTypes</code> from the configuration.
      */
-    private void initCompressableTypes(Map<String, Object> appMap) {
+    private void initCompressableTypes() {
 
         WebConfiguration config = WebConfiguration.getInstance();
         String value = config.getOptionValue(WebConfiguration.WebContextInitParameter.CompressableMimeTypes);
         if (value != null && value.length() > 0) {
-            String[] values = Util.split(appMap, value, ",");
+            String[] values = Util.split(value, ",");
             if (values != null) {
                 for (String s : values) {
                     String pattern = s.trim();

--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -906,9 +906,8 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
 
         String viewMappings = webConfig.getOptionValue(FaceletsViewMappings);
         if (viewMappings != null && viewMappings.length() > 0) {
-            Map<String, Object> appMap = FacesContext.getCurrentInstance().getExternalContext().getApplicationMap();
 
-            String[] mappingsArray = split(appMap, viewMappings, ";");
+            String[] mappingsArray = split(viewMappings, ";");
 
             List<String> prefixesList = new ArrayList<>(mappingsArray.length);
 
@@ -1358,7 +1357,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
             if (targetsExpression != null) {
                 String targets = (String) targetsExpression.getValue(ctx.getELContext());
                 if (targets != null) {
-                    return Util.split(ctx.getExternalContext().getApplicationMap(), targets, " ");
+                    return Util.split(targets, " ");
                 }
             }
 

--- a/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
+++ b/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
@@ -276,6 +276,20 @@ public class WebConfiguration {
         return getFacesConfigOptionValue(param, false);
     }
 
+    /**
+     * As {@link #getOptionValue(WebContextInitParameter, String)}, for a parameter whose values are separated by
+     * something only a regular expression can describe rather than by one literal delimiter.
+     *
+     * @param param the parameter to read
+     * @param sep the pattern separating the values
+     * @return the trimmed, non-empty values
+     */
+    public String[] getOptionValue(WebContextInitParameter param, Pattern sep) {
+        String value = getOptionValue(param);
+        return value == null ? new String[0]
+                : stream(sep.split(value)).map(String::trim).filter(not(String::isEmpty)).toArray(String[]::new);
+    }
+
     public String[] getOptionValue(WebContextInitParameter param, String sep) {
         String[] result;
 
@@ -284,8 +298,7 @@ public class WebConfiguration {
             if (value == null) {
                 result = new String[0];
             } else {
-                Map<String, Object> appMap = FacesContext.getCurrentInstance().getExternalContext().getApplicationMap();
-                result = stream(split(appMap, value, sep)).map(String::trim).filter(not(String::isEmpty)).toArray(String[]::new);
+                result = stream(split(value, sep)).map(String::trim).filter(not(String::isEmpty)).toArray(String[]::new);
             }
             cachedListParams.put(param, result);
         }

--- a/impl/src/main/java/com/sun/faces/config/configprovider/BaseWebConfigResourceProvider.java
+++ b/impl/src/main/java/com/sun/faces/config/configprovider/BaseWebConfigResourceProvider.java
@@ -17,7 +17,6 @@
 package com.sun.faces.config.configprovider;
 
 import static com.sun.faces.config.WebConfiguration.WebContextInitParameter.JakartaFacesConfigFiles;
-import static com.sun.faces.util.Util.split;
 import static java.util.Arrays.binarySearch;
 import static java.util.logging.Level.WARNING;
 
@@ -25,6 +24,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.regex.Pattern;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -55,7 +55,7 @@ public abstract class BaseWebConfigResourceProvider implements ConfigurationReso
         Set<URI> urls = new LinkedHashSet<>(6);
 
         if (paths != null) {
-            for (String token : split(context, paths.trim(), getSeparatorRegex())) {
+            for (String token : getSeparatorPattern().split(paths.trim())) {
                 String path = token.trim();
                 if (!isExcluded(path) && path.length() != 0) {
                     URI u = getContextURLForPath(context, path);
@@ -80,7 +80,7 @@ public abstract class BaseWebConfigResourceProvider implements ConfigurationReso
 
     protected abstract String[] getExcludedResources();
 
-    protected abstract String getSeparatorRegex();
+    protected abstract Pattern getSeparatorPattern();
 
     protected URI getContextURLForPath(ServletContext context, String path) {
         try {

--- a/impl/src/main/java/com/sun/faces/config/configprovider/WebFaceletTaglibResourceProvider.java
+++ b/impl/src/main/java/com/sun/faces/config/configprovider/WebFaceletTaglibResourceProvider.java
@@ -18,6 +18,8 @@ package com.sun.faces.config.configprovider;
 
 import static com.sun.faces.config.WebConfiguration.WebContextInitParameter.FaceletsLibraries;
 
+import java.util.regex.Pattern;
+
 import com.sun.faces.config.WebConfiguration.WebContextInitParameter;
 
 /**
@@ -25,7 +27,7 @@ import com.sun.faces.config.WebConfiguration.WebContextInitParameter;
  */
 public class WebFaceletTaglibResourceProvider extends BaseWebConfigResourceProvider {
 
-    private static final String SEPARATOR = ";";
+    private static final Pattern SEPARATOR = Pattern.compile(";", Pattern.LITERAL);
     private static final String[] EXCLUDES = {};
 
     // ------------------------------ Methods from BaseWebConfigResourceProvider
@@ -41,7 +43,7 @@ public class WebFaceletTaglibResourceProvider extends BaseWebConfigResourceProvi
     }
 
     @Override
-    protected String getSeparatorRegex() {
+    protected Pattern getSeparatorPattern() {
         return SEPARATOR;
     }
 }

--- a/impl/src/main/java/com/sun/faces/config/configprovider/WebFacesConfigResourceProvider.java
+++ b/impl/src/main/java/com/sun/faces/config/configprovider/WebFacesConfigResourceProvider.java
@@ -19,6 +19,7 @@ package com.sun.faces.config.configprovider;
 import static com.sun.faces.config.WebConfiguration.WebContextInitParameter.JakartaFacesConfigFiles;
 
 import java.net.URI;
+import java.util.regex.Pattern;
 import java.util.Collection;
 
 import com.sun.faces.config.WebConfiguration.WebContextInitParameter;
@@ -38,7 +39,7 @@ public class WebFacesConfigResourceProvider extends BaseWebConfigResourceProvide
     private static final String WEB_INF_RESOURCE = "/WEB-INF/faces-config.xml";
 
     private static final String[] EXCLUDES = { WEB_INF_RESOURCE };
-    private static final String SEPARATORS = ",|;";
+    private static final Pattern SEPARATORS = Pattern.compile(",|;");
 
     // ------------------------------ Methods from ConfigurationResourceProvider
 
@@ -76,7 +77,7 @@ public class WebFacesConfigResourceProvider extends BaseWebConfigResourceProvide
     }
 
     @Override
-    protected String getSeparatorRegex() {
+    protected Pattern getSeparatorPattern() {
         return SEPARATORS;
     }
 }

--- a/impl/src/main/java/com/sun/faces/config/manager/spi/AnnotationScanner.java
+++ b/impl/src/main/java/com/sun/faces/config/manager/spi/AnnotationScanner.java
@@ -22,6 +22,7 @@ import static java.util.Collections.unmodifiableSet;
 import static java.util.logging.Level.WARNING;
 
 import java.lang.annotation.Annotation;
+import java.util.regex.Pattern;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -65,6 +66,9 @@ public abstract class AnnotationScanner extends AnnotationProvider {
     private static final Logger LOGGER = FacesLogger.CONFIG.getLogger();
     private static final String WILDCARD = "*";
 
+    /** The scan-packages parameter is a whitespace separated list, which the spec allows to be padded out. */
+    private static final Pattern WHITESPACE_RUN = Pattern.compile("\\s+");
+
     protected static final Set<String> FACES_ANNOTATIONS = unmodifiableSet(new HashSet<>(asList(
             "Ljakarta/faces/component/FacesComponent;", "Ljakarta/faces/convert/FacesConverter;",
             "Ljakarta/faces/validator/FacesValidator;", "Ljakarta/faces/render/FacesRenderer;",
@@ -95,10 +99,10 @@ public abstract class AnnotationScanner extends AnnotationProvider {
         super(sc);
 
         WebConfiguration webConfig = WebConfiguration.getInstance(sc);
-        initializeAnnotationScanPackages(sc, webConfig);
+        initializeAnnotationScanPackages(webConfig);
     }
 
-    private void initializeAnnotationScanPackages(ServletContext sc, WebConfiguration webConfig) {
+    private void initializeAnnotationScanPackages(WebConfiguration webConfig) {
         if (!webConfig.isSet(AnnotationScanPackages)) {
             return;
         }
@@ -106,14 +110,14 @@ public abstract class AnnotationScanner extends AnnotationProvider {
         isAnnotationScanPackagesSet = true;
         classpathPackages = new HashMap<>(4);
         webInfClassesPackages = new String[0];
-        String[] options = webConfig.getOptionValue(AnnotationScanPackages, "\\s+");
+        String[] options = webConfig.getOptionValue(AnnotationScanPackages, WHITESPACE_RUN);
         List<String> packages = new ArrayList<>(4);
         for (String option : options) {
             if (option.length() == 0) {
                 continue;
             }
             if (option.startsWith("jar:")) {
-                String[] parts = Util.split(sc, option, ":");
+                String[] parts = Util.split(option, ":");
                 if (parts.length != 3) {
                     if (LOGGER.isLoggable(WARNING)) {
                         LOGGER.log(WARNING, "faces.annotation.scanner.configuration.invalid",
@@ -122,7 +126,7 @@ public abstract class AnnotationScanner extends AnnotationProvider {
                 } else {
                     if (WILDCARD.equals(parts[1]) && !classpathPackages.containsKey(WILDCARD)) {
                         classpathPackages.clear();
-                        classpathPackages.put(WILDCARD, normalizeJarPackages(Util.split(sc, parts[2], ",")));
+                        classpathPackages.put(WILDCARD, normalizeJarPackages(Util.split(parts[2], ",")));
                     } else if (WILDCARD.equals(parts[1]) && classpathPackages.containsKey(WILDCARD)) {
                         if (LOGGER.isLoggable(WARNING)) {
                             LOGGER.log(WARNING, "faces.annotation.scanner.configuration.duplicate.wildcard",
@@ -130,7 +134,7 @@ public abstract class AnnotationScanner extends AnnotationProvider {
                         }
                     } else {
                         if (!classpathPackages.containsKey(WILDCARD)) {
-                            classpathPackages.put(parts[1], normalizeJarPackages(Util.split(sc, parts[2], ",")));
+                            classpathPackages.put(parts[1], normalizeJarPackages(Util.split(parts[2], ",")));
                         }
                     }
                 }

--- a/impl/src/main/java/com/sun/faces/context/ExceptionHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/context/ExceptionHandlerImpl.java
@@ -215,7 +215,7 @@ public class ExceptionHandlerImpl extends ExceptionHandler {
         var typesParam = WebConfiguration.getInstance(context.getExternalContext()).getOptionValue(WebContextInitParameter.ExceptionTypesToIgnoreInLogging);
 
         if (typesParam != null) {
-            for (var typeParam : Util.split(context.getExternalContext().getApplicationMap(), typesParam, ",")) {
+            for (var typeParam : Util.split(typesParam, ",")) {
                 try {
                     types.add((Class<? extends Throwable>) Class.forName(typeParam));
                 }

--- a/impl/src/main/java/com/sun/faces/context/PartialViewContextImpl.java
+++ b/impl/src/main/java/com/sun/faces/context/PartialViewContextImpl.java
@@ -28,12 +28,12 @@ import static java.util.logging.Level.WARNING;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.util.regex.Pattern;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -91,6 +91,9 @@ public class PartialViewContextImpl extends PartialViewContext {
     private FacesContext ctx;
 
     private static final String ORIGINAL_WRITER = "com.sun.faces.ORIGINAL_WRITER";
+
+    /** The render and execute parameters are space separated lists, which the spec allows to be padded out. */
+    private static final Pattern WHITESPACE_RUN = Pattern.compile("[ \t]+");
 
     // ----------------------------------------------------------- Constructors
 
@@ -377,8 +380,7 @@ public class PartialViewContextImpl extends PartialViewContext {
         if (param == null) {
             return new ArrayList<>();
         } else {
-            Map<String, Object> appMap = FacesContext.getCurrentInstance().getExternalContext().getApplicationMap();
-            String[] pcs = Util.split(appMap, param, "[ \t]+");
+            String[] pcs = WHITESPACE_RUN.split(param);
             return pcs != null && pcs.length != 0 ? new ArrayList<>(Arrays.asList(pcs)) : new ArrayList<>();
         }
 

--- a/impl/src/main/java/com/sun/faces/context/UrlBuilder.java
+++ b/impl/src/main/java/com/sun/faces/context/UrlBuilder.java
@@ -161,11 +161,10 @@ class UrlBuilder {
             return;
         }
 
-        Map<String, Object> appMap = FacesContext.getCurrentInstance().getExternalContext().getApplicationMap();
 
-        String[] pairs = Util.split(appMap, queryString, PARAMETER_PAIR_SEPARATOR);
+        String[] pairs = Util.split(queryString, PARAMETER_PAIR_SEPARATOR);
         for (String pair : pairs) {
-            String[] nameAndValue = Util.split(appMap, pair, PARAMETER_NAME_VALUE_SEPARATOR);
+            String[] nameAndValue = Util.split(pair, PARAMETER_NAME_VALUE_SEPARATOR);
             // ignore malformed pair
             if (nameAndValue.length != 2 || nameAndValue[0].trim().length() == 0) {
                 continue;

--- a/impl/src/main/java/com/sun/faces/el/ResourceELResolver.java
+++ b/impl/src/main/java/com/sun/faces/el/ResourceELResolver.java
@@ -18,7 +18,6 @@ package com.sun.faces.el;
 
 import java.beans.FeatureDescriptor;
 import java.util.Iterator;
-import java.util.Map;
 
 import com.sun.faces.util.MessageUtils;
 import com.sun.faces.util.Util;
@@ -79,9 +78,8 @@ public class ResourceELResolver extends ELResolver {
                     // RELEASE_PENDING i18n
                     throw new ELException("Invalid resource format.  Property " + prop + " contains more than one colon (:)");
                 }
-                Map<String, Object> appMap = FacesContext.getCurrentInstance().getExternalContext().getApplicationMap();
 
-                String[] parts = Util.split(appMap, prop, ":");
+                String[] parts = Util.split(prop, ":");
 
                 // If the enclosing entity for this expression is itself
                 // a resource, the "this" syntax for the library name must

--- a/impl/src/main/java/com/sun/faces/facelets/tag/composite/AttachedObjectTargetImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/composite/AttachedObjectTargetImpl.java
@@ -18,7 +18,6 @@ package com.sun.faces.facelets.tag.composite;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import com.sun.faces.util.Util;
 
@@ -49,8 +48,7 @@ public class AttachedObjectTargetImpl implements AttachedObjectTarget {
         FacesContext ctx = FacesContext.getCurrentInstance();
         if (null != targetsList) {
             String targetsListStr = (String) targetsList.getValue(ctx.getELContext());
-            Map<String, Object> appMap = FacesContext.getCurrentInstance().getExternalContext().getApplicationMap();
-            String[] targetArray = Util.split(appMap, targetsListStr, " ");
+            String[] targetArray = Util.split(targetsListStr, " ");
             result = new ArrayList<>(targetArray.length);
             for (int i = 0, len = targetArray.length; i < len; i++) {
                 UIComponent comp = topLevelComponent.findComponent(augmentSearchId(ctx, topLevelComponent, targetArray[i]));

--- a/impl/src/main/java/com/sun/faces/renderkit/RenderKitImpl.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/RenderKitImpl.java
@@ -258,8 +258,7 @@ public class RenderKitImpl extends RenderKit {
     }
 
     private String[] contentTypeSplit(String contentTypeString) {
-        Map<String, Object> appMap = FacesContext.getCurrentInstance().getExternalContext().getApplicationMap();
-        String[] result = Util.split(appMap, contentTypeString, ",");
+        String[] result = Util.split(contentTypeString, ",");
         for (int i = 0; i < result.length; i++) {
             int semicolon = result[i].indexOf(";");
             if (-1 != semicolon) {

--- a/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
@@ -914,10 +914,9 @@ public class RenderKitUtils {
         String subtype;
         String level = null;
         String quality = null;
-        Map<String, Object> appMap = FacesContext.getCurrentInstance().getExternalContext().getApplicationMap();
 
         // Parse "types"
-        String[] types = Util.split(appMap, accept, CONTENT_TYPE_DELIMITER);
+        String[] types = Util.split(accept, CONTENT_TYPE_DELIMITER);
         String[][] arrayAccept = new String[types.length][MAX_CONTENT_TYPE_PARTS];
         int index = -1;
         for (int i = 0; i < types.length; i++) {
@@ -927,7 +926,7 @@ public class RenderKitUtils {
             // to add uniqueness to a type/subtype, and/or delimits a qualifier value:
             // Example: text/html;level=1,text/html;level=2; q=.5
             if (token.contains(";")) {
-                String[] typeParts = Util.split(appMap, token, ";");
+                String[] typeParts = Util.split(token, ";");
                 typeSubType = new StringBuilder(typeParts[0].trim());
                 for (int j = 1; j < typeParts.length; j++) {
                     quality = "not set";
@@ -935,14 +934,14 @@ public class RenderKitUtils {
                     // if "level" is present, make sure it gets included in the "type/subtype"
                     if (token.contains("level")) {
                         typeSubType.append(';').append(token);
-                        String[] levelParts = Util.split(appMap, token, "=");
+                        String[] levelParts = Util.split(token, "=");
                         level = levelParts[0].trim();
                         if (level.equalsIgnoreCase("level")) {
                             level = levelParts[1].trim();
                         }
                     } else {
                         quality = token;
-                        String[] qualityParts = Util.split(appMap, quality, "=");
+                        String[] qualityParts = Util.split(quality, "=");
                         quality = qualityParts[0].trim();
                         if (quality.equalsIgnoreCase("q")) {
                             quality = qualityParts[1].trim();
@@ -958,7 +957,7 @@ public class RenderKitUtils {
             }
             // now split type and subtype
             if (typeSubType.indexOf(CONTENT_TYPE_SUBTYPE_DELIMITER) >= 0) {
-                String[] typeSubTypeParts = Util.split(appMap, typeSubType.toString(), CONTENT_TYPE_SUBTYPE_DELIMITER);
+                String[] typeSubTypeParts = Util.split(typeSubType.toString(), CONTENT_TYPE_SUBTYPE_DELIMITER);
                 // Apparently there are user-agents that send invalid
                 // Accept headers containing no subtype (i.e. text/).
                 // For those cases, assume "*" for the subtype.

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/BaseTableRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/BaseTableRenderer.java
@@ -354,8 +354,7 @@ public abstract class BaseTableRenderer extends HtmlBasicRenderer {
             if (values == null) {
                 return EMPTY_STRING_ARRAY;
             }
-            Map<String, Object> appMap = FacesContext.getCurrentInstance().getExternalContext().getApplicationMap();
-            return Util.split(appMap, values.trim(), ",");
+            return Util.split(values.trim(), ",");
 
         }
 
@@ -447,8 +446,7 @@ public abstract class BaseTableRenderer extends HtmlBasicRenderer {
             if (values == null) {
                 return EMPTY_STRING_ARRAY;
             }
-            Map<String, Object> appMap = FacesContext.getCurrentInstance().getExternalContext().getApplicationMap();
-            return Util.split(appMap, values.trim(), ",");
+            return Util.split(values.trim(), ",");
 
         }
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/TableRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/TableRenderer.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
@@ -103,7 +102,7 @@ public class TableRenderer extends BaseTableRenderer {
         int processed = 0;
         int rowIndex = data.getFirst() - 1;
         int rows = data.getRows();
-        List<Integer> bodyRows = getBodyRows(context.getExternalContext().getApplicationMap(), data);
+        List<Integer> bodyRows = getBodyRows(data);
         boolean hasBodyRows = bodyRows != null && !bodyRows.isEmpty();
         boolean wroteTableBody = false;
         if (!hasBodyRows) {
@@ -180,12 +179,12 @@ public class TableRenderer extends BaseTableRenderer {
 
     // ------------------------------------------------------- Protected Methods
 
-    private List<Integer> getBodyRows(Map<String, Object> appMap, UIData data) {
+    private List<Integer> getBodyRows(UIData data) {
 
         List<Integer> result = null;
         String bodyRows = (String) data.getAttributes().get("bodyrows");
         if (bodyRows != null) {
-            String[] rows = Util.split(appMap, bodyRows, ",");
+            String[] rows = Util.split(bodyRows, ",");
             if (rows != null) {
                 result = new ArrayList<>(rows.length);
                 for (String curRow : rows) {

--- a/impl/src/main/java/com/sun/faces/spi/InjectionProviderFactory.java
+++ b/impl/src/main/java/com/sun/faces/spi/InjectionProviderFactory.java
@@ -222,7 +222,7 @@ public class InjectionProviderFactory {
             String[] serviceEntries = getServiceEntries();
             if (serviceEntries.length > 0) {
                 for (int i = 0; i < serviceEntries.length; i++) {
-                    provider = getProviderFromEntry(extContext.getApplicationMap(), serviceEntries[i]);
+                    provider = getProviderFromEntry(serviceEntries[i]);
                     if (provider != null) {
                         break;
                     }
@@ -236,13 +236,13 @@ public class InjectionProviderFactory {
 
     }
 
-    private static String getProviderFromEntry(Map<String, Object> appMap, String entry) {
+    private static String getProviderFromEntry(String entry) {
 
         if (entry == null) {
             return null;
         }
 
-        String[] parts = Util.split(appMap, entry, ":");
+        String[] parts = Util.split(entry, ":");
         if (parts.length != 2) {
             if (LOGGER.isLoggable(Level.SEVERE)) {
                 LOGGER.log(Level.SEVERE, "faces.spi.injection.invalid_service_entry", new Object[] { entry });

--- a/impl/src/main/java/com/sun/faces/util/Util.java
+++ b/impl/src/main/java/com/sun/faces/util/Util.java
@@ -141,38 +141,14 @@ public class Util {
     private static boolean unitTestModeEnabled = false;
 
     /**
-     * RegEx patterns
+     * The application scoped key the pattern for detecting an iterator-nested client id is stored under.
      */
-    private static final String PATTERN_CACHE_KEY = RIConstants.FACES_PREFIX + "patternCache";
-
     private static final String CLIENT_ID_NESTED_IN_ITERATOR_PATTERN = "CLIENT_ID_NESTED_IN_ITERATOR_PATTERN";
 
     private static final String FACES_SERVLET_CLASS = FacesServlet.class.getName();
 
     private Util() {
         throw new IllegalStateException();
-    }
-
-    private static Map<String, Pattern> getPatternCache(Map<String, Object> appMap) {
-    @SuppressWarnings("unchecked")
-        Map<String, Pattern> result = (Map<String, Pattern>) appMap.get(PATTERN_CACHE_KEY);
-        if (result == null) {
-            result = Collections.synchronizedMap(new LRUMap<>(15));
-            appMap.put(PATTERN_CACHE_KEY, result);
-        }
-
-        return result;
-    }
-
-    private static Map<String, Pattern> getPatternCache(ServletContext sc) {
-        @SuppressWarnings("unchecked")
-        Map<String, Pattern> result = (Map<String, Pattern>) sc.getAttribute(PATTERN_CACHE_KEY);
-        if (result == null) {
-            result = Collections.synchronizedMap(new LRUMap<>(15));
-            sc.setAttribute(PATTERN_CACHE_KEY, result);
-        }
-
-        return result;
     }
 
     private static Collection<String> getFacesServletMappings(ServletContext servletContext) {
@@ -1003,41 +979,64 @@ public class Util {
 
     /**
      * <p>
-     * A slightly more efficient version of <code>String.split()</code> which caches the <code>Pattern</code>s in an LRUMap
-     * instead of creating a new <code>Pattern</code> on each invocation.
+     * Splits the given string around occurrences of the given delimiter, which is taken literally: unlike
+     * {@link String#split(String)} it is not a regular expression, so nothing is compiled and nothing is cached. A
+     * caller that needs a real regular expression should hold its own {@link Pattern} constant and call
+     * {@link Pattern#split(CharSequence)}, which compiles it once at class initialisation rather than per call.
      * </p>
      *
-     * @param appMap the Application Map
      * @param toSplit the string to split
-     * @param regex the regex used for splitting
-     * @return the result of <code>Pattern.spit(String, int)</code>
+     * @param delimiter the literal delimiter to split around
+     * @return the split result, with trailing empty strings removed
      */
-    public static String[] split(Map<String, Object> appMap, String toSplit, String regex) {
-        return split(appMap, toSplit, regex, 0);
+    public static String[] split(String toSplit, String delimiter) {
+        return split(toSplit, delimiter, 0);
     }
 
     /**
-     * <p>A slightly more efficient version of
-     * <code>String.split()</code> which caches
-     * the <code>Pattern</code>s in an LRUMap instead of
-     * creating a new <code>Pattern</code> on each
-     * invocation. Limited by splitLimit.</p>
-     * @param appMap the Application Map
+     * <p>
+     * As {@link #split(String, String)}, limited by splitLimit, whose meaning follows
+     * {@link String#split(String, int)}: a positive limit caps the number of parts and leaves the remainder in the
+     * last one, zero means no cap and discards trailing empty strings, and a negative limit means no cap and keeps
+     * them.
+     * </p>
+     *
      * @param toSplit the string to split
-     * @param regex the regex used for splitting
+     * @param delimiter the literal delimiter to split around
      * @param splitLimit split result threshold
-     * @return the result of <code>Pattern.spit(String, int)</code>
+     * @return the split result
      */
-    public static String[] split(Map<String, Object> appMap, String toSplit, String regex, int splitLimit) {
-        Map<String, Pattern> patternCache = getPatternCache(appMap);
-        Pattern pattern = patternCache.computeIfAbsent(regex, Pattern::compile);
-        return pattern.split(toSplit, splitLimit);
-    }
+    public static String[] split(String toSplit, String delimiter, int splitLimit) {
+        if (delimiter.isEmpty()) {
+            throw new IllegalArgumentException("delimiter must not be empty");
+        }
 
-    public static String[] split(ServletContext sc, String toSplit, String regex) {
-        Map<String, Pattern> patternCache = getPatternCache(sc);
-        Pattern pattern = patternCache.computeIfAbsent(regex, Pattern::compile);
-        return pattern.split(toSplit, 0);
+        List<String> parts = new ArrayList<>();
+        int offset = 0;
+
+        for (int found; (found = toSplit.indexOf(delimiter, offset)) != -1;) {
+            if (splitLimit > 0 && parts.size() == splitLimit - 1) {
+                break;
+            }
+            parts.add(toSplit.substring(offset, found));
+            offset = found + delimiter.length();
+        }
+
+        if (parts.isEmpty()) {
+            // Nothing to split around, so the whole string is the only part -- kept even when it is itself empty,
+            // which is what String.split does before it discards any trailing empty one.
+            return new String[] { toSplit };
+        }
+
+        parts.add(toSplit.substring(offset));
+
+        if (splitLimit == 0) {
+            for (int last = parts.size() - 1; last >= 0 && parts.get(last).isEmpty(); last--) {
+                parts.remove(last);
+            }
+        }
+
+        return parts.toArray(new String[parts.size()]);
     }
 
     /**
@@ -1614,7 +1613,8 @@ public class Util {
         // We should in long term probably introduce a common interface like UIIterable.
         // But this is solid for now as all known implementing components already follow this pattern.
         // We could theoretically even remove the above instanceof checks.
-        Pattern clientIdNestedInIteratorPattern = getPatternCache(context.getExternalContext().getApplicationMap()).computeIfAbsent(CLIENT_ID_NESTED_IN_ITERATOR_PATTERN, k -> {
+        // Application scoped rather than a constant: the separator character it is built around is configurable.
+        Pattern clientIdNestedInIteratorPattern = (Pattern) context.getExternalContext().getApplicationMap().computeIfAbsent(CLIENT_ID_NESTED_IN_ITERATOR_PATTERN, k -> {
             String separatorChar = Pattern.quote(String.valueOf(UINamingContainer.getSeparatorChar(context)));
             return Pattern.compile(".+" + separatorChar + "[0-9]+" + separatorChar + ".+");
         });

--- a/impl/src/test/java/com/sun/faces/application/resource/ResourceHandlerImplExcludesTest.java
+++ b/impl/src/test/java/com/sun/faces/application/resource/ResourceHandlerImplExcludesTest.java
@@ -36,7 +36,7 @@ class ResourceHandlerImplExcludesTest {
     private final Map<String, Object> appMap = new HashMap<>();
 
     private String[] parse(String excludesParam) {
-        return parseExcludedExtensions(appMap, excludesParam);
+        return parseExcludedExtensions(excludesParam);
     }
 
     // --- parseExcludedExtensions ---

--- a/impl/src/test/java/com/sun/faces/util/TestUtil_local.java
+++ b/impl/src/test/java/com/sun/faces/util/TestUtil_local.java
@@ -72,15 +72,15 @@ public class TestUtil_local {
     public void testSplit() {
         String[] result = null;
 
-        result = Util.split(new HashMap<String,Object>(), "fooBarKey=Zm9vQmFyVmFsdWU====", "=", 2);
+        result = Util.split("fooBarKey=Zm9vQmFyVmFsdWU====", "=", 2);
         assertEquals(2, result.length);
         assertEquals(result[1], "Zm9vQmFyVmFsdWU====");
 
-        result = Util.split(new HashMap<String,Object>(), "fooBarKey=Zm9vQmFyVmFsdWU=", "=", 2);
+        result = Util.split("fooBarKey=Zm9vQmFyVmFsdWU=", "=", 2);
         assertEquals(2, result.length);
         assertEquals(result[1], "Zm9vQmFyVmFsdWU=");
 
-        result = Util.split(new HashMap<String,Object>(), "fooBarKey2=Zm9vQmFyVmFsdWUy", "=", 2);
+        result = Util.split("fooBarKey2=Zm9vQmFyVmFsdWUy", "=", 2);
         assertEquals(2, result.length);
         assertEquals(result[1], "Zm9vQmFyVmFsdWUy");
     }

--- a/impl/src/test/java/com/sun/faces/util/UtilSplitTest.java
+++ b/impl/src/test/java/com/sun/faces/util/UtilSplitTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.util;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Util.split takes its delimiter literally, so it must produce exactly what splitting around a quoted regular
+ * expression produces -- quoted being what makes the delimiter literal -- including for the limit, which decides
+ * whether trailing empty strings survive.
+ */
+class UtilSplitTest {
+
+    @ParameterizedTest
+    @CsvSource(quoteCharacter = '\'', value = {
+            // the delimiters the implementation itself passes
+            "'a,b,c', ',', 0",
+            "'a:b:c', ':', 0",
+            "'a b c', ' ', 0",
+            "'a/b/c', '/', 0",
+            "'a;b;c', ';', 0",
+            "'a&b&c', '&', 0",
+            "'k=v=w', '=', 0",
+            "'k=v=w', '=', 2",
+            // regex metacharacters, which are now delimiters like any other
+            "'a.b.c', '.', 0",
+            "'a|b|c', '|', 0",
+            "'a*b*c', '*', 0",
+            "'a+b+c', '+', 0",
+            "'a$b$c', '$', 0",
+            "'a(b(c', '(', 0",
+            "'a[b[c', '[', 0",
+            "'a?b?c', '?', 0",
+            "'a\\b\\c', '\\', 0",
+            // a delimiter of more than one character
+            "'a<>b<>c', '<>', 0",
+            "'a, b, c', ', ', 0",
+            // the delimiter is absent, or is the whole string
+            "'nodelimiter', ',', 0",
+            "',', ',', 0",
+            "'', ',', 0",
+            // leading and trailing empties, where the limit semantics live
+            "'a,b,,,', ',', 0",
+            "'a,b,,,', ',', -1",
+            "'a,b,,,', ',', 2",
+            "'a,b,,,', ',', 3",
+            "',,a,b', ',', 0",
+            "',,a,b', ',', -1",
+            "'a,b', ',', 1",
+    })
+    void splitsAroundTheDelimiterTakenLiterally(String toSplit, String delimiter, int splitLimit) {
+        assertArrayEquals(Pattern.compile(Pattern.quote(delimiter)).split(toSplit, splitLimit),
+                Util.split(toSplit, delimiter, splitLimit));
+    }
+
+    /**
+     * The two-argument overload is the one most call sites use, and it must agree with a limit of zero.
+     */
+    @Test
+    void theTwoArgumentOverloadSplitsWithoutALimit() {
+        assertArrayEquals(Util.split("a,b,,,", ",", 0), Util.split("a,b,,,", ","));
+        assertArrayEquals(Util.split("a.b.c", ".", 0), Util.split("a.b.c", "."));
+    }
+
+    @Test
+    void anEmptyDelimiterIsRejectedRatherThanLoopingForever() {
+        assertThrows(IllegalArgumentException.class, () -> Util.split("abc", ""));
+    }
+
+    /**
+     * The delimiter being literal is the whole point of the method, so the case that would differ under regular
+     * expression semantics gets an assertion of its own rather than only being covered against a quoted oracle.
+     */
+    @Test
+    void aMetacharacterDelimiterIsNotTreatedAsARegularExpression() {
+        assertArrayEquals(new String[] { "a", "b", "c" }, Util.split("a.b.c", "."));
+        assertArrayEquals(new String[] { "abc" }, Util.split("abc", "."));
+        assertArrayEquals(new String[] { "a", "b" }, Util.split("a\\b", "\\"));
+    }
+}


### PR DESCRIPTION
Same ground as #5937, taken to the point where the pattern cache is no longer needed at all. That PR's five complaints are the right diagnosis; this addresses all of them by removing the thing they are complaints about rather than mitigating it.

### What was happening

`Util.split` took a regular expression and looked up its compiled `Pattern` in an `LRUMap` kept in the application map or the servlet context. Of the 26 call sites, **22 pass one plain character** — `,` `:` `/` ` ` `;` `=` — for which none of that machinery pays: the cache lookup and the `Matcher` cost more than splitting by index does.

Only four call sites pass a real regular expression. Each now holds its own compiled constant, which is what a constant regular expression should have been in the first place:

| where | pattern |
|---|---|
| `NavigationHandlerImpl` | `&amp;\|&` |
| `PartialViewContextImpl` | `[ \t]+` |
| `WebFacesConfigResourceProvider` | `,\|;` |
| `AnnotationScanner` | `\s+` |

With those moved out there is nothing left to cache, so the cache goes, and with it the capacity, the `synchronizedMap` every read went through, the lazy-initialisation race, and the application map argument threaded through every caller.

The one `Pattern` that is genuinely per-application — the iterator-nested client id check, built around the configurable separator character — keeps application scope but is stored under its own application map key rather than in a map of patterns.

`getSeparatorRegex()` becomes `getSeparatorPattern()` returning a `Pattern`, and `WebConfiguration` gains a `Pattern`-taking `getOptionValue` overload for the one caller that needs one.

### Measured

Splitting `"javax.faces,jakarta.faces,com.sun.faces,org.glassfish,foo,bar,baz"` on a comma, best of 8 rounds of 300k after warmup, same harness for both:

| | ns/op |
|---|--:|
| before | 420.9 |
| after | **127.1** |

### Against the five points in #5937

1. *pre-Java-7 problem for the majority of use cases* — the majority no longer touch a regular expression at all.
2. *calls retrieve FacesContext + ExternalContext + ApplicationMap just to split on a comma* — the argument is gone from the signature, so 22 call sites stopped fetching it.
3. *inefficient `synchronizedMap` over an `LRUMap`* — gone.
4. *only 15 patterns cached* — there is no cache to size.
5. *unsynchronized lazy initialisation creates several caches under load* — nothing is lazily initialised any more.

### Tests

`UtilSplitTest` covers 32 cases against `Pattern.compile(Pattern.quote(delimiter)).split(...)` as the oracle — quoting being exactly what makes a delimiter literal — across the delimiters the implementation uses, regex metacharacters as ordinary delimiters, multi-character delimiters, an absent delimiter, and the limit semantics that decide whether trailing empty strings survive.

Two defects it caught during development, both of which would otherwise have shipped:

- empty input returned `[]` rather than `[""]`. `Pattern.split` short-circuits with *"if no match was found, return this"* **before** discarding trailing empty strings; the first implementation applied that pass unconditionally.
- an empty delimiter looped forever, since `indexOf("", offset)` returns `offset`. Now rejected explicitly.

Full impl suite green: 1321 tests.

### The one thing to weigh

This changes `Util.split`'s **semantics**, not only its speed: a delimiter such as `"."` used to match any character and now matches a dot. All 26 in-tree call sites were audited and none relies on the old behaviour, but `com.sun.faces.util.Util` is reachable by anything that puts it on the classpath, and for such a caller the change is silent rather than a compile or link error.

If that is a concern, the mitigation is to name the new method `splitLiteral` and leave `split` deleted, so an outside caller gets a compile error instead of different output. Happy to do that if maintainers prefer.

🤖 Generated with Claude Opus 5
