### PR TITLE
Split around a character, and stop treating literal delimiters as regular expressions

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/ApplicationAssociate.java
+++ b/impl/src/main/java/com/sun/faces/application/ApplicationAssociate.java
@@ -665,7 +665,7 @@ public class ApplicationAssociate {
         String decoratorsParamValue = webConfig.getOptionValue(FaceletsDecorators);
 
         if (decoratorsParamValue != null) {
-            for (String decorator : split(decoratorsParamValue.trim(), ";")) {
+            for (String decorator : split(decoratorsParamValue.trim(), ';')) {
                 try {
                     newCompiler
                             .addTagDecorator((TagDecorator) forName(decorator).getDeclaredConstructor().newInstance());

--- a/impl/src/main/java/com/sun/faces/application/ApplicationStateInfo.java
+++ b/impl/src/main/java/com/sun/faces/application/ApplicationStateInfo.java
@@ -43,7 +43,7 @@ public class ApplicationStateInfo {
         partialStateSaving = config.isOptionEnabled(PartialStateSaving);
 
         if (partialStateSaving) {
-            String[] viewIds = config.getOptionValue(FullStateSavingViewIds, ",");
+            String[] viewIds = config.getOptionValue(FullStateSavingViewIds, ',');
             fullStateViewIds = new HashSet<>(viewIds.length, 1.0f);
             fullStateViewIds.addAll(asList(viewIds));
         }

--- a/impl/src/main/java/com/sun/faces/application/NavigationHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/NavigationHandlerImpl.java
@@ -867,7 +867,7 @@ public class NavigationHandlerImpl extends ConfigurableNavigationHandler {
             if (queryString != null && queryString.length() > 0) {
                 String[] queryElements = QUERY_STRING_SEPARATOR.split(queryString);
                 for (int i = 0, len = queryElements.length; i < len; i++) {
-                    String[] elements = Util.split(queryElements[i], "=", 2);
+                    String[] elements = Util.split(queryElements[i], '=', 2);
                     if (elements.length == 2) {
                         String rightHandSide = elements[1];
                         String sanitized = null != rightHandSide && 2 < rightHandSide.length() ? rightHandSide.trim() : "";

--- a/impl/src/main/java/com/sun/faces/application/resource/FaceletWebappResourceHelper.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/FaceletWebappResourceHelper.java
@@ -56,7 +56,7 @@ public class FaceletWebappResourceHelper extends ResourceHelper {
     public FaceletWebappResourceHelper(WebappResourceHelper webappResourceHelper) {
         this.webappResourceHelper = webappResourceHelper;
         WebConfiguration webConfig = WebConfiguration.getInstance();
-        configuredExtensions = webConfig.getOptionValue(FaceletsSuffix, " ");
+        configuredExtensions = webConfig.getOptionValue(FaceletsSuffix, ' ');
     }
 
     @Override

--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
@@ -638,7 +638,7 @@ public class ResourceHandlerImpl extends ResourceHandler {
      * @return the excluded file extensions, without empty entries, as an empty entry would exclude every resource
      */
     static String[] parseExcludedExtensions(String excludesParam) {
-        return Stream.of(Util.split(excludesParam, " ")).filter(extension -> !extension.isEmpty()).toArray(String[]::new);
+        return Stream.of(Util.split(excludesParam, ' ')).filter(extension -> !extension.isEmpty()).toArray(String[]::new);
     }
 
     private void initMaxAge() {

--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceHelper.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceHelper.java
@@ -514,7 +514,7 @@ public abstract class ResourceHelper {
      */
     private VersionInfo getVersion(String pathElement, boolean isResource) {
 
-        String[] pathElements = Util.split(pathElement, "/");
+        String[] pathElements = Util.split(pathElement, '/');
         String path = pathElements[pathElements.length - 1];
 
         String extension = null;
@@ -736,7 +736,7 @@ public abstract class ResourceHelper {
                     throw new ELException(message);
                 }
 
-                String[] parts = Util.split(expressionBody, ":");
+                String[] parts = Util.split(expressionBody, ':');
                 if (null == parts[0] || null == parts[1]) {
                     String message = MessageUtils.getExceptionMessageString(MessageUtils.INVALID_RESOURCE_FORMAT_NO_LIBRARY_NAME_ERROR, expressionBody);
                     throw new ELException(message);

--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceManager.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceManager.java
@@ -598,7 +598,7 @@ public class ResourceManager {
         WebConfiguration config = WebConfiguration.getInstance();
         String value = config.getOptionValue(WebConfiguration.WebContextInitParameter.CompressableMimeTypes);
         if (value != null && value.length() > 0) {
-            String[] values = Util.split(value, ",");
+            String[] values = Util.split(value, ',');
             if (values != null) {
                 for (String s : values) {
                     String pattern = s.trim();

--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -907,7 +907,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
         String viewMappings = webConfig.getOptionValue(FaceletsViewMappings);
         if (viewMappings != null && viewMappings.length() > 0) {
 
-            String[] mappingsArray = split(viewMappings, ";");
+            String[] mappingsArray = split(viewMappings, ';');
 
             List<String> prefixesList = new ArrayList<>(mappingsArray.length);
 
@@ -1357,7 +1357,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
             if (targetsExpression != null) {
                 String targets = (String) targetsExpression.getValue(ctx.getELContext());
                 if (targets != null) {
-                    return Util.split(targets, " ");
+                    return Util.split(targets, ' ');
                 }
             }
 

--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -1624,7 +1624,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
                     if (-1 != j) {
                         String strValue = methodSignature.substring(i + 1, j);
                         if (0 < strValue.length()) {
-                            String[] params = strValue.split(",");
+                            String[] params = Util.split(strValue, ',');
                             expectedParameters = new Class[params.length];
                             boolean exceptionThrown = false;
                             for (i = 0; i < params.length; i++) {

--- a/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
+++ b/impl/src/main/java/com/sun/faces/config/WebConfiguration.java
@@ -136,9 +136,9 @@ public class WebConfiguration {
 
         // build the cache of list type params
         cachedListParams = new HashMap<>(3);
-        getOptionValue(WebContextInitParameter.ResourceExcludes, " ");
-        getOptionValue(WebContextInitParameter.FaceletsViewMappings, ";");
-        getOptionValue(WebContextInitParameter.FaceletsSuffix, " ");
+        getOptionValue(WebContextInitParameter.ResourceExcludes, ' ');
+        getOptionValue(WebContextInitParameter.FaceletsViewMappings, ';');
+        getOptionValue(WebContextInitParameter.FaceletsSuffix, ' ');
     }
 
     // ---------------------------------------------------------- Public Methods
@@ -277,7 +277,7 @@ public class WebConfiguration {
     }
 
     /**
-     * As {@link #getOptionValue(WebContextInitParameter, String)}, for a parameter whose values are separated by
+     * As {@link #getOptionValue(WebContextInitParameter, char)}, for a parameter whose values are separated by
      * something only a regular expression can describe rather than by one literal delimiter.
      *
      * @param param the parameter to read
@@ -290,7 +290,7 @@ public class WebConfiguration {
                 : stream(sep.split(value)).map(String::trim).filter(not(String::isEmpty)).toArray(String[]::new);
     }
 
-    public String[] getOptionValue(WebContextInitParameter param, String sep) {
+    public String[] getOptionValue(WebContextInitParameter param, char sep) {
         String[] result;
 
         if ((result = cachedListParams.get(param)) == null) {
@@ -358,7 +358,7 @@ public class WebConfiguration {
      * @return the configured Facelets suffixes.
      */
     public List<String> getFaceletsSuffixes() {
-        String[] faceletsSuffix = getOptionValue(FaceletsSuffix, " ");
+        String[] faceletsSuffix = getOptionValue(FaceletsSuffix, ' ');
 
         Set<String> deduplicatedFaceletsSuffixes = new LinkedHashSet<>(asList(faceletsSuffix));
 
@@ -382,7 +382,7 @@ public class WebConfiguration {
         Set<String> faceletResourceSuffixes = new LinkedHashSet<>(getFaceletsSuffixes());
         faceletResourceSuffixes.add(ViewHandler.DEFAULT_FACELETS_SUFFIX);
 
-        for (String viewMapping : getOptionValue(FaceletsViewMappings, ";")) {
+        for (String viewMapping : getOptionValue(FaceletsViewMappings, ';')) {
             if (viewMapping.length() > 1 && viewMapping.charAt(0) == '*') {
                 faceletResourceSuffixes.add(viewMapping.substring(1));
             }

--- a/impl/src/main/java/com/sun/faces/config/configprovider/BaseWebConfigResourceProvider.java
+++ b/impl/src/main/java/com/sun/faces/config/configprovider/BaseWebConfigResourceProvider.java
@@ -86,7 +86,7 @@ public abstract class BaseWebConfigResourceProvider implements ConfigurationReso
         try {
             URL url = context.getResource(path);
             if (url != null) {
-                return new URI(url.toExternalForm().replaceAll(" ", "%20"));
+                return new URI(url.toExternalForm().replace(" ", "%20"));
             }
         } catch (MalformedURLException | URISyntaxException mue) {
             throw new FacesException(mue);

--- a/impl/src/main/java/com/sun/faces/config/configprovider/MetaInfFaceletTaglibraryConfigProvider.java
+++ b/impl/src/main/java/com/sun/faces/config/configprovider/MetaInfFaceletTaglibraryConfigProvider.java
@@ -76,7 +76,7 @@ public class MetaInfFaceletTaglibraryConfigProvider implements ConfigurationReso
 
     private URI transformToURI(URL url) {
         try {
-            return new URI(url.toExternalForm().replaceAll(" ", "%20"));
+            return new URI(url.toExternalForm().replace(" ", "%20"));
         } catch (URISyntaxException ex) {
             throw new FacesException(ex);
         }

--- a/impl/src/main/java/com/sun/faces/config/configprovider/MetaInfFacesConfigResourceProvider.java
+++ b/impl/src/main/java/com/sun/faces/config/configprovider/MetaInfFacesConfigResourceProvider.java
@@ -131,13 +131,13 @@ public class MetaInfFacesConfigResourceProvider implements ConfigurationResource
         try {
             for (Enumeration<URL> e = Util.getCurrentLoader(this).getResources(META_INF_RESOURCES); e.hasMoreElements();) {
                 String urlString = e.nextElement().toExternalForm();
-                urlString = urlString.replaceAll(" ", "%20");
+                urlString = urlString.replace(" ", "%20");
                 urls.add(new URI(urlString));
             }
             URL[] urlArray = Classpath.search("META-INF/", FACES_CONFIG_EXTENSION);
             for (URL cur : urlArray) {
                 String urlString = cur.toExternalForm();
-                urlString = urlString.replaceAll(" ", "%20");
+                urlString = urlString.replace(" ", "%20");
                 urls.add(new URI(urlString));
             }
             // special case for finding taglib files in WEB-INF/classes/META-INF
@@ -147,7 +147,7 @@ public class MetaInfFacesConfigResourceProvider implements ConfigurationResource
                     String p = path.toString();
                     if (p.endsWith(FACES_CONFIG_EXTENSION)) {
                         String urlString = context.getResource(p).toExternalForm();
-                        urlString = urlString.replaceAll(" ", "%20");
+                        urlString = urlString.replace(" ", "%20");
                         urls.add(new URI(urlString));
                     }
                 }

--- a/impl/src/main/java/com/sun/faces/config/manager/spi/AnnotationScanner.java
+++ b/impl/src/main/java/com/sun/faces/config/manager/spi/AnnotationScanner.java
@@ -117,7 +117,7 @@ public abstract class AnnotationScanner extends AnnotationProvider {
                 continue;
             }
             if (option.startsWith("jar:")) {
-                String[] parts = Util.split(option, ":");
+                String[] parts = Util.split(option, ':');
                 if (parts.length != 3) {
                     if (LOGGER.isLoggable(WARNING)) {
                         LOGGER.log(WARNING, "faces.annotation.scanner.configuration.invalid",
@@ -126,7 +126,7 @@ public abstract class AnnotationScanner extends AnnotationProvider {
                 } else {
                     if (WILDCARD.equals(parts[1]) && !classpathPackages.containsKey(WILDCARD)) {
                         classpathPackages.clear();
-                        classpathPackages.put(WILDCARD, normalizeJarPackages(Util.split(parts[2], ",")));
+                        classpathPackages.put(WILDCARD, normalizeJarPackages(Util.split(parts[2], ',')));
                     } else if (WILDCARD.equals(parts[1]) && classpathPackages.containsKey(WILDCARD)) {
                         if (LOGGER.isLoggable(WARNING)) {
                             LOGGER.log(WARNING, "faces.annotation.scanner.configuration.duplicate.wildcard",
@@ -134,7 +134,7 @@ public abstract class AnnotationScanner extends AnnotationProvider {
                         }
                     } else {
                         if (!classpathPackages.containsKey(WILDCARD)) {
-                            classpathPackages.put(parts[1], normalizeJarPackages(Util.split(parts[2], ",")));
+                            classpathPackages.put(parts[1], normalizeJarPackages(Util.split(parts[2], ',')));
                         }
                     }
                 }

--- a/impl/src/main/java/com/sun/faces/config/processor/FaceletTaglibConfigProcessor.java
+++ b/impl/src/main/java/com/sun/faces/config/processor/FaceletTaglibConfigProcessor.java
@@ -31,6 +31,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import com.sun.faces.util.Util;
 import com.sun.faces.application.ApplicationAssociate;
 import com.sun.faces.config.ConfigurationException;
 import com.sun.faces.config.manager.documents.DocumentInfo;
@@ -614,7 +615,7 @@ public class FaceletTaglibConfigProcessor extends AbstractConfigProcessor {
                 if (pos == -1) {
                     throw new Exception("Must close parentheses, ')' missing: " + signature);
                 } else {
-                    String[] ps = signature.substring(pos2 + 1, pos).trim().split(",");
+                    String[] ps = Util.split(signature.substring(pos2 + 1, pos).trim(), ',');
                     Class<?>[] pc;
                     if (ps.length == 1 && "".equals(ps[0])) {
                         pc = new Class[0];

--- a/impl/src/main/java/com/sun/faces/config/processor/FacesFlowDefinitionConfigProcessor.java
+++ b/impl/src/main/java/com/sun/faces/config/processor/FacesFlowDefinitionConfigProcessor.java
@@ -45,6 +45,7 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import com.sun.faces.util.Util;
 import com.sun.faces.RIConstants;
 import com.sun.faces.application.ApplicationAssociate;
 import com.sun.faces.config.WebConfiguration;
@@ -99,7 +100,7 @@ public class FacesFlowDefinitionConfigProcessor extends AbstractConfigProcessor 
     public static boolean uriIsFlowDefinition(URI uri) {
         boolean result = false;
         String path = uri.getPath();
-        String[] segments = path.split("/");
+        String[] segments = Util.split(path, '/');
         if (1 < segments.length) {
             String flowName = segments[segments.length - 2];
             String definingName = segments[segments.length - 1];
@@ -122,7 +123,7 @@ public class FacesFlowDefinitionConfigProcessor extends AbstractConfigProcessor 
         Document newDoc = null;
 
         String path = uri.getPath();
-        String[] segments = path.split("/");
+        String[] segments = Util.split(path, '/');
         if (segments.length < 2) {
             return newDoc;
         }

--- a/impl/src/main/java/com/sun/faces/config/processor/ResourceLibraryContractsConfigProcessor.java
+++ b/impl/src/main/java/com/sun/faces/config/processor/ResourceLibraryContractsConfigProcessor.java
@@ -35,6 +35,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import com.sun.faces.util.Util;
 import com.sun.faces.application.ApplicationAssociate;
 import com.sun.faces.config.manager.documents.DocumentInfo;
 import com.sun.faces.util.FacesLogger;
@@ -124,7 +125,7 @@ public class ResourceLibraryContractsConfigProcessor extends AbstractConfigProce
                                     NodeList contracts = (NodeList) xpath.evaluate(".//ns1:contracts/text()", contractMapping, XPathConstants.NODESET);
                                     if (contracts != null && contracts.getLength() > 0) {
                                         for (int j = 0; j < contracts.getLength(); j++) {
-                                            String[] contractStrings = contracts.item(j).getNodeValue().trim().split(",");
+                                            String[] contractStrings = Util.split(contracts.item(j).getNodeValue().trim(), ',');
                                             for (int k = 0; k < contractStrings.length; k++) {
                                                 if (!list.contains(contractStrings[k])) {
                                                     if (LOGGER.isLoggable(INFO)) {

--- a/impl/src/main/java/com/sun/faces/context/ExceptionHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/context/ExceptionHandlerImpl.java
@@ -215,7 +215,7 @@ public class ExceptionHandlerImpl extends ExceptionHandler {
         var typesParam = WebConfiguration.getInstance(context.getExternalContext()).getOptionValue(WebContextInitParameter.ExceptionTypesToIgnoreInLogging);
 
         if (typesParam != null) {
-            for (var typeParam : Util.split(typesParam, ",")) {
+            for (var typeParam : Util.split(typesParam, ',')) {
                 try {
                     types.add((Class<? extends Throwable>) Class.forName(typeParam));
                 }

--- a/impl/src/main/java/com/sun/faces/context/UrlBuilder.java
+++ b/impl/src/main/java/com/sun/faces/context/UrlBuilder.java
@@ -49,10 +49,10 @@ import com.sun.faces.util.Util;
  * </p>
  */
 class UrlBuilder {
-    public static final String QUERY_STRING_SEPARATOR = "?";
-    public static final String PARAMETER_PAIR_SEPARATOR = "&";
-    public static final String PARAMETER_NAME_VALUE_SEPARATOR = "=";
-    public static final String FRAGMENT_SEPARATOR = "#";
+    public static final char QUERY_STRING_SEPARATOR = '?';
+    public static final char PARAMETER_PAIR_SEPARATOR = '&';
+    public static final char PARAMETER_NAME_VALUE_SEPARATOR = '=';
+    public static final char FRAGMENT_SEPARATOR = '#';
 
     private static final List<String> NULL_LIST = Arrays.asList((String) null);
 
@@ -184,7 +184,7 @@ class UrlBuilder {
         boolean hasQueryString = false;
 
         if (parameters != null) {
-            String nextSeparatorChar;
+            char nextSeparatorChar;
             if (queryString == null) {
                 nextSeparatorChar = QUERY_STRING_SEPARATOR;
             } else {
@@ -307,7 +307,7 @@ class UrlBuilder {
         if (fragment != null) {
             String f = fragment;
             f = f.trim();
-            if (f.startsWith(FRAGMENT_SEPARATOR)) {
+            if (!f.isEmpty() && f.charAt(0) == FRAGMENT_SEPARATOR) {
                 f = f.substring(1);
             }
 
@@ -323,7 +323,7 @@ class UrlBuilder {
         if (queryString != null) {
             String q = queryString;
             q = q.trim();
-            if (q.startsWith(QUERY_STRING_SEPARATOR)) {
+            if (!q.isEmpty() && q.charAt(0) == QUERY_STRING_SEPARATOR) {
                 q = q.substring(1);
             }
 

--- a/impl/src/main/java/com/sun/faces/el/ResourceELResolver.java
+++ b/impl/src/main/java/com/sun/faces/el/ResourceELResolver.java
@@ -79,7 +79,7 @@ public class ResourceELResolver extends ELResolver {
                     throw new ELException("Invalid resource format.  Property " + prop + " contains more than one colon (:)");
                 }
 
-                String[] parts = Util.split(prop, ":");
+                String[] parts = Util.split(prop, ':');
 
                 // If the enclosing entity for this expression is itself
                 // a resource, the "this" syntax for the library name must

--- a/impl/src/main/java/com/sun/faces/facelets/tag/DefaultTagDecorator.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/DefaultTagDecorator.java
@@ -19,6 +19,7 @@ package com.sun.faces.facelets.tag;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.sun.faces.util.Util;
 import com.sun.faces.facelets.tag.faces.PassThroughAttributeLibrary;
 import com.sun.faces.facelets.tag.faces.PassThroughElementLibrary;
 import com.sun.faces.facelets.tag.faces.html.HtmlLibrary;
@@ -144,13 +145,13 @@ class DefaultTagDecorator implements TagDecorator {
         }
 
         private ElementConverter(String faceletsTag, String arbiterAttributeName) {
-            String[] strings = faceletsTag.split(":");
+            String[] strings = Util.split(faceletsTag, ':');
             namespace = Namespace.valueOf(strings[0]);
             localName = strings[1];
             this.arbiterAttributeName = arbiterAttributeName;
 
             if (arbiterAttributeName != null && arbiterAttributeName.indexOf(':') > 0) {
-                strings = arbiterAttributeName.split(":");
+                strings = Util.split(arbiterAttributeName, ':');
                 arbiterAttributeNamespace = Namespace.valueOf(strings[0]).uri;
                 this.arbiterAttributeName = strings[1];
             }

--- a/impl/src/main/java/com/sun/faces/facelets/tag/composite/AttachedObjectTargetImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/composite/AttachedObjectTargetImpl.java
@@ -48,7 +48,7 @@ public class AttachedObjectTargetImpl implements AttachedObjectTarget {
         FacesContext ctx = FacesContext.getCurrentInstance();
         if (null != targetsList) {
             String targetsListStr = (String) targetsList.getValue(ctx.getELContext());
-            String[] targetArray = Util.split(targetsListStr, " ");
+            String[] targetArray = Util.split(targetsListStr, ' ');
             result = new ArrayList<>(targetArray.length);
             for (int i = 0, len = targetArray.length; i < len; i++) {
                 UIComponent comp = topLevelComponent.findComponent(augmentSearchId(ctx, topLevelComponent, targetArray[i]));

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/core/ResetValuesHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/core/ResetValuesHandler.java
@@ -16,6 +16,7 @@
 
 package com.sun.faces.facelets.tag.faces.core;
 
+import com.sun.faces.util.Util;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -88,7 +89,7 @@ public final class ResetValuesHandler extends ActionListenerHandlerBase implemen
         }
 
         // We're stuck splitting up the string.
-        String[] values = SPLIT_PATTERN.split(strValue);
+        String[] values = Util.split(strValue, ' ');
         if (values == null || values.length == 0) {
             return null;
         }

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/core/ViewHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/core/ViewHandler.java
@@ -23,6 +23,7 @@ import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.sun.faces.util.Util;
 import com.sun.faces.RIConstants;
 import com.sun.faces.facelets.tag.TagHandlerImpl;
 import com.sun.faces.facelets.tag.faces.ComponentSupport;
@@ -135,7 +136,7 @@ public final class ViewHandler extends TagHandlerImpl {
                 }
                 String contractsValue = contracts.getValue(ctx);
                 if (contractsValue != null) {
-                    List<String> contractList = Arrays.asList(contractsValue.split(","));
+                    List<String> contractList = Arrays.asList(Util.split(contractsValue, ','));
                     ctx.getFacesContext().setResourceLibraryContracts(contractList);
                 }
             }

--- a/impl/src/main/java/com/sun/faces/facelets/util/Classpath.java
+++ b/impl/src/main/java/com/sun/faces/facelets/util/Classpath.java
@@ -16,6 +16,7 @@
 
 package com.sun.faces.facelets.util;
 
+import com.sun.faces.util.Util;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.File;
@@ -156,7 +157,7 @@ public final class Classpath {
         if (!done && prefix.length() > 0) {
             // we add '/' at the end since join adds it as well
             String urlString = url.toExternalForm() + "/";
-            String[] split = prefix.split("/");
+            String[] split = Util.split(prefix, '/');
             prefix = join(split, true);
             String end = join(split, false);
             int p = urlString.lastIndexOf(end);

--- a/impl/src/main/java/com/sun/faces/facelets/util/DevTools.java
+++ b/impl/src/main/java/com/sun/faces/facelets/util/DevTools.java
@@ -127,7 +127,7 @@ public final class DevTools {
         if (e != null) {
             String msg = e.getMessage();
             if (msg != null) {
-                writer.write(msg.replaceAll("<", TS));
+                writer.write(msg.replace("<", TS));
             } else {
                 writer.write(e.getClass().getName());
             }
@@ -142,7 +142,7 @@ public final class DevTools {
             PrintWriter pstr = new PrintWriter(str);
             e.printStackTrace(pstr);
             pstr.close();
-            writer.write(str.toString().replaceAll("<", TS));
+            writer.write(str.toString().replace("<", TS));
         }
 
     }
@@ -317,9 +317,9 @@ public final class DevTools {
                 String key = entry.getKey();
                 if (key.indexOf('.') == -1) {
                     writer.write("<tr style=\"padding: 10px 6px;\"><td style=\"padding: 10px 6px;\">");
-                    writer.write(key.replaceAll("<", TS));
+                    writer.write(key.replace("<", TS));
                     writer.write("</td><td>");
-                    writer.write(entry.getValue() == null ? "null" : entry.getValue().toString().replaceAll("<", TS));
+                    writer.write(entry.getValue() == null ? "null" : entry.getValue().toString().replace("<", TS));
                     writer.write("</td></tr>");
                     written = true;
                 }
@@ -368,7 +368,7 @@ public final class DevTools {
                             } else {
                                 str = v.toString();
                             }
-                            writer.write(str.replaceAll("<", TS));
+                            writer.write(str.replace("<", TS));
                             writer.write("\"");
                         }
                     } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | IOException e) {
@@ -392,7 +392,7 @@ public final class DevTools {
     private static void writeStart(Writer writer, UIComponent c, boolean children) throws IOException {
         if (isText(c)) {
             String str = c.toString().trim();
-            writer.write(str.replaceAll("<", TS));
+            writer.write(str.replace("<", TS));
         } else {
             writer.write(TS);
             writer.write(getName(c));

--- a/impl/src/main/java/com/sun/faces/renderkit/RenderKitImpl.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/RenderKitImpl.java
@@ -258,7 +258,7 @@ public class RenderKitImpl extends RenderKit {
     }
 
     private String[] contentTypeSplit(String contentTypeString) {
-        String[] result = Util.split(contentTypeString, ",");
+        String[] result = Util.split(contentTypeString, ',');
         for (int i = 0; i < result.length; i++) {
             int semicolon = result[i].indexOf(";");
             if (-1 != semicolon) {

--- a/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
@@ -120,14 +120,14 @@ public class RenderKitUtils {
      * The character that is used to delimit content types in an accept String.
      * </p>
      */
-    private final static String CONTENT_TYPE_DELIMITER = ",";
+    private final static char CONTENT_TYPE_DELIMITER = ',';
 
     /**
      * The character that is used to delimit the type and subtype portions of a content type in an accept String. Example:
      * text/html
      * </p>
      */
-    private final static String CONTENT_TYPE_SUBTYPE_DELIMITER = "/";
+    private final static char CONTENT_TYPE_SUBTYPE_DELIMITER = '/';
 
     /**
      * This represents the base package that can leverage the <code>attributesThatAreSet</code> List for optimized attribute
@@ -926,7 +926,7 @@ public class RenderKitUtils {
             // to add uniqueness to a type/subtype, and/or delimits a qualifier value:
             // Example: text/html;level=1,text/html;level=2; q=.5
             if (token.contains(";")) {
-                String[] typeParts = Util.split(token, ";");
+                String[] typeParts = Util.split(token, ';');
                 typeSubType = new StringBuilder(typeParts[0].trim());
                 for (int j = 1; j < typeParts.length; j++) {
                     quality = "not set";
@@ -934,14 +934,14 @@ public class RenderKitUtils {
                     // if "level" is present, make sure it gets included in the "type/subtype"
                     if (token.contains("level")) {
                         typeSubType.append(';').append(token);
-                        String[] levelParts = Util.split(token, "=");
+                        String[] levelParts = Util.split(token, '=');
                         level = levelParts[0].trim();
                         if (level.equalsIgnoreCase("level")) {
                             level = levelParts[1].trim();
                         }
                     } else {
                         quality = token;
-                        String[] qualityParts = Util.split(quality, "=");
+                        String[] qualityParts = Util.split(quality, '=');
                         quality = qualityParts[0].trim();
                         if (quality.equalsIgnoreCase("q")) {
                             quality = qualityParts[1].trim();
@@ -956,8 +956,9 @@ public class RenderKitUtils {
                 quality = "not set"; // to identifiy that no quality was supplied
             }
             // now split type and subtype
-            if (typeSubType.indexOf(CONTENT_TYPE_SUBTYPE_DELIMITER) >= 0) {
-                String[] typeSubTypeParts = Util.split(typeSubType.toString(), CONTENT_TYPE_SUBTYPE_DELIMITER);
+            String typeSubTypeString = typeSubType.toString();
+            if (typeSubTypeString.indexOf(CONTENT_TYPE_SUBTYPE_DELIMITER) >= 0) {
+                String[] typeSubTypeParts = Util.split(typeSubTypeString, CONTENT_TYPE_SUBTYPE_DELIMITER);
                 // Apparently there are user-agents that send invalid
                 // Accept headers containing no subtype (i.e. text/).
                 // For those cases, assume "*" for the subtype.

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/AjaxBehaviorRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/AjaxBehaviorRenderer.java
@@ -326,7 +326,7 @@ public class AjaxBehaviorRenderer extends ClientBehaviorRenderer {
             boolean clientResolveableExpression = expression.equals("@all") || expression.equals("@none") || expression.equals("@form") || expression.equals("@this");
 
             if (composite != null && (ajaxBehavior instanceof RetargetedAjaxBehavior) && (expression.equals("@this") || expression.startsWith("@this" + separatorChar))) {
-                expression = expression.replaceFirst("@this", separatorChar + composite.getClientId(facesContext));
+                expression = separatorChar + composite.getClientId(facesContext) + expression.substring("@this".length());
                 clientResolveableExpression = false;
             }
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/BaseTableRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/BaseTableRenderer.java
@@ -354,7 +354,7 @@ public abstract class BaseTableRenderer extends HtmlBasicRenderer {
             if (values == null) {
                 return EMPTY_STRING_ARRAY;
             }
-            return Util.split(values.trim(), ",");
+            return Util.split(values.trim(), ',');
 
         }
 
@@ -446,7 +446,7 @@ public abstract class BaseTableRenderer extends HtmlBasicRenderer {
             if (values == null) {
                 return EMPTY_STRING_ARRAY;
             }
-            return Util.split(values.trim(), ",");
+            return Util.split(values.trim(), ',');
 
         }
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/TableRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/TableRenderer.java
@@ -184,7 +184,7 @@ public class TableRenderer extends BaseTableRenderer {
         List<Integer> result = null;
         String bodyRows = (String) data.getAttributes().get("bodyrows");
         if (bodyRows != null) {
-            String[] rows = Util.split(bodyRows, ",");
+            String[] rows = Util.split(bodyRows, ',');
             if (rows != null) {
                 result = new ArrayList<>(rows.length);
                 for (String curRow : rows) {

--- a/impl/src/main/java/com/sun/faces/spi/InjectionProviderFactory.java
+++ b/impl/src/main/java/com/sun/faces/spi/InjectionProviderFactory.java
@@ -242,7 +242,7 @@ public class InjectionProviderFactory {
             return null;
         }
 
-        String[] parts = Util.split(entry, ":");
+        String[] parts = Util.split(entry, ':');
         if (parts.length != 2) {
             if (LOGGER.isLoggable(Level.SEVERE)) {
                 LOGGER.log(Level.SEVERE, "faces.spi.injection.invalid_service_entry", new Object[] { entry });

--- a/impl/src/main/java/com/sun/faces/util/Util.java
+++ b/impl/src/main/java/com/sun/faces/util/Util.java
@@ -968,38 +968,35 @@ public class Util {
 
     /**
      * <p>
-     * Splits the given string around occurrences of the given delimiter, which is taken literally: unlike
-     * {@link String#split(String)} it is not a regular expression, so nothing is compiled and nothing is cached. A
-     * caller that needs a real regular expression should hold its own {@link Pattern} constant and call
-     * {@link Pattern#split(CharSequence)}, which compiles it once at class initialisation rather than per call.
+     * Splits the given string around occurrences of the given delimiter character. Unlike
+     * {@link String#split(String)} the delimiter is a character rather than a regular expression, so nothing is
+     * compiled and nothing is cached. A caller that needs a real regular expression should hold its own
+     * {@link Pattern} constant and call {@link Pattern#split(CharSequence)}, which compiles it once at class
+     * initialisation rather than per call.
      * </p>
      *
      * @param toSplit the string to split
-     * @param delimiter the literal delimiter to split around
+     * @param delimiter the character to split around
      * @return the split result, with trailing empty strings removed
      */
-    public static String[] split(String toSplit, String delimiter) {
+    public static String[] split(String toSplit, char delimiter) {
         return split(toSplit, delimiter, 0);
     }
 
     /**
      * <p>
-     * As {@link #split(String, String)}, limited by splitLimit, whose meaning follows
+     * As {@link #split(String, char)}, limited by splitLimit, whose meaning follows
      * {@link String#split(String, int)}: a positive limit caps the number of parts and leaves the remainder in the
      * last one, zero means no cap and discards trailing empty strings, and a negative limit means no cap and keeps
      * them.
      * </p>
      *
      * @param toSplit the string to split
-     * @param delimiter the literal delimiter to split around
+     * @param delimiter the character to split around
      * @param splitLimit split result threshold
      * @return the split result
      */
-    public static String[] split(String toSplit, String delimiter, int splitLimit) {
-        if (delimiter.isEmpty()) {
-            throw new IllegalArgumentException("delimiter must not be empty");
-        }
-
+    public static String[] split(String toSplit, char delimiter, int splitLimit) {
         List<String> parts = new ArrayList<>();
         int offset = 0;
 
@@ -1008,7 +1005,7 @@ public class Util {
                 break;
             }
             parts.add(toSplit.substring(offset, found));
-            offset = found + delimiter.length();
+            offset = found + 1;
         }
 
         if (parts.isEmpty()) {

--- a/impl/src/main/java/com/sun/faces/util/copier/CopierUtils.java
+++ b/impl/src/main/java/com/sun/faces/util/copier/CopierUtils.java
@@ -16,6 +16,7 @@
 
 package com.sun.faces.util.copier;
 
+import com.sun.faces.util.Util;
 import static com.sun.faces.util.ReflectionUtils.instance;
 
 import java.util.Collections;
@@ -96,7 +97,7 @@ public class CopierUtils {
     private static boolean isName(CharSequence name) {
         String id = name.toString();
 
-        for (String s : id.split("\\.", -1)) {
+        for (String s : Util.split(id, '.', -1)) {
             if (!isIdentifier(s) || isKeyword(s)) {
                 return false;
             }

--- a/impl/src/main/java/jakarta/faces/component/behavior/AjaxBehavior.java
+++ b/impl/src/main/java/jakarta/faces/component/behavior/AjaxBehavior.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import jakarta.el.ELContext;
 import jakarta.el.ELException;
@@ -721,7 +720,7 @@ public class AjaxBehavior extends ClientBehaviorBase {
             }
 
             // We're stuck splitting up the string.
-            String[] values = SPLIT_PATTERN.split(strValue);
+            String[] values = strValue.split(" ");
             if (values == null || values.length == 0) {
                 return null;
             }
@@ -793,8 +792,5 @@ public class AjaxBehavior extends ClientBehaviorBase {
     private static List<String> FORM_LIST = Collections.singletonList("@form");
     private static List<String> THIS_LIST = Collections.singletonList("@this");
     private static List<String> NONE_LIST = Collections.singletonList("@none");
-
-    // Pattern used for execute/render string splitting
-    private static Pattern SPLIT_PATTERN = Pattern.compile(" ");
 
 }

--- a/impl/src/test/java/com/sun/faces/util/TestUtil_local.java
+++ b/impl/src/test/java/com/sun/faces/util/TestUtil_local.java
@@ -72,15 +72,15 @@ public class TestUtil_local {
     public void testSplit() {
         String[] result = null;
 
-        result = Util.split("fooBarKey=Zm9vQmFyVmFsdWU====", "=", 2);
+        result = Util.split("fooBarKey=Zm9vQmFyVmFsdWU====", '=', 2);
         assertEquals(2, result.length);
         assertEquals(result[1], "Zm9vQmFyVmFsdWU====");
 
-        result = Util.split("fooBarKey=Zm9vQmFyVmFsdWU=", "=", 2);
+        result = Util.split("fooBarKey=Zm9vQmFyVmFsdWU=", '=', 2);
         assertEquals(2, result.length);
         assertEquals(result[1], "Zm9vQmFyVmFsdWU=");
 
-        result = Util.split("fooBarKey2=Zm9vQmFyVmFsdWUy", "=", 2);
+        result = Util.split("fooBarKey2=Zm9vQmFyVmFsdWUy", '=', 2);
         assertEquals(2, result.length);
         assertEquals(result[1], "Zm9vQmFyVmFsdWUy");
     }

--- a/impl/src/test/java/com/sun/faces/util/UtilSplitTest.java
+++ b/impl/src/test/java/com/sun/faces/util/UtilSplitTest.java
@@ -17,7 +17,6 @@
 package com.sun.faces.util;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.regex.Pattern;
 
@@ -26,9 +25,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 /**
- * Util.split takes its delimiter literally, so it must produce exactly what splitting around a quoted regular
- * expression produces -- quoted being what makes the delimiter literal -- including for the limit, which decides
- * whether trailing empty strings survive.
+ * Util.split splits around a character, so it must produce exactly what splitting around that character quoted as a
+ * regular expression produces -- quoting being what makes it literal -- including for the limit, which decides whether
+ * trailing empty strings survive.
  */
 class UtilSplitTest {
 
@@ -43,19 +42,18 @@ class UtilSplitTest {
             "'a&b&c', '&', 0",
             "'k=v=w', '=', 0",
             "'k=v=w', '=', 2",
-            // regex metacharacters, which are now delimiters like any other
+            // characters that would be metacharacters if this were a regular expression
             "'a.b.c', '.', 0",
             "'a|b|c', '|', 0",
             "'a*b*c', '*', 0",
             "'a+b+c', '+', 0",
             "'a$b$c', '$', 0",
+            "'a^b^c', '^', 0",
             "'a(b(c', '(', 0",
             "'a[b[c', '[', 0",
+            "'a{b{c', '{', 0",
             "'a?b?c', '?', 0",
             "'a\\b\\c', '\\', 0",
-            // a delimiter of more than one character
-            "'a<>b<>c', '<>', 0",
-            "'a, b, c', ', ', 0",
             // the delimiter is absent, or is the whole string
             "'nodelimiter', ',', 0",
             "',', ',', 0",
@@ -69,8 +67,8 @@ class UtilSplitTest {
             "',,a,b', ',', -1",
             "'a,b', ',', 1",
     })
-    void splitsAroundTheDelimiterTakenLiterally(String toSplit, String delimiter, int splitLimit) {
-        assertArrayEquals(Pattern.compile(Pattern.quote(delimiter)).split(toSplit, splitLimit),
+    void splitsAroundTheCharacterTakenLiterally(String toSplit, char delimiter, int splitLimit) {
+        assertArrayEquals(Pattern.compile(Pattern.quote(String.valueOf(delimiter))).split(toSplit, splitLimit),
                 Util.split(toSplit, delimiter, splitLimit));
     }
 
@@ -79,23 +77,19 @@ class UtilSplitTest {
      */
     @Test
     void theTwoArgumentOverloadSplitsWithoutALimit() {
-        assertArrayEquals(Util.split("a,b,,,", ",", 0), Util.split("a,b,,,", ","));
-        assertArrayEquals(Util.split("a.b.c", ".", 0), Util.split("a.b.c", "."));
-    }
-
-    @Test
-    void anEmptyDelimiterIsRejectedRatherThanLoopingForever() {
-        assertThrows(IllegalArgumentException.class, () -> Util.split("abc", ""));
+        assertArrayEquals(Util.split("a,b,,,", ',', 0), Util.split("a,b,,,", ','));
+        assertArrayEquals(Util.split("a.b.c", '.', 0), Util.split("a.b.c", '.'));
     }
 
     /**
-     * The delimiter being literal is the whole point of the method, so the case that would differ under regular
-     * expression semantics gets an assertion of its own rather than only being covered against a quoted oracle.
+     * A character delimiter cannot be a regular expression, which is the reason the method takes one. The case that
+     * would differ under regular expression semantics gets an assertion of its own rather than only being covered
+     * against a quoted oracle.
      */
     @Test
     void aMetacharacterDelimiterIsNotTreatedAsARegularExpression() {
-        assertArrayEquals(new String[] { "a", "b", "c" }, Util.split("a.b.c", "."));
-        assertArrayEquals(new String[] { "abc" }, Util.split("abc", "."));
-        assertArrayEquals(new String[] { "a", "b" }, Util.split("a\\b", "\\"));
+        assertArrayEquals(new String[] { "a", "b", "c" }, Util.split("a.b.c", '.'));
+        assertArrayEquals(new String[] { "abc" }, Util.split("abc", '.'));
+        assertArrayEquals(new String[] { "a", "b" }, Util.split("a\\b", '\\'));
     }
 }


### PR DESCRIPTION
A further step on the ground #5937 opened and #5940 built on.

#5937 pointed out that `Util.split` was pushing every call through a regular expression when almost none of them needed one. #5940 stopped the delimiter being a regular expression at all and deleted the pattern cache. This finishes the thought: every caller passes a single character, and the delimiter is taken literally anyway, so the parameter becomes the `char` it always was.

### What changes

```java
-    public static String[] split(String toSplit, String delimiter, int splitLimit)
+    public static String[] split(String toSplit, char delimiter, int splitLimit)
```

`indexOf(char)` replaces `indexOf(String)`, so a `String` comparison per delimiter occurrence goes away. More usefully, handing the method something regex-shaped is no longer expressible — `split(value, ".")` at least *looked* like it might be a pattern; `split(value, '.')` cannot be one.

The separator constants become characters along with it:

| | |
|---|---|
| `UrlBuilder` | all four separators, and `nextSeparatorChar` now holds the `char` its name has always claimed |
| `RenderKitUtils` | `CONTENT_TYPE_DELIMITER`, `CONTENT_TYPE_SUBTYPE_DELIMITER` |
| `WebConfiguration` | the separator `getOptionValue` takes |

`UrlBuilder` is package-private, so its `public` constants were never reachable outside `com.sun.faces.context` and the type change carries no API consequence.

The `Pattern`-taking `getOptionValue` overload stays, for the one parameter (`AnnotationScanPackages`) whose values a single character cannot separate.

The empty-delimiter guard #5940 needed is gone too — a `char` cannot be empty, so the case stopped existing rather than needing rejecting.

### Measured

Splitting `"javax.faces,jakarta.faces,com.sun.faces,org.glassfish,foo,bar,baz"` on a comma, best of 8 rounds of 400k after warmup:

| | ns/op |
|---|--:|
| before #5940 (cached `Pattern`) | 420.9 |
| after #5940 (`String` delimiter) | 127.1 |
| this (`char` delimiter) | **112.9** |

The 14 ns is not the point at this scale — a handful of splits per request. The API no longer being able to take a pattern is.

### Tests

`UtilSplitTest` retargeted to `char`, still asserting against `Pattern.compile(Pattern.quote(...)).split(...)` as the oracle across the delimiters the implementation uses, characters that would be metacharacters if this were a regular expression, an absent delimiter, and the limit semantics. The multi-character and empty-delimiter cases are dropped because the signature makes them unrepresentable.

Full impl suite green: 1328 tests.

### Second commit: the rest of the literal-regex sites

Once `Util.split` takes a character, the same question applies to everywhere else in `impl` that hands the regex engine something fixed.

- **Nine `String.split("x")` calls** plus one `split("\\.")` go through `Util.split(s, ch)`. Each was compiling a `Pattern` per call.
- **Eleven `String.replaceAll` calls** whose pattern is a single literal character become `String.replace`, which replaces the same occurrences and compiles nothing. (`DevTools` ×6 on `"<"`, the config resource providers ×5 on `" "`.)
- **`AjaxBehavior` and `ResetValuesHandler`** each held a `Pattern` for one space, purely to split the ajax execute and render lists — on the per-ajax-request path. `AjaxBehavior` is a spec class, so it uses `String.split(" ")`, whose own single-character path skips the regex engine and needs nothing from the implementation; that matters because on 5.0 the API is a separate module that cannot see `com.sun.faces`. `ResetValuesHandler` uses `Util.split`.

  Splitting `"@form :form:input1 :form:input2 :form:messages @this"` on a space: **183.5 → 103.8 ns/op**. A cached `Pattern` still builds a `Matcher` per call; `String.split` does not.

- **`AjaxBehaviorRenderer`** replaced a leading `@this` via `replaceFirst`. The enclosing branch has already established `@this` is at the front, so it now takes the remainder directly. That also stops the client id being interpreted as a *replacement* string, where `$` and `\` carry meaning — latent rather than live, since client ids don't normally contain either.

Deliberately left alone: everything that is genuinely a regular expression, and `ExternalContextImpl`'s `replaceFirst("http", "ws")`, which depends on matching only the *first* occurrence — a `replace` would also rewrite a later `http` in a query string, so it is not an equivalent swap.

🤖 Generated with Claude Opus 5
