### PR TITLE
Cache event constructors concurrently in EventInfo (backport of #5943)

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/applicationimpl/events/EventInfo.java
+++ b/impl/src/main/java/com/sun/faces/application/applicationimpl/events/EventInfo.java
@@ -18,13 +18,12 @@ package com.sun.faces.application.applicationimpl.events;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.sun.faces.util.Cache;
 import com.sun.faces.util.FacesLogger;
 
 import jakarta.faces.FacesException;
@@ -42,34 +41,29 @@ public class EventInfo {
     private Class<? extends SystemEvent> systemEvent;
     private Class<?> sourceClass;
     private Set<SystemEventListener> listeners;
-    private Constructor eventConstructor;
-    private Map<Class<?>, Constructor> constructorMap;
+    private Cache<Class<?>, Constructor<?>> constructorCache;
+    private Constructor<?> eventConstructor;
 
     // -------------------------------------------------------- Constructors
 
     public EventInfo(Class<? extends SystemEvent> systemEvent, Class<?> sourceClass) {
-
         this.systemEvent = systemEvent;
         this.sourceClass = sourceClass;
-        listeners = new CopyOnWriteArraySet<>();
-        constructorMap = new HashMap<>();
+        this.listeners = new CopyOnWriteArraySet<>();
+        this.constructorCache = new Cache<>(this::getEventConstructor);
         if (!sourceClass.equals(Void.class)) {
             eventConstructor = getEventConstructor(sourceClass);
         }
-
     }
 
     // ------------------------------------------------------ Public Methods
 
     public Set<SystemEventListener> getListeners() {
-
         return listeners;
-
     }
 
     public SystemEvent createSystemEvent(Object source) {
-
-        Constructor toInvoke = getCachedConstructor(source.getClass());
+        Constructor<?> toInvoke = getCachedConstructor(source.getClass());
         if (toInvoke != null) {
             try {
                 return (SystemEvent) toInvoke.newInstance(source);
@@ -78,53 +72,42 @@ public class EventInfo {
             }
         }
         return null;
-
     }
 
     // ----------------------------------------------------- Private Methods
 
-    private Constructor getCachedConstructor(Class<?> source) {
-
+    private Constructor<?> getCachedConstructor(Class<?> source) {
         if (eventConstructor != null) {
             return eventConstructor;
-        } else {
-            Constructor c = constructorMap.get(source);
-            if (c == null) {
-                c = getEventConstructor(source);
-                if (c != null) {
-                    constructorMap.put(source, c);
-                }
-            }
-            return c;
         }
-
+        return constructorCache.get(source);
     }
 
-    private Constructor getEventConstructor(Class<?> source) {
+    private Constructor<?> getEventConstructor(Class<?> source) {
 
-        Constructor ctor = null;
         try {
             return systemEvent.getDeclaredConstructor(source);
-        } catch (NoSuchMethodException ignored) {
-            Constructor[] ctors = systemEvent.getConstructors();
-            if (ctors != null) {
-                for (Constructor c : ctors) {
-                    Class<?>[] params = c.getParameterTypes();
-                    if (params.length != 1) {
-                        continue;
-                    }
-                    if (params[0].isAssignableFrom(source)) {
-                        return c;
-                    }
+        }
+        catch (NoSuchMethodException ignored) {
+            Constructor<?>[] ctors = systemEvent.getConstructors();
+
+            for (Constructor<?> c : ctors) {
+                Class<?>[] params = c.getParameterTypes();
+                if (params.length != 1) {
+                    continue;
+                }
+                if (params[0].isAssignableFrom(source)) {
+                    return c;
                 }
             }
+
             if (eventConstructor == null && LOGGER.isLoggable(Level.FINE)) {
                 LOGGER.log(Level.FINE, "Unable to find Constructor within {0} that accepts {1} instances.",
                         new Object[] { systemEvent.getName(), sourceClass.getName() });
             }
         }
-        return ctor;
 
+        return null;
     }
 
 }


### PR DESCRIPTION
Backport of #5943 (a76160d86f) to 4.0.

`EventInfo`'s per-instance constructor cache was a plain `HashMap` mutated from request threads without synchronisation. A concurrent populate can lose an entry, hand back `null`, or corrupt a bin. `EventInfo` instances are application-scoped — cached in `SystemEventInfo` and `ComponentSystemEventHelper` — so they are shared across every request thread.

The reachable window is narrower than it looks: `getCachedConstructor` only consults the map when `eventConstructor` is `null`, which is the `Void`-sourced `EventInfo`, i.e. listeners subscribed via `subscribeToEvent` without a source class. It is then only entered when such a listener actually exists, since `createSystemEvent` is never called on an empty listener set. So: apps with source-less subscriptions, during the window before every source class is resolved.

Note the failure mode is not a `ConcurrentModificationException` as the original report assumed — there is no iteration and no `HashMap.computeIfAbsent` on this path, so a CME cannot be thrown here. What a racing `put` actually produces is a lost entry, a spurious `null` (making `createSystemEvent` return `null`), or a corrupted bin under a concurrent resize.

## How it got here

Introduced 2008-06-04 by Ryan Lubke in [javaee/mojarra@1295a0b](https://github.com/javaee/mojarra/commit/1295a0b96ed811947dadc44a96802f4a3affc22b) (SVN r4849), "Rework of the Application event system", as a private inner class of `jsf-api/src/javax/faces/application/Application.java`. First shipped in 2.0.0-B01-EDR1 and present in every Mojarra 2.0+ since.

The irony is that the commit *replaced* thread-safe code. The prior `EventFactory` cached constructors in a `ConcurrentHashMap<CompositeKey, Constructor>`. The rework dropped the composite key in favour of a map-within-map (two lookups per publish instead of rebuilding a key on every publish), and in doing so demoted the constructor cache:

```diff
-        private final ConcurrentHashMap<CompositeKey,Constructor> cache
-              = new ConcurrentHashMap<CompositeKey,Constructor>();
+            this.constructorMap = new HashMap<Class<?>,Constructor>();
```

Thread-safety was not overlooked wholesale in that commit — the enclosing `SystemEventInfo.getEventInfo()` got a proper `ReentrantLock` double-checked populate in the same diff. Just not the inner constructor map. It was a performance rework, and the `ConcurrentHashMap` looked like overhead worth shedding.

`getCachedConstructor` has been byte-for-byte identical ever since; only its address changed:

| When | What |
| --- | --- |
| 2008-06-04, SVN r4849 | Introduced as an inner class of `javax.faces.application.Application` — [javaee/mojarra@1295a0b](https://github.com/javaee/mojarra/commit/1295a0b96ed811947dadc44a96802f4a3affc22b) |
| 2008-06-25 | Moved into `jsf-ri/.../ApplicationImpl.java`, where it belongs |
| 2017-03-06 | Extracted to its own `applicationimpl/events/EventInfo.java` |
| 2018-04-16 | Eclipse initial contribution — squashed root commit |

Worth knowing for anyone tracing this: `git log` in this repository dead-ends at the 2018 squashed root, so blame there concludes "always been this way". The real provenance is only in the pre-Eclipse history at [javaee/mojarra](https://github.com/javaee/mojarra).

## Backport notes

The only conflict against 4.0 was the field block: 4.0 does not carry the 4.1-only `final`-fields cleanup (6d7d6674d3), so the fields stay non-final here rather than pulling an unrelated change into a backport. The rest of the file is identical to 4.1, so the next upmerge stays quiet.

🤖 Generated with Claude Opus 5
