### PR TITLE
Remove three fixed per-request costs from RESTORE_VIEW

### DIFF
--- a/impl/src/main/java/com/sun/faces/cdi/CdiUtils.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CdiUtils.java
@@ -54,6 +54,7 @@ import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.enterprise.util.TypeLiteral;
+import jakarta.faces.annotation.View;
 import jakarta.faces.component.behavior.Behavior;
 import jakarta.faces.component.behavior.FacesBehavior;
 import jakarta.faces.context.FacesContext;
@@ -63,6 +64,7 @@ import jakarta.faces.model.DataModel;
 import jakarta.faces.model.FacesDataModel;
 import jakarta.faces.validator.FacesValidator;
 import jakarta.faces.validator.Validator;
+import jakarta.faces.view.facelets.Facelet;
 
 /**
  * A static utility class for CDI.
@@ -115,11 +117,12 @@ public final class CdiUtils {
             synchronizedMap(new WeakHashMap<>());
 
     /**
-     * Target-class / id keyed caches of the resolved managed converter, validator and behavior {@link Bean}s
-     * per {@link BeanManager}. The by-class converter lookup otherwise walks the superclass chain building a
-     * {@link FacesConverter} qualifier + {@link BeanLookupKey} at each level (and the by-id paths build two to
-     * four such keys) on every call -- per cell during render. Keying directly on the target {@code Class} or
-     * id collapses that to a single cheap map lookup. The resolved {@link Bean} is stable post-bootstrap;
+     * Target-class / id / view-id keyed caches of the resolved managed converter, validator, behavior and
+     * {@link View} facelet {@link Bean}s per {@link BeanManager}. The by-class converter lookup otherwise walks
+     * the superclass chain building a {@link FacesConverter} qualifier + {@link BeanLookupKey} at each level (and
+     * the by-id paths build two to four such keys) on every call -- per cell during render, and per facelet
+     * lookup for the view path. Keying directly on the target {@code Class}, id or view id collapses that to a
+     * single cheap map lookup. The resolved {@link Bean} is stable post-bootstrap;
      * {@link BeanManager#getReference} stays per-call so scope semantics are preserved. Misses are cached as
      * {@link #NO_BEAN}. Cleared on shutdown together with {@link #RESOLVED_BEANS} (same stale-Bean concern).
      */
@@ -128,6 +131,8 @@ public final class CdiUtils {
     private static final Map<BeanManager, ConcurrentMap<Object, Bean<?>>> VALIDATOR_BEANS_BY_KEY =
             synchronizedMap(new WeakHashMap<>());
     private static final Map<BeanManager, ConcurrentMap<Object, Bean<?>>> BEHAVIOR_BEANS_BY_KEY =
+            synchronizedMap(new WeakHashMap<>());
+    private static final Map<BeanManager, ConcurrentMap<Object, Bean<?>>> VIEW_FACELET_BEANS_BY_KEY =
             synchronizedMap(new WeakHashMap<>());
 
     private static final Bean<?> NO_BEAN = new NoBean();
@@ -148,6 +153,7 @@ public final class CdiUtils {
         CONVERTER_BEANS_BY_KEY.clear();
         VALIDATOR_BEANS_BY_KEY.clear();
         BEHAVIOR_BEANS_BY_KEY.clear();
+        VIEW_FACELET_BEANS_BY_KEY.clear();
     }
 
     /**
@@ -258,6 +264,24 @@ public final class CdiUtils {
 
         Behavior managedBehavior = (Behavior) getReferenceInstance(beanManager, bean.getBeanClass(), bean);
         return new CdiBehavior(value, managedBehavior);
+    }
+
+    /**
+     * Obtain the programmatic facelet the application declares for the given view id with {@link View}.
+     *
+     * @param beanManager the bean manager.
+     * @param viewId the view id.
+     * @return the facelet, or null if the application declares none for that view id.
+     */
+    public static Facelet getViewFacelet(BeanManager beanManager, String viewId) {
+        Bean<?> bean = cachedBean(VIEW_FACELET_BEANS_BY_KEY, beanManager, viewId,
+                () -> resolveBeanUncached(beanManager, Facelet.class, null, View.Literal.of(viewId)));
+
+        if (bean == null) {
+            return null;
+        }
+
+        return (Facelet) getReferenceInstance(beanManager, Facelet.class, bean);
     }
 
     /**

--- a/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFaceletFactory.java
+++ b/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFaceletFactory.java
@@ -17,8 +17,9 @@
 package com.sun.faces.facelets.impl;
 
 import static com.sun.faces.RIConstants.CHAR_ENCODING;
-import static com.sun.faces.cdi.CdiUtils.getBeanReference;
+import static com.sun.faces.cdi.CdiUtils.getViewFacelet;
 import static com.sun.faces.config.WebConfiguration.BooleanWebContextInitParameter.UseFaceletsID;
+import static com.sun.faces.util.Util.getCdiBeanManager;
 import static com.sun.faces.util.Util.isEmpty;
 import static com.sun.faces.util.Util.notNull;
 import static com.sun.faces.util.Util.saveDOCTYPEToFacesContextAttributes;
@@ -47,7 +48,6 @@ import java.util.regex.Pattern;
 import jakarta.el.ELException;
 import jakarta.faces.FacesException;
 import jakarta.faces.FactoryFinder;
-import jakarta.faces.annotation.View;
 import jakarta.faces.application.Application;
 import jakarta.faces.component.Doctype;
 import jakarta.faces.component.UIComponent;
@@ -135,16 +135,16 @@ public class DefaultFaceletFactory {
     }
 
     public Facelet getMetadataFacelet(FacesContext context, String viewId) throws IOException {
-        Facelet facelet = getBeanReference(context, Facelet.class, View.Literal.of(viewId));
+        Facelet facelet = getViewFacelet(getCdiBeanManager(context), viewId);
         if (facelet == null) {
             facelet = getMetadataFacelet(context, resolveURL(viewId));
         }
 
         return facelet;
     }
-   
+
     public Facelet getFacelet(FacesContext context, String viewId) throws IOException {
-        Facelet facelet = getBeanReference(context, Facelet.class, View.Literal.of(viewId));
+        Facelet facelet = getViewFacelet(getCdiBeanManager(context), viewId);
         if (facelet == null) {
             facelet = getFacelet(context, resolveURL(viewId));
         }

--- a/impl/src/main/java/jakarta/faces/CurrentThreadToServletContext.java
+++ b/impl/src/main/java/jakarta/faces/CurrentThreadToServletContext.java
@@ -38,6 +38,13 @@ final class CurrentThreadToServletContext {
     // by the fix for 20458755
     private final ServletContextFacesContextFactory servletContextFacesContextFactory = new ServletContextFacesContextFactory();
 
+    /**
+     * Application map key under which a web app's resolved {@link FactoryFinderInstance} is memoized. Every
+     * {@code FactoryFinder.getFactory} call otherwise rebuilds a {@link FactoryFinderCacheKey}, which reads the
+     * marker and the init-time ClassLoader out of that same application map before it can even be hashed.
+     */
+    private static final String FACTORY_FINDER_KEY = FactoryFinder.class.getName() + ".FactoryFinderInstance";
+
     ConcurrentMap<FactoryFinderCacheKey, FactoryFinderInstance> factoryFinderMap = new ConcurrentHashMap<>();
     private AtomicBoolean logNullFacesContext = new AtomicBoolean();
     private AtomicBoolean logNonNullFacesContext = new AtomicBoolean();
@@ -55,6 +62,14 @@ final class CurrentThreadToServletContext {
     private FactoryFinderInstance getFactoryFinder(ClassLoader classLoader, boolean create) {
 
         FacesContext facesContext = servletContextFacesContextFactory.getFacesContextWithoutServletContextLookup();
+
+        Map<String, Object> applicationMap = applicationMapOf(facesContext);
+        if (applicationMap != null) {
+            FactoryFinderInstance resolved = (FactoryFinderInstance) applicationMap.get(FACTORY_FINDER_KEY);
+            if (resolved != null) {
+                return resolved;
+            }
+        }
 
         boolean isSpecialInitializationCase = detectSpecialInitializationCase(facesContext);
         FactoryFinderCacheKey key = new FactoryFinderCacheKey(facesContext, classLoader, factoryFinderMap);
@@ -113,7 +128,26 @@ final class CurrentThreadToServletContext {
             }
         }
 
+        if (applicationMap != null && factoryFinder != null) {
+            applicationMap.put(FACTORY_FINDER_KEY, factoryFinder);
+        }
+
         return factoryFinder;
+    }
+
+    /**
+     * The application map of the given context, or null when there is none to answer from -- which is the same
+     * condition {@link FactoryFinderCacheKey} treats as "no web app to key on", so a context without one keeps
+     * resolving through the ClassLoader-and-marker key alone.
+     */
+    private static Map<String, Object> applicationMapOf(FacesContext facesContext) {
+        ExternalContext extContext = facesContext != null ? facesContext.getExternalContext() : null;
+
+        if (extContext == null || extContext.getContext() == null) {
+            return null;
+        }
+
+        return extContext.getApplicationMap();
     }
 
     Object getFallbackFactory(FactoryFinderInstance brokenFactoryManager, String factoryName) {
@@ -165,6 +199,11 @@ final class CurrentThreadToServletContext {
 
         FacesContext facesContext = servletContextFacesContextFactory.getFacesContextWithoutServletContextLookup();
         boolean isSpecialInitializationCase = detectSpecialInitializationCase(facesContext);
+
+        Map<String, Object> applicationMap = applicationMapOf(facesContext);
+        if (applicationMap != null) {
+            applicationMap.remove(FACTORY_FINDER_KEY);
+        }
 
         factoryFinderMap.remove(new FactoryFinderCacheKey(facesContext, classLoader, factoryFinderMap));
 

--- a/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
+++ b/impl/src/main/java/jakarta/faces/component/UIComponentBase.java
@@ -2168,10 +2168,10 @@ public abstract class UIComponentBase extends UIComponent {
             }
 
             if (component.getFacetCount() > 0) {
-                // Facets are few and rarely relocated; a small defensive copy keeps the iteration trivially safe.
-                Collection<UIComponent> clist = new ArrayList<>(component.getFacets().values());
-                for (UIComponent c : clist) {
-                    publishAfterViewEvents(context, application, c);
+                // The facets map's values iterator walks a snapshot of the map, so a listener relocating a facet
+                // mid-walk cannot disturb this iteration and it needs no defensive copy of its own.
+                for (UIComponent facet : component.getFacets().values()) {
+                    publishAfterViewEvents(context, application, facet);
                 }
             }
         } finally {

--- a/impl/src/test/java/com/sun/faces/cdi/CdiLookupCountTest.java
+++ b/impl/src/test/java/com/sun/faces/cdi/CdiLookupCountTest.java
@@ -18,6 +18,7 @@ package com.sun.faces.cdi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.annotation.Annotation;
@@ -29,8 +30,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.behavior.Behavior;
 import jakarta.faces.component.behavior.BehaviorBase;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.view.facelets.Facelet;
 
 import com.sun.faces.mock.MockBeanManager;
 
@@ -154,6 +158,81 @@ public class CdiLookupCountTest {
         CdiUtils.createConverter(bm, "jakarta.faces.Integer"); // by-id                            = 2
 
         assertEquals(6, bm.getBeansByType.get(), "Total getBeans calls for one Integer input component");
+    }
+
+    @Test
+    public void getViewFacelet_unknown_performsOneLookup() {
+        CountingBeanManager bm = new CountingBeanManager();
+
+        assertNull(CdiUtils.getViewFacelet(bm, "/index.xhtml"));
+
+        assertEquals(1, bm.getBeansByType.get(), "getBeans(Type, qualifiers) calls per getViewFacelet");
+        assertEquals(1, bm.resolves.get(), "resolve(Set) calls per getViewFacelet");
+    }
+
+    @Test
+    public void getViewFacelet_repeatedCalls_areCached() {
+        CountingBeanManager bm = new CountingBeanManager();
+
+        for (int i = 0; i < 10; i++) {
+            CdiUtils.getViewFacelet(bm, "/index.xhtml");
+        }
+
+        // Every request looks up the facelet for the view it renders -- twice on a postback, once for the
+        // metadata facelet and once for the build. Only the first call may walk the BeanManager.
+        assertEquals(1, bm.getBeansByType.get(), "Only first getViewFacelet call hits BeanManager");
+    }
+
+    /**
+     * A {@link jakarta.faces.annotation.View} facelet may be request scoped, so caching the resolution must
+     * not cache the instance: the reference is obtained per call and its scope decides what that yields.
+     */
+    @Test
+    public void getViewFacelet_matchingBean_resolutionCachedButReferenceCalledEveryTime() {
+        final Facelet dummyFacelet = new Facelet() {
+            @Override
+            public void apply(FacesContext facesContext, UIComponent parent) { }
+        };
+        final Bean<Facelet> matchingBean = new StubBean<>(dummyFacelet);
+        CountingBeanManager bm = new CountingBeanManager() {
+            @Override
+            @SuppressWarnings({ "unchecked", "rawtypes" })
+            public Set<Bean<?>> getBeans(Type beanType, Annotation... qualifiers) {
+                getBeansByType.incrementAndGet();
+                return (Set) Collections.singleton(matchingBean);
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public <X> Bean<? extends X> resolve(Set<Bean<? extends X>> beans) {
+                resolves.incrementAndGet();
+                return (Bean<? extends X>) matchingBean;
+            }
+
+            @Override
+            public Object getReference(Bean<?> bean, Type beanType, CreationalContext<?> ctx) {
+                references.incrementAndGet();
+                return dummyFacelet;
+            }
+        };
+
+        for (int i = 0; i < 10; i++) {
+            assertSame(dummyFacelet, CdiUtils.getViewFacelet(bm, "/index.xhtml"));
+        }
+
+        assertEquals(1, bm.getBeansByType.get(), "Resolution cached after first hit");
+        assertEquals(10, bm.references.get(), "getReference invoked per call to preserve scope semantics");
+    }
+
+    @Test
+    public void getViewFacelet_distinctViewIds_resolveIndependently() {
+        CountingBeanManager bm = new CountingBeanManager();
+
+        CdiUtils.getViewFacelet(bm, "/index.xhtml");
+        CdiUtils.getViewFacelet(bm, "/other.xhtml");
+        CdiUtils.getViewFacelet(bm, "/index.xhtml");
+
+        assertEquals(2, bm.getBeansByType.get(), "Each view id resolves once; a view id is never conflated with another");
     }
 
     @Test


### PR DESCRIPTION
Three fixed-cost removals in `RESTORE_VIEW`, found by profiling the phase on the `test/perf` suite against MyFaces 4.1.4-SNAPSHOT on Tomcat.

Framing first, because the suite's own numbers are misleading here: the 32-scenario lifecycle suite reports the GET-path `RESTORE_VIEW` cells at +46…+119% against MyFaces, but an isolated 4-scenario GET run (20 000 requests each) puts the real gap at **22.3 vs 17.2 µs, ~5 µs**, with `index` at outright parity. The rest is cross-scenario cache interleaving. On a 16-35 µs cell the percentages rank essentially at random — `flat-readonly` (+119%) and `flat-text` (+106%) score worse than the scenarios that look worst in the report. These changes target the ~5 µs that survives isolation, plus one per-component cost on facet-bearing tables.

### 1. Resolve the `@View` facelet bean once per view id

`DefaultFaceletFactory.getMetadataFacelet`/`getFacelet` built a `View.Literal` and a qualifier `HashSet` on every call to probe CDI for a programmatic facelet. Hashing that key runs `AnnotationLiteral`'s reflective member walk, so it is far from free: **13.9% of `RESTORE_VIEW` on an initial request — two thirds of what `getMetadataFacelet` costs in total, i.e. more than resolving and applying the facelet it is looking for.** It runs once per request for the metadata facelet and again per `buildView`, so a postback pays it twice.

`CdiUtils.getViewFacelet(BeanManager, String)` now keys the resolved `Bean` on the view id, next to the existing converter, validator and behavior bean caches and cleared with them on shutdown. `getReference` stays per call, so a request-scoped `@View` facelet keeps its scope.

### 2. Memoize the `FactoryFinder` instance per web application

Every `FactoryFinder.getFactory` call rebuilt a `FactoryFinderCacheKey`, and building one reads the marker and the init-time ClassLoader out of the application map before the key can even be hashed. A request makes several such calls per phase. JFR: **4.3% of `RESTORE_VIEW`, against 0.13% for MyFaces**, which resolves its factories once.

`CurrentThreadToServletContext.getFactoryFinder` now answers from the web application's own application map once the instance is known. That map belongs to exactly one web application, which is precisely what the key's marker exists to disambiguate, so it is a finer key than the one it short-circuits. The fast path is gated on the same "we have a FacesContext with a ServletContext" condition `FactoryFinderCacheKey` uses to pick `initFromApplicationMap`, so init-time calls without a FacesContext — the ones the key's ClassLoader scan exists for — still take the full path, and `removeFactoryFinder` clears the entry.

### 3. Walk the facets map's own snapshot when publishing after-view events

`publishAfterViewEvents` copied `getFacets().values()` into a list to stay safe against a listener relocating a facet mid-walk. But `FacetsMapValuesIterator` already iterates `entrySetIterator()`, which is itself a snapshot — so this was a copy of a copy, taken per facet-bearing component, per walk, and the build, the state restore and the post-restore-state pass each walk the whole tree. The sibling walks `disconnectFromView` and `updateInView` already iterate the values directly.

This is what makes a facet cost more than an ordinary child. Isolated, `flat-table-nofacets` is at **parity** (410 vs 413 µs); the whole table deficit is facets, at 260 ns/facet. JFR puts `entrySetIterator` at 3.11% of `RESTORE_VIEW` (~28 µs/request on a 200-facet table) with leaves that are pure copying.

Refuted along the way, so nobody re-chases them: the `facelets.FACET_NAME` put/remove protocol is byte-identical in MyFaces, and Mojarra's marker is already field-backed via `UIComponentBase.facetName`, so neither the protocol nor the attributes-map cost is the facet gap.

## Measurements

Tomcat, interleaved jar-swap A/B, both arms built and run back-to-back in one session, 4 reps per arm.

| | base | fix | Δ |
|---|--:|--:|--:|
| `RESTORE_VIEW` min, mean over all 40 scenarios | 25.1 µs | 19.3 µs | **−22%** |
| GET cells (avg): index / repeat-readonly / table-readonly | 22 / 26 / 25 µs | 16 / 18 / 20 µs | −27% / −32% / −18% |
| `repeat-build` / `table-build` (avg) | 118 / 104 µs | 90 / 92 µs | −24% / −11% |
| `flat-table-facets` (isolated, 6 reps, avg / min) | 524 / 164 µs | 488 / 118 µs | −7.0% / −28.1% |
| `flat-table-nofacets` (isolated, same run) | 402 / 90 µs | 394 / 90 µs | −2.1% / −0.6% |

The per-block minimum is the GET request that bootstraps each scenario's block, so it is the GET path directly; it improves on all 40 scenarios. The two `flat-table` rows are the evidence for change 3: the views differ only in whether the same 200 components hang as facets or as children, and only the facet one moves.

Non-`RESTORE_VIEW` phases are flat (mean +0.5% across 156 cells, nothing outside noise).

Honest caveat: change 3's own magnitude is a point estimate against a ±8% session noise floor — the facets-vs-nofacets differential and the JFR attribution agree on ~28 µs, but a single run does not certify it.

## Verification

- Impl unit suite green on this branch: 1332 tests, 0 failures.
- 4 new tests in `CdiLookupCountTest` covering lookup count, caching across calls, per-view-id independence, and `getReference` being invoked per call so scope semantics hold.
- Rendered-HTML equivalence over the whole `test/perf` corpus: **40/40 pages byte-identical**, 825 872 bytes on both arms (run on the 4.1 pair, same sources).
- Full Faces TCK green (run against the 5.0 port of these changes).

Refs #5856

🤖 Generated with Claude Opus 5
