### PR TITLE
Parse the resource buffer size once at init

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
@@ -89,13 +89,14 @@ public class ResourceHandlerImpl extends ResourceHandler {
      */
     public static final String DEFAULT_CSP_POLICY = "script-src 'self' 'nonce-#{nonce}' 'strict-dynamic'";
 
-    ResourceManager manager;
+    private final ResourceManager manager;
     private String[] excludedExtensions;
     private long creationTime;
     private long maxAge;
-    private boolean cspEnabled;
+    private final boolean cspEnabled;
     private SecureRandom secureRandom;
-    private WebConfiguration webconfig;
+    private final WebConfiguration webconfig;
+    private final int bufferSize;
 
     // ------------------------------------------------------------ Constructors
 
@@ -103,12 +104,13 @@ public class ResourceHandlerImpl extends ResourceHandler {
      * Creates a new instance of ResourceHandlerImpl
      */
     public ResourceHandlerImpl() {
-        creationTime = System.currentTimeMillis();
-        webconfig = WebConfiguration.getInstance();
         ExternalContext extContext = FacesContext.getCurrentInstance().getExternalContext();
+        creationTime = System.currentTimeMillis();
+        webconfig = WebConfiguration.getInstance(extContext);
         manager = ApplicationAssociate.getInstance(extContext).getResourceManager();
         initExclusions();
         initMaxAge();
+        bufferSize = initBufferSize();
         cspEnabled = webconfig.isOptionEnabled(WebConfiguration.BooleanWebContextInitParameter.CspNonceEnabled);
         if (cspEnabled) {
             secureRandom = new SecureRandom();
@@ -328,7 +330,7 @@ public class ResourceHandlerImpl extends ResourceHandler {
             if (resource.userAgentNeedsUpdate(context)) {
                 ReadableByteChannel resourceChannel = null;
                 WritableByteChannel out = null;
-                ByteBuffer buf = allocateByteBuffer();
+                ByteBuffer buf = ByteBuffer.allocate(bufferSize);
                 try {
                     InputStream in = resource.getInputStream();
                     if (in == null) {
@@ -342,7 +344,7 @@ public class ResourceHandlerImpl extends ResourceHandler {
                     if (contentType != null) {
                         extContext.setResponseContentType(resource.getContentType());
                     }
-                    handleHeaders(context, resource);
+                    handleHeaders(extContext, resource);
 
                     int size = 0;
                     for (int thisRead = resourceChannel.read(buf), totalWritten = 0; thisRead != -1; thisRead = resourceChannel.read(buf)) {
@@ -602,7 +604,7 @@ public class ResourceHandlerImpl extends ResourceHandler {
         if (getFacesMapping(context).getMappingMatch() == EXTENSION) {
             String path = context.getExternalContext().getRequestServletPath();
             // strip off the extension
-            return path.substring(0, path.lastIndexOf("."));
+            return path.substring(0, path.lastIndexOf('.'));
         }
 
         return context.getExternalContext().getRequestPathInfo();
@@ -645,26 +647,23 @@ public class ResourceHandlerImpl extends ResourceHandler {
         maxAge = Long.parseLong(webconfig.getOptionValue(DefaultResourceMaxAge));
     }
 
-    private void handleHeaders(FacesContext ctx, Resource resource) {
-        ExternalContext extContext = ctx.getExternalContext();
-        for (Map.Entry<String, String> cur : resource.getResponseHeaders().entrySet()) {
-            extContext.setResponseHeader(cur.getKey(), cur.getValue());
+    private int initBufferSize() {
+        String size = webconfig.getOptionValue(ResourceBufferSize);
+        try {
+            return Integer.parseInt(size);
+        } catch (NumberFormatException nfe) {
+            if (LOGGER.isLoggable(WARNING)) {
+                LOGGER.log(WARNING, "faces.application.resource.invalid_resource_buffer_size",
+                        new Object[] { size, ResourceBufferSize.getQualifiedName(), ResourceBufferSize.getDefaultValue() });
+            }
+            return Integer.parseInt(ResourceBufferSize.getDefaultValue());
         }
     }
 
-    private ByteBuffer allocateByteBuffer() {
-        int size;
-        try {
-            size = Integer.parseInt(webconfig.getOptionValue(ResourceBufferSize));
-        } catch (NumberFormatException nfe) {
-            if (LOGGER.isLoggable(WARNING)) {
-                LOGGER.log(WARNING, "faces.application.resource.invalid_resource_buffer_size", new Object[] { webconfig.getOptionValue(ResourceBufferSize),
-                        ResourceBufferSize.getQualifiedName(), ResourceBufferSize.getDefaultValue() });
-            }
-            size = Integer.parseInt(ResourceBufferSize.getDefaultValue());
+    private void handleHeaders(ExternalContext extContext, Resource resource) {
+        for (Map.Entry<String, String> cur : resource.getResponseHeaders().entrySet()) {
+            extContext.setResponseHeader(cur.getKey(), cur.getValue());
         }
-
-        return ByteBuffer.allocate(size);
     }
 
 }


### PR DESCRIPTION
The `ResourceHandlerImpl` part of #5946, on 4.0 so it upmerges rather than conflicting, and without the `WebConfiguration` refactor.

`allocateByteBuffer()` re-read `com.sun.faces.resourceBufferSize` from the config and re-parsed it on every resource request. The parsed value is now held on the handler next to the other init-time settings (`initExclusions`, `initMaxAge`), and `handleHeaders` takes the `ExternalContext` the caller already resolved instead of digging it back out of the `FacesContext`.

## What this is and is not worth

The throughput effect is not measurable, and the PR should not be read as claiming one. `getOptionValue` is an `EnumMap` lookup and the parse is `Integer.parseInt("2048")` — together roughly 25ns, against a method that allocates a 2KB `ByteBuffer`, opens the resource stream and copies it to the response. That is a floor of tens of microseconds, so the saving is on the order of 0.02% of the request.

What it does fix is concrete: with a misconfigured `com.sun.faces.resourceBufferSize`, the old code logged `faces.application.resource.invalid_resource_buffer_size` at WARNING **on every resource request**, and read the option three more times to build the message. It now warns once, at startup. Parsing configuration once at init rather than per request is the right shape regardless of whether it shows up in a profile.

## Differences from #5946

- **`WebConfiguration` is untouched.** #5946 introduces a generic `getOptionIntValueOrDefault` helper; the parse stays local here, in an `initBufferSize()` matching the class's existing `initExclusions()` / `initMaxAge()`. This also keeps the localized, keyed log message — the generic helper in #5946 replaces it with a hardcoded English string, which would be a regression for non-English deployments.
- **`Util.isNotEmpty` is not pulled in.** It would touch a second file to swap a non-capturing lambda for a static method reference, which is a wash.
- The javadoc typo fixes and the `ctx` → `context` rename are left out to keep the diff to the change being made.

🤖 Generated with Claude Opus 5
