### PR TITLE
ZipDirectoryEntryScanner: backport of #5948 + locale-prefixed library lookup fix

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/resource/ZipDirectoryEntryScanner.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ZipDirectoryEntryScanner.java
@@ -19,7 +19,6 @@ package com.sun.faces.application.resource;
 import static java.util.logging.Level.SEVERE;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
@@ -58,7 +57,9 @@ class ZipDirectoryEntryScanner {
                                 int i = entryName.lastIndexOf('/');
                                 if (-1 != i) {
                                     entryName = entryName.substring(0, i);
-                                    resourceLibraries.add(entryName);
+                                    if (isLibraryKey(entryName)) {
+                                        resourceLibraries.add(entryName);
+                                    }
                                 }
                             }
                         }
@@ -70,16 +71,14 @@ class ZipDirectoryEntryScanner {
                 }
             }
         }
+    }
 
-        // remove the optional local prefix entries
-        Iterator<String> iter = resourceLibraries.iterator();
-        String cur;
-        while (iter.hasNext()) {
-            cur = iter.next();
-            if (cur.contains("/")) {
-                iter.remove();
-            }
-        }
+    /**
+     * A key as built by {@link #libraryExists(String, String)} is either {@code libraryName} or
+     * {@code localePrefix + "/" + libraryName}. Anything deeper is a directory within a library, not a library.
+     */
+    private static boolean isLibraryKey(String entryName) {
+        return entryName.indexOf('/') == entryName.lastIndexOf('/');
     }
 
     boolean libraryExists(String libraryName, String localePrefix) {

--- a/impl/src/main/java/com/sun/faces/application/resource/ZipDirectoryEntryScanner.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ZipDirectoryEntryScanner.java
@@ -20,7 +20,6 @@ import static java.util.logging.Level.SEVERE;
 
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
@@ -37,14 +36,15 @@ class ZipDirectoryEntryScanner {
     private static final Logger LOGGER = FacesLogger.RESOURCE.getLogger();
     private static final String PREFIX = "META-INF/resources";
     private static final int PREFIX_LENGTH = PREFIX.length();
-    Map<String, Boolean> resourceLibraries;
+
+    private final Set<String> resourceLibraries;
 
     ZipDirectoryEntryScanner() {
         ExternalContext extContext = FacesContext.getCurrentInstance().getExternalContext();
         Set<String> webInfLibJars = extContext.getResourcePaths("/WEB-INF/lib");
-        resourceLibraries = new ConcurrentHashMap<>();
-        ZipEntry ze = null;
-        String entryName = null;
+        resourceLibraries = ConcurrentHashMap.newKeySet();
+        ZipEntry ze;
+        String entryName;
         if (webInfLibJars != null) {
             for (String cur : webInfLibJars) {
                 try (ZipInputStream zis = new ZipInputStream(extContext.getResourceAsStream(cur))) {
@@ -55,12 +55,10 @@ class ZipDirectoryEntryScanner {
                             if (!entryName.endsWith("/")) {
                                 // Assume this code is only reached if the zip entry
                                 // is NOT a 'directory' entry.
-                                int i = entryName.lastIndexOf("/");
+                                int i = entryName.lastIndexOf('/');
                                 if (-1 != i) {
                                     entryName = entryName.substring(0, i);
-                                    if (!resourceLibraries.containsKey(entryName)) {
-                                        resourceLibraries.put(entryName, Boolean.TRUE);
-                                    }
+                                    resourceLibraries.add(entryName);
                                 }
                             }
                         }
@@ -74,7 +72,7 @@ class ZipDirectoryEntryScanner {
         }
 
         // remove the optional local prefix entries
-        Iterator<String> iter = resourceLibraries.keySet().iterator();
+        Iterator<String> iter = resourceLibraries.iterator();
         String cur;
         while (iter.hasNext()) {
             cur = iter.next();
@@ -85,9 +83,9 @@ class ZipDirectoryEntryScanner {
     }
 
     boolean libraryExists(String libraryName, String localePrefix) {
-        String key = localePrefix != null ? localePrefix + "/" + libraryName : libraryName;
+        String key = localePrefix != null ? localePrefix + '/' + libraryName : libraryName;
 
-        return resourceLibraries.containsKey(key);
+        return resourceLibraries.contains(key);
     }
 
 }

--- a/impl/src/test/java/com/sun/faces/application/resource/ZipDirectoryEntryScannerTest.java
+++ b/impl/src/test/java/com/sun/faces/application/resource/ZipDirectoryEntryScannerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.faces.application.resource;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * Pins which resource libraries a scan of the JARs under <code>/WEB-INF/lib</code> reports as present. A library
+ * packaged under <code>META-INF/resources</code> is found by its name, and one packaged under a locale prefix is
+ * found by name and prefix together, matching the key {@link ZipDirectoryEntryScanner#libraryExists(String, String)}
+ * builds for each.
+ */
+class ZipDirectoryEntryScannerTest {
+
+    private static final String JAR_PATH = "/WEB-INF/lib/resources.jar";
+
+    @Test
+    void libraryIsFoundByName() {
+        ZipDirectoryEntryScanner scanner = scan("META-INF/resources/mylib/foo.js");
+
+        assertTrue(scanner.libraryExists("mylib", null));
+    }
+
+    @Test
+    void localePrefixedLibraryIsFoundByNameAndPrefix() {
+        ZipDirectoryEntryScanner scanner = scan("META-INF/resources/de/mylib/foo.js");
+
+        assertTrue(scanner.libraryExists("mylib", "de"));
+    }
+
+    @Test
+    void unpackagedLibraryIsNotFound() {
+        ZipDirectoryEntryScanner scanner = scan("META-INF/resources/mylib/foo.js", "META-INF/resources/de/mylib/foo.js");
+
+        assertFalse(scanner.libraryExists("otherlib", null));
+        assertFalse(scanner.libraryExists("mylib", "fr"));
+    }
+
+    private static ZipDirectoryEntryScanner scan(String... entryNames) {
+        ExternalContext extContext = mock(ExternalContext.class);
+        when(extContext.getResourcePaths("/WEB-INF/lib")).thenReturn(Set.of(JAR_PATH));
+        when(extContext.getResourceAsStream(JAR_PATH)).thenReturn(new ByteArrayInputStream(jar(entryNames)));
+
+        FacesContext context = mock(FacesContext.class);
+        when(context.getExternalContext()).thenReturn(extContext);
+
+        try (MockedStatic<FacesContext> staticContext = mockStatic(FacesContext.class)) {
+            staticContext.when(FacesContext::getCurrentInstance).thenReturn(context);
+            return new ZipDirectoryEntryScanner();
+        }
+    }
+
+    private static byte[] jar(String... entryNames) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+
+        try (ZipOutputStream zos = new ZipOutputStream(bytes)) {
+            for (String entryName : entryNames) {
+                zos.putNextEntry(new ZipEntry(entryName));
+                zos.write(entryName.getBytes(UTF_8));
+                zos.closeEntry();
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        return bytes.toByteArray();
+    }
+
+}


### PR DESCRIPTION
Two commits: the backport of #5948, and a fix for a defect in the code it touches.

## Backport of #5948 (1572215a9c)

Clean cherry-pick, no adaptation — the file was byte-identical on both branches.

`ZipDirectoryEntryScanner` held its scanned library names in a `Map<String, Boolean>` mapped to `Boolean.TRUE` and populated it with a `containsKey`/`put` pair. It now uses a `Set<String>` backed by `ConcurrentHashMap.newKeySet()` — same backing structure, honest type — and populates it in one lookup instead of two. The field is `private final`; it has no references outside the class.

No behaviour change. The constructor runs once per application and is dominated by inflating every JAR under `WEB-INF/lib` through a `ZipInputStream`, so the saved lookups are not expected to be measurable; the value here is the type stating what the data actually is.

## Locale-prefixed libraries were never found

The scan and the lookup disagreed about what a key looks like. For a resource at `META-INF/resources/de/mylib/foo.js` the scan recorded `de/mylib`, then swept the set:

```java
if (cur.contains("/")) {
    iter.remove();
}
```

while `libraryExists` builds exactly that shape whenever a locale prefix is given:

```java
String key = localePrefix != null ? localePrefix + '/' + libraryName : libraryName;
```

So every locale-prefixed key was guaranteed absent, and `libraryExists(name, prefix)` could only ever return `false`.

Reachable from `ResourceManager`, which passes the real locale prefix and, on failure, retries with a null prefix. The effect is therefore silent rather than fatal: with `com.sun.faces.enableMissingResourceLibraryDetection` enabled (opt-in, default off), a localized resource library packaged inside a JAR degrades to its non-localized variant instead of being found. That, plus the default-off flag, is why it has gone unreported.

The filter now runs at insert rather than as a sweep afterwards, which also disposes of the iterator loop:

```java
/**
 * A key as built by {@link #libraryExists(String, String)} is either {@code libraryName} or
 * {@code localePrefix + "/" + libraryName}. Anything deeper is a directory within a library, not a library.
 */
private static boolean isLibraryKey(String entryName) {
    return entryName.indexOf('/') == entryName.lastIndexOf('/');
}
```

One deliberate limitation: `<library>/<subdir>` is indistinguishable from `<locale>/<library>` at this level, so a library subdirectory stays in the set. That direction only weakens missing-library *detection*; the reverse drops libraries that genuinely exist, which is the bug being fixed here.

`ZipDirectoryEntryScannerTest` covers all three cases against an in-memory JAR. Without the fix, `localePrefixedLibraryIsFoundByNameAndPrefix` fails and the other two pass.

The fix goes on 4.0 so it upmerges; 4.1 and master currently carry the refactor from #5948 without it.

🤖 Generated with Claude Opus 5
