### PR TITLE
Skip view map for CSP nonce on stateless views (#5952)

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
@@ -455,9 +455,10 @@ public class ResourceHandlerImpl extends ResourceHandler {
             var nonce = (String) requestMap.get(CURRENT_NONCE);
 
             if (nonce == null) {
-                var viewMap = context.getViewRoot().getViewMap(true);
+                var viewRoot = context.getViewRoot();
+                var viewMap = viewRoot.isTransient() ? null : viewRoot.getViewMap(true);
 
-                if (context.getPartialViewContext().isPartialRequest()) {
+                if (viewMap != null && context.getPartialViewContext().isPartialRequest()) {
                     nonce = (String) viewMap.get(CURRENT_NONCE);
                 }
 
@@ -468,7 +469,10 @@ public class ResourceHandlerImpl extends ResourceHandler {
                 }
 
                 requestMap.put(CURRENT_NONCE, nonce);
-                viewMap.put(CURRENT_NONCE, nonce);
+
+                if (viewMap != null) {
+                    viewMap.put(CURRENT_NONCE, nonce);
+                }
             }
 
             return nonce;

--- a/test/csp/src/main/webapp/issue5952.xhtml
+++ b/test/csp/src/main/webapp/issue5952.xhtml
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="en"
+    xmlns:h="jakarta.faces.html"
+    xmlns:f="jakarta.faces.core"
+>
+    <f:view transient="true">
+        <h:head>
+            <title>issue5952</title>
+        </h:head>
+        <h:body>
+            <h:form id="form">
+                <h:commandLink id="commandLink" value="commandLink" />
+                <h:outputText id="commandLinkExecuted" value="#{not empty param['form:commandLink']}" />
+            </h:form>
+        </h:body>
+    </f:view>
+</html>

--- a/test/csp/src/test/java/org/eclipse/mojarra/test/csp/Issue5952IT.java
+++ b/test/csp/src/test/java/org/eclipse/mojarra/test/csp/Issue5952IT.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package org.eclipse.mojarra.test.csp;
+
+import static java.net.URI.create;
+import static java.net.http.HttpClient.newHttpClient;
+import static java.net.http.HttpRequest.newBuilder;
+import static java.net.http.HttpResponse.BodyHandlers.ofString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.faces.application.resource.ResourceHandlerImpl;
+import jakarta.faces.event.PostConstructViewMapEvent;
+import org.eclipse.mojarra.test.base.BaseIT;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * The webapp enables <code>com.sun.faces.enableCspNonce</code> and the view is declared
+ * <code>&lt;f:view transient="true"&gt;</code>.
+ */
+class Issue5952IT extends BaseIT {
+
+    @FindBy(id = "form:commandLink")
+    private WebElement commandLink;
+
+    @FindBy(id = "form:commandLinkExecuted")
+    private WebElement commandLinkExecuted;
+
+    /**
+     * A stateless view has no view map to carry the nonce across requests, so obtaining the nonce must not create
+     * one. Creating it would publish a {@link PostConstructViewMapEvent}, which acquires a session and registers
+     * an unreachable view map in it, defeating the statelessness of the view.
+     *
+     * @see ResourceHandlerImpl#getCurrentNonce
+     * @see <a href="https://github.com/eclipse-ee4j/mojarra/issues/5952">https://github.com/eclipse-ee4j/mojarra/issues/5952</a>
+     */
+    @Test
+    public void testStatelessViewAcquiresNoSession() throws Exception {
+        var response = newHttpClient().send(newBuilder(create(baseURL + "issue5952.xhtml"))
+                .build(), ofString());
+        assertTrue(response.body().contains("value=\"stateless\""), "View must be stateless");
+
+        var cspHeader = response.headers().firstValue("Content-Security-Policy");
+        assertTrue(cspHeader.isPresent(), "Content-Security-Policy response header must be present");
+        assertTrue(cspHeader.get().contains("'nonce-"), "Content-Security-Policy response header must contain nonce");
+
+        assertFalse(response.headers().allValues("Set-Cookie").stream().anyMatch(cookie -> cookie.contains("JSESSIONID")),
+                "Stateless view must not acquire a session");
+    }
+
+    /**
+     * A stateless view must still get a nonce on its behavior scripts, and a fresh one on every request.
+     *
+     * @see ResourceHandlerImpl#ENABLE_CSP_NONCE_PARAM_NAME
+     * @see <a href="https://github.com/eclipse-ee4j/mojarra/issues/5952">https://github.com/eclipse-ee4j/mojarra/issues/5952</a>
+     */
+    @Test
+    public void testNonceOnStatelessView() {
+        open("issue5952.xhtml");
+        var nonce = getBehaviorScriptElement(commandLink).getAttribute("nonce");
+        assertNotNull(nonce);
+        assertNotEquals("", nonce);
+        assertEquals("false", commandLinkExecuted.getText());
+        guardHttp(commandLink::click);
+        assertEquals("true", commandLinkExecuted.getText());
+        assertNotEquals(nonce, getBehaviorScriptElement(commandLink).getAttribute("nonce"));
+    }
+
+}


### PR DESCRIPTION
When CSP nonce support is enabled, `ResourceHandlerImpl#getCurrentNonce` called `getViewMap(true)` unconditionally, also on a transient view root. That publishes a `PostConstructViewMapEvent`, and `ViewScopeManager` then logs "@ViewScoped beans are not supported on stateless views" in Development stage, and — in any stage — acquires an HTTP session and registers a view map in `ACTIVE_VIEW_MAPS` which is unreachable on a stateless view, so a stateless view with CSP enabled acquired a session on every render.

The view map is transient state and cannot carry the nonce across requests on a stateless view anyway, so it is now resolved only for a non-transient view root. The nonce is still cached in the request map.

Integration tests are added to `test/csp`: a `<f:view transient="true">` view asserting the CSP header carries a nonce while no session is acquired, and one asserting behavior scripts still get a nonce.

Closes #5952

🤖 Generated with Claude Opus 5
