### PR TITLE
Size LRUMap to fit one entry above its LRU bound (#5953)

### DIFF
--- a/impl/src/main/java/com/sun/faces/util/LRUMap.java
+++ b/impl/src/main/java/com/sun/faces/util/LRUMap.java
@@ -30,14 +30,15 @@ public class LRUMap<K, V> extends LinkedHashMap<K, V> {
     // ------------------------------------------------------------ Constructors
 
     public LRUMap(int maxCapacity) {
-        super(maxCapacity, 1.0f, true);
+        // The eldest entry is evicted only after the new one is inserted, so the table must hold maxCapacity + 1 entries.
+        super(maxCapacity + 1, 1.0f, true);
         this.maxCapacity = maxCapacity;
     }
 
     // ---------------------------------------------- Methods from LinkedHashMap
 
     @Override
-    protected boolean removeEldestEntry(Map.Entry eldest) {
+    protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
         return size() > maxCapacity;
     }
 


### PR DESCRIPTION
Rewrite of #5953 by @pizzi80, on 4.0 instead of 4.1 so it upmerges cleanly through all versions, and without the load factor change.

`LinkedHashMap` evicts the eldest entry only after the new one has been inserted — `HashMap#putVal` resizes on `++size > threshold` and only then calls `afterNodeInsertion`, which is where `removeEldestEntry` is consulted. So an `LRUMap` bounded at `maxCapacity` entries momentarily holds `maxCapacity + 1`. The constructor asked for exactly `maxCapacity` at load factor `1.0f`, which makes the threshold equal the table length, so that transient peak rehashes the table.

Asking for `maxCapacity + 1` removes it. At `1.0f` the threshold *is* the capacity, so `maxCapacity + 1` is precisely the requirement — no conversion needed.

`removeEldestEntry`'s raw `Map.Entry` parameter is generified along the way, which is what master already has.

## Measured

Table length and resize count after 400 inserts, by reflection on `HashMap.table`:

| maxCapacity | before | after | #5953 as proposed |
|---|---|---|---|
| 10 (`NumberOfClientWindows`) | 16, 0 resizes | 16, 0 resizes | 16, 0 resizes |
| 15 (`NumberOfViews`, `NumberOfLogicalViews`, `ServerSideStateHelper` actual map) | 16, 0 resizes | 16, 0 resizes | **32**, 0 resizes |
| 16 | 32, **1 resize** | 32, 0 resizes | 32, 0 resizes |
| 32 | 64, **1 resize** | 64, 0 resizes | 64, 0 resizes |
| 100 | 128, 0 resizes | 128, 0 resizes | **256**, 0 resizes |

Two things this makes explicit, neither of which matches how #5953 described itself:

The rehash only ever happened when `maxCapacity` is an exact power of two — otherwise `tableSizeFor` already rounded the requested capacity up past the peak. None of the four configured defaults is a power of two, so the "avoid the rehash" premise did not hold for any of them, and even when it does hold the rehash is a one-time warm-up cost, not per-insert: eviction pins the size at `maxCapacity` forever after.

## Why not `calculateMapCapacity` / `0.75f`

`Util.calculateMapCapacity`, and the `HashMap.newHashMap` / `LinkedHashMap.newLinkedHashMap` factories it is ported from in #5953, answer a different question: *I am going to put n mappings into this map and keep them — how large must the table be so that filling it never rehashes?* The ÷0.75 is headroom for growth, and it is needed because in an unbounded map the size is what drives the resize.

A **bounded** LRU map has **no growth**. `removeEldestEntry` pins the size at `maxCapacity` from the moment the bound is reached, and it never moves again. Headroom above the bound is therefore memory that can never be occupied, and the load factor stops being a growth policy at all — it is only the multiplier that decides whether a table of fixed occupancy ever crosses its threshold. The whole requirement is `threshold ≥ maxCapacity + 1`, and at `1.0f` the threshold *is* the capacity, so `maxCapacity + 1` meets it exactly, with the smallest table that can.

This is also why the two halves cannot be combined: `calculateMapCapacity(maxCapacity + 1)` at `1.0f` inflates the request by 4/3 and rounds up to the next power of two, producing the same 32-slot table as `0.75f` does, with a threshold of 32 the map can never reach.

What `0.75f` genuinely buys is a lower load — 0.47 against 0.94 at capacity 15 — and so shorter collision chains. That is real, but it is a memory-for-collisions trade to argue on its own merits rather than part of a rehash fix. It doubles the table on maps that live in the session, and `ServerSideStateHelper` holds one bounded map per logical view, so a session can carry roughly 16 of them; on the other side of the scale is a fraction of a probe on a 15-entry map, read a handful of times per request behind a `Collections.synchronizedMap` monitor. Left at `1.0f` pending a number that says otherwise.

## Not included

`@Serial` from #5953 is dropped: `java.io.Serial` is JDK 14+ and this branch compiles at source/target 11, so it would have blocked the fix from landing on 4.0. It also buys nothing here — `-Xlint:serial`, which this build already enables, reports the same diagnostics with or without it.

`jakarta.faces.component.LRUMap` on master (used by `PackageUtils` at capacity 15) is a private copy of this class with the same constructor. It needs the same one-line change and will not come along in the upmerge; that goes in a separate PR against master.

## Verification

`impl` builds and the unit suite is green on JDK 17 at source/target 11: 1335 tests, 0 failures, 0 errors, 4 skipped, plus the 347 jest tests. `TestLRUMap_local` covers the LRU ordering and eviction behavior, which is unchanged.

🤖 Generated with Claude Opus 5
