### PR TITLE
Resources model modernization + NO_VALUE/EMPTY_STRING split (#5944)

### DIFF
--- a/impl/src/main/java/com/sun/faces/RIConstants.java
+++ b/impl/src/main/java/com/sun/faces/RIConstants.java
@@ -63,7 +63,7 @@ public class RIConstants {
      */
     public static final String TLV_RESOURCE_LOCATION = FACES_PREFIX + "resources.Resources";
 
-    public static final String NO_VALUE = "";
+    public static final String EMPTY_STRING = "";
 
     public static final Class<?>[] EMPTY_CLASS_ARGS = new Class[0];
     public static final Object[] EMPTY_METH_ARGS = new Object[0];

--- a/impl/src/main/java/com/sun/faces/application/resource/ClasspathResourceHelper.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ClasspathResourceHelper.java
@@ -24,10 +24,10 @@ import static jakarta.faces.application.ProjectStage.Development;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 import com.sun.faces.config.WebConfiguration;
 import com.sun.faces.util.Util;
@@ -57,33 +57,26 @@ public class ClasspathResourceHelper extends ResourceHelper {
         WebConfiguration webconfig = WebConfiguration.getInstance();
         cacheTimestamp = webconfig.isOptionEnabled(CacheResourceModificationTimestamp);
         enableMissingResourceLibraryDetection = webconfig.isOptionEnabled(EnableMissingResourceLibraryDetection);
-
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final ClasspathResourceHelper other = (ClasspathResourceHelper) obj;
-        if (cacheTimestamp != other.cacheTimestamp) {
-            return false;
-        }
-        if (enableMissingResourceLibraryDetection != other.enableMissingResourceLibraryDetection) {
-            return false;
-        }
-        return true;
+
+        ClasspathResourceHelper other = (ClasspathResourceHelper) obj;
+
+        return cacheTimestamp == other.cacheTimestamp
+            && enableMissingResourceLibraryDetection == other.enableMissingResourceLibraryDetection;
     }
 
     @Override
     public int hashCode() {
-        int hash = 5;
-        hash = 67 * hash + (cacheTimestamp ? 1 : 0);
-        hash = 67 * hash + (enableMissingResourceLibraryDetection ? 1 : 0);
-        return hash;
+        return Objects.hash(cacheTimestamp, enableMissingResourceLibraryDetection);
     }
 
     // --------------------------------------------- Methods from ResourceHelper
@@ -277,21 +270,19 @@ public class ClasspathResourceHelper extends ResourceHelper {
     private URL findPathConsideringContracts(ClassLoader loader, LibraryInfo library, String resourceName, String localePrefix, ContractInfo[] outContract,
             String[] outBasePath, FacesContext ctx) {
         UIViewRoot root = ctx.getViewRoot();
-        List<String> contracts = null;
+        final List<String> contracts;
         URL result = null;
 
         if (library != null) {
             if (library.getContract() == null) {
                 contracts = Collections.emptyList();
             } else {
-                contracts = new ArrayList<>(1);
-                contracts.add(library.getContract());
+                contracts = List.of(library.getContract());
             }
         } else if (root == null) {
             String contractName = ctx.getExternalContext().getRequestParameterMap().get("con");
-            if (null != contractName && 0 < contractName.length() && !ResourceManager.nameContainsForbiddenSequence(contractName)) {
-                contracts = new ArrayList<>();
-                contracts.add(contractName);
+            if (contractName != null && !contractName.isEmpty() && !ResourceManager.nameContainsForbiddenSequence(contractName)) {
+                contracts = List.of(contractName);
             } else {
                 return null;
             }

--- a/impl/src/main/java/com/sun/faces/application/resource/ClientResourceInfo.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ClientResourceInfo.java
@@ -187,7 +187,7 @@ public class ClientResourceInfo extends ResourceInfo {
 
     /**
      * Create the full path to the resource. If the resource can be compressed, setup the compressedPath ivar so that the
-     * path refers to the directory refereneced by the context attribute <code>jakarta.servlet.context.tempdir</code>.
+     * path refers to the directory referenced by the context attribute <code>jakarta.servlet.context.tempdir</code>.
      */
     private void initPath(boolean isDevStage) {
 

--- a/impl/src/main/java/com/sun/faces/application/resource/ContractInfo.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ContractInfo.java
@@ -16,11 +16,11 @@
 
 package com.sun.faces.application.resource;
 
+import java.util.Objects;
+
 public final class ContractInfo {
 
-    private static final long serialVersionUID = 6585532979916457692L;
-
-    String contract;
+    final String contract;
 
     public ContractInfo(String contract) {
         this.contract = contract;
@@ -28,24 +28,21 @@ public final class ContractInfo {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ContractInfo)) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final ContractInfo other = (ContractInfo) obj;
-        if (contract == null ? other.contract != null : !contract.equals(other.contract)) {
-            return false;
-        }
-        return true;
+
+        ContractInfo other = (ContractInfo) obj;
+
+        return Objects.equals(contract, other.contract);
     }
 
     @Override
     public int hashCode() {
-        int hash = 7;
-        hash = 29 * hash + (contract != null ? contract.hashCode() : 0);
-        return hash;
+        return Objects.hashCode(contract);
     }
 
     @Override

--- a/impl/src/main/java/com/sun/faces/application/resource/FaceletWebappResourceHelper.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/FaceletWebappResourceHelper.java
@@ -16,6 +16,7 @@
 
 package com.sun.faces.application.resource;
 
+import static com.sun.faces.RIConstants.EMPTY_STRING;
 import static com.sun.faces.RIConstants.FLOW_IN_JAR_PREFIX;
 import static com.sun.faces.config.WebConfiguration.META_INF_CONTRACTS_DIR;
 import static com.sun.faces.config.WebConfiguration.WebContextInitParameter.FaceletsSuffix;
@@ -28,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -61,12 +63,22 @@ public class FaceletWebappResourceHelper extends ResourceHelper {
 
     @Override
     public boolean equals(Object obj) {
-        return obj instanceof FaceletWebappResourceHelper;
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        FaceletWebappResourceHelper other = (FaceletWebappResourceHelper) obj;
+
+        return Objects.equals(webappResourceHelper, other.webappResourceHelper)
+            && Arrays.equals(configuredExtensions, other.configuredExtensions);
     }
 
     @Override
     public int hashCode() {
-        return 3;
+        return Objects.hash(webappResourceHelper, Arrays.hashCode(configuredExtensions));
     }
 
     @Override
@@ -189,7 +201,7 @@ public class FaceletWebappResourceHelper extends ResourceHelper {
 
     private URL findResourceUrlConsideringFlows(String resourceName, boolean[] outDoNotCache) throws IOException {
 
-        URL url = null;
+        URL url;
 
         ClassLoader cl = Util.getCurrentLoader(this);
         Enumeration<URL> matches = cl.getResources(FLOW_IN_JAR_PREFIX + resourceName);
@@ -205,7 +217,7 @@ public class FaceletWebappResourceHelper extends ResourceHelper {
             Flow currentFlow = context.getApplication().getFlowHandler().getCurrentFlow(context);
 
             do {
-                if (currentFlow != null && 0 < currentFlow.getDefiningDocumentId().length()) {
+                if (currentFlow != null && !currentFlow.getDefiningDocumentId().isEmpty()) {
                     String definingDocumentId = currentFlow.getDefiningDocumentId();
                     ExternalContext extContext = context.getExternalContext();
                     ApplicationAssociate associate = ApplicationAssociate.getInstance(extContext);
@@ -230,7 +242,7 @@ public class FaceletWebappResourceHelper extends ResourceHelper {
 
     @Override
     public String getBaseResourcePath() {
-        return "";
+        return EMPTY_STRING;
     }
 
     @Override

--- a/impl/src/main/java/com/sun/faces/application/resource/LibraryInfo.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/LibraryInfo.java
@@ -16,6 +16,8 @@
 
 package com.sun.faces.application.resource;
 
+import java.util.Objects;
+
 /**
  * <p>
  * <code>LibraryInfo</code> is a simple wrapper class for information pertinent to building a complete resource path
@@ -64,43 +66,25 @@ public class LibraryInfo {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
         if (this == obj) {
             return true;
         }
-        final LibraryInfo other = (LibraryInfo) obj;
-        if (name == null ? other.name != null : !name.equals(other.name)) {
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        if (version != other.version && (version == null || !version.equals(other.version))) {
-            return false;
-        }
-        if (localePrefix == null ? other.localePrefix != null : !localePrefix.equals(other.localePrefix)) {
-            return false;
-        }
-        if (contract == null ? other.contract != null : !contract.equals(other.contract)) {
-            return false;
-        }
-        if (path == null ? other.path != null : !path.equals(other.path)) {
-            return false;
-        }
-        return true;
+
+        LibraryInfo other = (LibraryInfo) obj;
+
+        return Objects.equals(name, other.name)
+            && Objects.equals(version, other.version)
+            && Objects.equals(localePrefix, other.localePrefix)
+            && Objects.equals(contract, other.contract)
+            && Objects.equals(path, other.path);
     }
 
     @Override
     public int hashCode() {
-        int hash = 5;
-        hash = 37 * hash + (name != null ? name.hashCode() : 0);
-        hash = 37 * hash + (version != null ? version.hashCode() : 0);
-        hash = 37 * hash + (localePrefix != null ? localePrefix.hashCode() : 0);
-        hash = 37 * hash + (contract != null ? contract.hashCode() : 0);
-        hash = 37 * hash + (path != null ? path.hashCode() : 0);
-        return hash;
+        return Objects.hash(name, version, localePrefix, contract, path);
     }
 
     /**
@@ -132,13 +116,7 @@ public class LibraryInfo {
     }
 
     public String getPath(String localePrefix) {
-        String result = null;
-        if (null == localePrefix) {
-            result = nonLocalizedPath;
-        } else {
-            result = path;
-        }
-        return result;
+        return localePrefix == null ? nonLocalizedPath : path;
     }
 
     /**

--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceCache.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceCache.java
@@ -40,7 +40,7 @@ import jakarta.servlet.ServletContext;
  * resources. This check is periodic, configurable via context init param
  * <code>com.sun.faces.resourceUpdateCheckPeriod</code>. Through this config option, the cache can also be made static
  * or completely disabled. If the value of of this option is <code>0</code>, then no check will be made making the cache
- * static. If value of this option is <code>less than 0</code>, then no caching will be perfomed. Otherwise, the value
+ * static. If value of this option is <code>less than 0</code>, then no caching will be performed. Otherwise, the value
  * of the option will be the number of minutes between modification checks.
  * </p>
  */
@@ -51,12 +51,12 @@ public class ResourceCache {
     /**
      * The <code>ResourceInfo<code> cache.
      */
-    private MultiKeyConcurrentHashMap<Object, ResourceInfoCheckPeriodProxy> resourceCache;
+    private final MultiKeyConcurrentHashMap<Object, ResourceInfoCheckPeriodProxy> resourceCache;
 
     /**
      * Resource check period in minutes.
      */
-    private long checkPeriod;
+    private final long checkPeriod;
 
     // ------------------------------------------------------------ Constructors
 
@@ -99,7 +99,7 @@ public class ResourceCache {
         if (LOGGER.isLoggable(FINE)) {
             LOGGER.log(FINE, "Caching ResourceInfo: {0}", info.toString());
         }
-        ResourceInfoCheckPeriodProxy proxy = resourceCache.putIfAbsent(info.name, info.libraryName, info.localePrefix, new ArrayList(contracts),
+        ResourceInfoCheckPeriodProxy proxy = resourceCache.putIfAbsent(info.name, info.libraryName, info.localePrefix, new ArrayList<>(contracts),
                 new ResourceInfoCheckPeriodProxy(info, checkPeriod));
         return proxy != null ? proxy.getResourceInfo() : null;
 

--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceHelper.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceHelper.java
@@ -416,7 +416,7 @@ public abstract class ResourceHelper {
                     break;
                 }
                 if (value.contains("*") && !value.contains("*;q=0,") && !value.endsWith("*;q=0")) {
-                    // gzip not explictly listed, but client sent *
+                    // gzip not explicitly listed, but client sent *
                     // meaning gzip is implicitly acceptable
                     // keep looping to ensure we don't come across a
                     // *;q=0 value.
@@ -436,7 +436,7 @@ public abstract class ResourceHelper {
 
     /**
      * <p>
-     * Utility method to peform the necessary actions to compress content.
+     * Utility method to perform the necessary actions to compress content.
      * </p>
      *
      * <p>
@@ -478,14 +478,12 @@ public abstract class ResourceHelper {
      * @param s input String
      * @return the String without a leading slash if it has one.
      */
-    protected String trimLeadingSlash(String s) {
-
+    protected static String trimLeadingSlash(String s) {
         if (s.charAt(0) == '/') {
             return s.substring(1);
         } else {
             return s;
         }
-
     }
 
     // --------------------------------------------------------- Private Methods
@@ -532,12 +530,12 @@ public abstract class ResourceHelper {
     private static final class ELEvaluatingInputStream extends InputStream {
 
         // Premature optimization is the root of all evil. Blah blah.
-        private List<Integer> buf = new ArrayList<>(1024);
+        private final List<Integer> buf = new ArrayList<>(1024);
         private boolean failedExpressionTest = false;
         private boolean writingExpression = false;
-        private InputStream inner;
-        private ClientResourceInfo info;
-        private FacesContext ctx;
+        private final InputStream inner;
+        private final ClientResourceInfo info;
+        private final FacesContext ctx;
         private boolean expressionEvaluated;
         private boolean endOfStreamReached;
 
@@ -550,11 +548,9 @@ public abstract class ResourceHelper {
         // ---------------------------------------------------- Constructors
 
         public ELEvaluatingInputStream(FacesContext ctx, ClientResourceInfo info, InputStream inner) {
-
-            this.inner = inner;
-            this.info = info;
             this.ctx = ctx;
-
+            this.info = info;
+            this.inner = inner;
         }
 
         // ------------------------------------------------ Methods from InputStream
@@ -573,7 +569,7 @@ public abstract class ResourceHelper {
                 nextRead = -1;
                 failedExpressionTest = false;
             } else if (writingExpression) {
-                if (0 < buf.size()) {
+                if (!buf.isEmpty()) {
                     i = buf.remove(0);
                 } else {
                     writingExpression = false;
@@ -729,7 +725,7 @@ public abstract class ResourceHelper {
             String expressionBody = new String(chars);
             int colon;
             // If this expression contains a ":"
-            if (-1 != (colon = expressionBody.indexOf(":"))) {
+            if (-1 != (colon = expressionBody.indexOf(':'))) {
                 // Make sure it contains only one ":"
                 if (!isPropertyValid(expressionBody)) {
                     String message = MessageUtils.getExceptionMessageString(MessageUtils.INVALID_RESOURCE_FORMAT_COLON_ERROR, expressionBody);
@@ -743,7 +739,7 @@ public abstract class ResourceHelper {
 
                 }
                 try {
-                    int mark = parts[0].indexOf("[") + 2;
+                    int mark = parts[0].indexOf('[') + 2;
                     char quoteMark = parts[0].charAt(mark - 1);
                     parts[0] = parts[0].substring(mark, colon);
                     if (parts[0].equals("this")) {
@@ -756,7 +752,7 @@ public abstract class ResourceHelper {
                             throw new NullPointerException("Resource expression is not a library or resource library contract");
                         }
 
-                        mark = parts[1].indexOf("]") - 1;
+                        mark = parts[1].indexOf(']') - 1;
                         parts[1] = parts[1].substring(0, mark);
                         expressionBody = "resource[" + quoteMark + parts[0] + ":" + parts[1] + quoteMark + "]";
                     }

--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceInfo.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceInfo.java
@@ -16,6 +16,8 @@
 
 package com.sun.faces.application.resource;
 
+import java.util.Objects;
+
 public class ResourceInfo {
 
     ResourceHelper helper;
@@ -29,14 +31,13 @@ public class ResourceInfo {
     boolean doNotCache = false;
 
     public ResourceInfo(LibraryInfo library, ContractInfo contract, String name, VersionInfo version) {
-        this.contract = contract;
         this.library = library;
-        helper = library.getHelper();
-        localePrefix = library.getLocalePrefix();
+        this.contract = contract;
         this.name = name;
         this.version = version;
-        libraryName = library.getName();
-
+        this.helper = library.getHelper();
+        this.localePrefix = library.getLocalePrefix();
+        this.libraryName = library.getName();
     }
 
     public ResourceInfo(ContractInfo contract, String name, VersionInfo version, ResourceHelper helper) {
@@ -70,52 +71,28 @@ public class ResourceInfo {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final ResourceInfo other = (ResourceInfo) obj;
-        if (helper != other.helper && (helper == null || !helper.equals(other.helper))) {
-            return false;
-        }
-        if (library != other.library && (library == null || !library.equals(other.library))) {
-            return false;
-        }
-        if (libraryName == null ? other.libraryName != null : !libraryName.equals(other.libraryName)) {
-            return false;
-        }
-        if (localePrefix == null ? other.localePrefix != null : !localePrefix.equals(other.localePrefix)) {
-            return false;
-        }
-        if (name == null ? other.name != null : !name.equals(other.name)) {
-            return false;
-        }
-        if (path == null ? other.path != null : !path.equals(other.path)) {
-            return false;
-        }
-        if (version != other.version && (version == null || !version.equals(other.version))) {
-            return false;
-        }
-        if (doNotCache != other.doNotCache) {
-            return false;
-        }
-        return true;
+
+        ResourceInfo other = (ResourceInfo) obj;
+
+        return Objects.equals(helper, other.helper)
+            && Objects.equals(library, other.library)
+            && Objects.equals(libraryName, other.libraryName)
+            && Objects.equals(localePrefix, other.localePrefix)
+            && Objects.equals(name, other.name)
+            && Objects.equals(path, other.path)
+            && Objects.equals(version, other.version)
+            && doNotCache == other.doNotCache;
     }
 
     @Override
     public int hashCode() {
-        int hash = 7;
-        hash = 17 * hash + (helper != null ? helper.hashCode() : 0);
-        hash = 17 * hash + (library != null ? library.hashCode() : 0);
-        hash = 17 * hash + (libraryName != null ? libraryName.hashCode() : 0);
-        hash = 17 * hash + (localePrefix != null ? localePrefix.hashCode() : 0);
-        hash = 17 * hash + (name != null ? name.hashCode() : 0);
-        hash = 17 * hash + (path != null ? path.hashCode() : 0);
-        hash = 17 * hash + (version != null ? version.hashCode() : 0);
-        hash = 17 * hash + (doNotCache ? 1 : 0);
-        return hash;
+        return Objects.hash(helper, library, libraryName, localePrefix, name, path, version, doNotCache);
     }
 
     public boolean isDoNotCache() {

--- a/impl/src/main/java/com/sun/faces/application/resource/VersionInfo.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/VersionInfo.java
@@ -16,6 +16,8 @@
 
 package com.sun.faces.application.resource;
 
+import java.util.Objects;
+
 /**
  * Metadata pertaining to versions.
  */
@@ -44,53 +46,38 @@ public class VersionInfo implements Comparable {
      * @return the version
      */
     public String getVersion() {
-
         return version;
-
     }
 
     /**
      * @return the extension of the resource at processing time, or null if this version is associated with a library
      */
     public String getExtension() {
-
         return extension;
-
     }
 
     @Override
     public String toString() {
-
         return version;
-
     }
 
     @Override
     public int hashCode() {
-
-        return version.hashCode() ^ (extension != null ? extension.hashCode() : 0);
-
+        return 31 * version.hashCode() + Objects.hashCode(extension);
     }
 
     @Override
     public boolean equals(Object obj) {
-
-        if (obj == null || !(obj instanceof VersionInfo)) {
-            return false;
-        }
         if (this == obj) {
             return true;
         }
-        VersionInfo passed = (VersionInfo) obj;
-        boolean versionsEqual = version.equals(passed.version);
-        boolean extensionEqual;
-        if (extension == null) {
-            extensionEqual = passed.extension == null;
-        } else {
-            extensionEqual = extension.equals(passed.extension);
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
         }
-        return versionsEqual && extensionEqual;
 
+        VersionInfo other = (VersionInfo) obj;
+
+        return version.equals(other.version) && Objects.equals(extension, other.extension);
     }
 
     // ------------------------------------------------- Methods from Comparable

--- a/impl/src/main/java/com/sun/faces/application/resource/WebappResourceHelper.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/WebappResourceHelper.java
@@ -23,9 +23,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -59,42 +59,31 @@ public class WebappResourceHelper extends ResourceHelper {
     // ------------------------------------------------------------ Constructors
 
     public WebappResourceHelper() {
-
         WebConfiguration webconfig = WebConfiguration.getInstance();
         cacheTimestamp = webconfig.isOptionEnabled(CacheResourceModificationTimestamp);
         BASE_RESOURCE_PATH = ensureLeadingSlash(webconfig.getOptionValue(WebConfiguration.WebContextInitParameter.WebAppResourcesDirectory));
         BASE_CONTRACTS_PATH = ensureLeadingSlash(webconfig.getOptionValue(WebConfiguration.WebContextInitParameter.WebAppContractsDirectory));
-
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final WebappResourceHelper other = (WebappResourceHelper) obj;
-        if (BASE_RESOURCE_PATH == null ? other.BASE_RESOURCE_PATH != null : !BASE_RESOURCE_PATH.equals(other.BASE_RESOURCE_PATH)) {
-            return false;
-        }
-        if (BASE_CONTRACTS_PATH == null ? other.BASE_CONTRACTS_PATH != null : !BASE_CONTRACTS_PATH.equals(other.BASE_CONTRACTS_PATH)) {
-            return false;
-        }
-        if (cacheTimestamp != other.cacheTimestamp) {
-            return false;
-        }
-        return true;
+
+        WebappResourceHelper other = (WebappResourceHelper) obj;
+
+        return Objects.equals(BASE_RESOURCE_PATH, other.BASE_RESOURCE_PATH)
+            && Objects.equals(BASE_CONTRACTS_PATH, other.BASE_CONTRACTS_PATH)
+            && cacheTimestamp == other.cacheTimestamp;
     }
 
     @Override
     public int hashCode() {
-        int hash = 5;
-        hash = 37 * hash + (BASE_RESOURCE_PATH != null ? BASE_RESOURCE_PATH.hashCode() : 0);
-        hash = 37 * hash + (BASE_CONTRACTS_PATH != null ? BASE_CONTRACTS_PATH.hashCode() : 0);
-        hash = 37 * hash + (cacheTimestamp ? 1 : 0);
-        return hash;
+        return Objects.hash(BASE_RESOURCE_PATH, BASE_CONTRACTS_PATH, cacheTimestamp);
     }
 
     // --------------------------------------------- Methods from ResourceHelper
@@ -104,9 +93,7 @@ public class WebappResourceHelper extends ResourceHelper {
      */
     @Override
     public String getBaseResourcePath() {
-
         return BASE_RESOURCE_PATH;
-
     }
 
     @Override
@@ -213,7 +200,7 @@ public class WebappResourceHelper extends ResourceHelper {
         // if getResourcePaths returns null or an empty set, this means that we have
         // a non-directory resource, therefor, this resource isn't versioned.
         ClientResourceInfo value;
-        if (resourcePaths == null || resourcePaths.size() == 0) {
+        if (resourcePaths == null || resourcePaths.isEmpty()) {
             if (library != null) {
                 value = new ClientResourceInfo(library, outContract[0], resourceName, null, compressable,
                         resourceSupportsEL(resourceName, library.getName(), ctx), ctx.isProjectStage(ProjectStage.Development), cacheTimestamp);
@@ -245,20 +232,18 @@ public class WebappResourceHelper extends ResourceHelper {
 
     private String findPathConsideringContracts(LibraryInfo library, String resourceName, String localePrefix, ContractInfo[] outContract, FacesContext ctx) {
         UIViewRoot root = ctx.getViewRoot();
-        List<String> contracts = null;
+        final List<String> contracts;
 
         if (library != null) {
             if (library.getContract() == null) {
                 contracts = Collections.emptyList();
             } else {
-                contracts = new ArrayList<>(1);
-                contracts.add(library.getContract());
+                contracts = List.of(library.getContract());
             }
         } else if (root == null) {
             String contractName = ctx.getExternalContext().getRequestParameterMap().get("con");
-            if (null != contractName && 0 < contractName.length() && !ResourceManager.nameContainsForbiddenSequence(contractName)) {
-                contracts = new ArrayList<>();
-                contracts.add(contractName);
+            if (contractName != null && !contractName.isEmpty() && !ResourceManager.nameContainsForbiddenSequence(contractName)) {
+                contracts = List.of(contractName);
             } else {
                 return null;
             }

--- a/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/RenderKitUtils.java
@@ -16,6 +16,7 @@
 
 package com.sun.faces.renderkit;
 
+import static com.sun.faces.RIConstants.EMPTY_STRING;
 import static com.sun.faces.renderkit.RenderKitUtils.PredefinedPostbackParameter.BEHAVIOR_EVENT_PARAM;
 import static com.sun.faces.renderkit.RenderKitUtils.PredefinedPostbackParameter.BEHAVIOR_SOURCE_PARAM;
 import static com.sun.faces.renderkit.RenderKitUtils.PredefinedPostbackParameter.PARTIAL_EVENT_PARAM;
@@ -156,6 +157,15 @@ public class RenderKitUtils {
     protected static final Logger LOGGER = FacesLogger.RENDERKIT.getLogger();
 
     public static final String DEVELOPMENT_STAGE_MESSAGES_ID = "jakarta_faces_developmentstage_messages";
+
+    /**
+     * <p>
+     * Sentinel submitted value for a selection component whose request parameter was absent, so that a subsequent
+     * decode can tell "submitted with nothing selected" apart from "not submitted at all". It is not a general purpose
+     * empty string; use {@link RIConstants#EMPTY_STRING} for that.
+     * </p>
+     */
+    public static final String NO_VALUE = "";
 
     /**
      * @see UIViewRoot#encodeChildren(FacesContext)
@@ -1387,8 +1397,8 @@ public class RenderKitUtils {
         } else {
 
             String value = (String) component.getAttributes().get(attrName);
-            if (value == null || value.length() == 0) {
-                return "";
+            if (value == null || value.isEmpty()) {
+                return EMPTY_STRING;
             }
             WebConfiguration webConfig = WebConfiguration.getInstance();
             if (Util.ensureLeadingSlash(value).startsWith(Util.ensureLeadingSlash(webConfig.getOptionValue(WebConfiguration.WebContextInitParameter.WebAppContractsDirectory)))) {

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/MenuRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/MenuRenderer.java
@@ -18,7 +18,8 @@
 
 package com.sun.faces.renderkit.html_basic;
 
-import static com.sun.faces.RIConstants.NO_VALUE;
+import static com.sun.faces.RIConstants.EMPTY_STRING;
+import static com.sun.faces.renderkit.RenderKitUtils.NO_VALUE;
 import static com.sun.faces.renderkit.RenderKitUtils.getSelectItems;
 import static com.sun.faces.renderkit.RenderKitUtils.flushPendingBehaviorEventListeners;
 import static com.sun.faces.renderkit.RenderKitUtils.renderPassThruAttributes;
@@ -80,7 +81,6 @@ import jakarta.faces.convert.ConverterException;
 import jakarta.faces.model.SelectItem;
 import jakarta.faces.model.SelectItemGroup;
 
-import com.sun.faces.RIConstants;
 import com.sun.faces.io.FastStringWriter;
 import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
@@ -556,7 +556,7 @@ public class MenuRenderer extends HtmlBasicInputRenderer {
             return " multiple ";
         }
 
-        return "";
+        return EMPTY_STRING;
     }
 
     protected Object[] getSubmittedSelectedValues(UIComponent component) {
@@ -926,7 +926,7 @@ public class MenuRenderer extends HtmlBasicInputRenderer {
             if (newValue != null && !newValue.isEmpty()) {
                 Set<String> disabledSelectItemValues = getDisabledSelectItemValues(context, component);
                 if (disabledSelectItemValues.contains(newValue)) {
-                    newValue = RIConstants.NO_VALUE;
+                    newValue = NO_VALUE;
                 }
             }
 

--- a/impl/src/main/java/com/sun/faces/renderkit/html_basic/RadioRenderer.java
+++ b/impl/src/main/java/com/sun/faces/renderkit/html_basic/RadioRenderer.java
@@ -18,6 +18,7 @@
 
 package com.sun.faces.renderkit.html_basic;
 
+import static com.sun.faces.renderkit.RenderKitUtils.NO_VALUE;
 import static java.lang.Boolean.TRUE;
 
 import java.io.IOException;
@@ -48,7 +49,6 @@ import jakarta.faces.event.ListenerFor;
 import jakarta.faces.event.PostAddToViewEvent;
 import jakarta.faces.model.SelectItem;
 
-import com.sun.faces.RIConstants;
 import com.sun.faces.renderkit.Attributes;
 import com.sun.faces.renderkit.AttributeManager;
 import com.sun.faces.renderkit.RenderKitUtils;
@@ -151,7 +151,7 @@ public class RadioRenderer extends SelectManyCheckboxListRenderer implements Com
             }
         } else {
             // There is no submitted value at all, but this is different from a null value.
-            radio.setSubmittedValue(RIConstants.NO_VALUE);
+            radio.setSubmittedValue(NO_VALUE);
         }
     }
 

--- a/impl/src/main/java/com/sun/faces/util/Util.java
+++ b/impl/src/main/java/com/sun/faces/util/Util.java
@@ -19,10 +19,10 @@
 
 package com.sun.faces.util;
 
+import static com.sun.faces.RIConstants.EMPTY_STRING;
 import static com.sun.faces.RIConstants.FACELETS_ENCODING_KEY;
 import static com.sun.faces.RIConstants.FACES_SERVLET_MAPPINGS;
 import static com.sun.faces.RIConstants.FACES_SERVLET_REGISTRATION;
-import static com.sun.faces.RIConstants.NO_VALUE;
 import static com.sun.faces.util.MessageUtils.ILLEGAL_ATTEMPT_SETTING_APPLICATION_ARTIFACT_ID;
 import static com.sun.faces.util.MessageUtils.NAMED_OBJECT_NOT_FOUND_ERROR_MESSAGE_ID;
 import static com.sun.faces.util.MessageUtils.NULL_PARAMETERS_ERROR_MESSAGE_ID;
@@ -285,8 +285,8 @@ public class Util {
         try {
             Thread.currentThread().setContextClassLoader(Util.class.getClassLoader());
             factory = TransformerFactory.newInstance();
-            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, NO_VALUE);
-            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, NO_VALUE);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, EMPTY_STRING);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, EMPTY_STRING);
             setFeature(factory::setFeature, XMLConstants.FEATURE_SECURE_PROCESSING, true);
         } finally {
             Thread.currentThread().setContextClassLoader(cl);
@@ -921,7 +921,7 @@ public class Util {
      */
     public static String getStackTraceString(Throwable e) {
         if (null == e) {
-            return "";
+            return EMPTY_STRING;
         }
 
         StackTraceElement[] stacks = e.getStackTrace();
@@ -1126,7 +1126,7 @@ public class Util {
 
             @Override
             public String getServletName() {
-                return "";
+                return EMPTY_STRING;
             }
 
             @Override
@@ -1293,7 +1293,7 @@ public class Util {
         if (viewRoot instanceof NamingContainer) {
             return viewRoot.getContainerClientId(context) + UINamingContainer.getSeparatorChar(context);
         } else {
-            return "";
+            return EMPTY_STRING;
         }
     }
 

--- a/impl/src/test/java/com/sun/faces/application/resource/ResourceMetadataEqualsTest.java
+++ b/impl/src/test/java/com/sun/faces/application/resource/ResourceMetadataEqualsTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.application.resource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.faces.context.FacesContext;
+
+public class ResourceMetadataEqualsTest {
+
+    private static final ResourceHelper RESOURCE_HELPER = new ResourceHelper() {
+
+        @Override
+        public String getBaseResourcePath() {
+            return "/resources";
+        }
+
+        @Override
+        public String getBaseContractsPath() {
+            return "/contracts";
+        }
+
+        @Override
+        public URL getURL(ResourceInfo resource, FacesContext ctx) {
+            return null;
+        }
+
+        @Override
+        public LibraryInfo findLibrary(String libraryName, String localePrefix, String contract, FacesContext ctx) {
+            return null;
+        }
+
+        @Override
+        public ResourceInfo findResource(LibraryInfo library, String resourceName, String localePrefix, boolean compressable, FacesContext ctx) {
+            return null;
+        }
+
+        @Override
+        protected InputStream getNonCompressedInputStream(ResourceInfo resource, FacesContext ctx) {
+            return null;
+        }
+    };
+
+    /**
+     * A subclass carries state that the base class knows nothing about, so it must never compare equal to a base
+     * instance holding the same base state, in either direction. Both hierarchies are therefore safe to mix within one
+     * <code>Collection&lt;? extends ResourceInfo&gt;</code> or <code>Collection&lt;? extends LibraryInfo&gt;</code>.
+     */
+    @Test
+    public void subclassIsNeverEqualToBaseClassWithSameBaseState() throws MalformedURLException {
+        URL url = new URL("http://localhost/theme.css");
+        VersionInfo version = new VersionInfo("1_0", "css");
+        ContractInfo contract = new ContractInfo("contract");
+
+        ResourceInfo resourceInfo = new ResourceInfo(contract, "theme.css", version, RESOURCE_HELPER);
+        ResourceInfo faceletResourceInfo = new FaceletResourceInfo(contract, "theme.css", version, RESOURCE_HELPER, url);
+
+        assertNotEquals(resourceInfo, faceletResourceInfo);
+        assertNotEquals(faceletResourceInfo, resourceInfo);
+
+        LibraryInfo libraryInfo = new LibraryInfo("library", version, "nl", null, RESOURCE_HELPER);
+        LibraryInfo faceletLibraryInfo = new FaceletLibraryInfo("library", version, "nl", null, RESOURCE_HELPER, url);
+
+        assertNotEquals(libraryInfo, faceletLibraryInfo);
+        assertNotEquals(faceletLibraryInfo, libraryInfo);
+    }
+
+    @Test
+    public void sameStateIsEqualAndSharesHashCode() {
+        VersionInfo version = new VersionInfo("1_0", "css");
+        ContractInfo contract = new ContractInfo("contract");
+
+        assertEquals(version, new VersionInfo("1_0", "css"));
+        assertEquals(version.hashCode(), new VersionInfo("1_0", "css").hashCode());
+        assertNotEquals(version, new VersionInfo("1_0", "js"));
+
+        assertEquals(contract, new ContractInfo("contract"));
+        assertEquals(contract.hashCode(), new ContractInfo("contract").hashCode());
+        assertNotEquals(contract, new ContractInfo("other"));
+
+        LibraryInfo libraryInfo = new LibraryInfo("library", version, "nl", null, RESOURCE_HELPER);
+        LibraryInfo sameLibraryInfo = new LibraryInfo("library", version, "nl", null, RESOURCE_HELPER);
+
+        assertEquals(libraryInfo, sameLibraryInfo);
+        assertEquals(libraryInfo.hashCode(), sameLibraryInfo.hashCode());
+        assertNotEquals(libraryInfo, new LibraryInfo("other", version, "nl", null, RESOURCE_HELPER));
+
+        ResourceInfo resourceInfo = new ResourceInfo(contract, "theme.css", version, RESOURCE_HELPER);
+        ResourceInfo sameResourceInfo = new ResourceInfo(contract, "theme.css", version, RESOURCE_HELPER);
+
+        assertEquals(resourceInfo, sameResourceInfo);
+        assertEquals(resourceInfo.hashCode(), sameResourceInfo.hashCode());
+        assertNotEquals(resourceInfo, new ResourceInfo(contract, "other.css", version, RESOURCE_HELPER));
+    }
+
+    @Test
+    public void nullAndUnrelatedTypesAreNotEqual() {
+        VersionInfo version = new VersionInfo("1_0", "css");
+
+        assertNotEquals(null, new ContractInfo("contract"));
+        assertNotEquals("contract", new ContractInfo("contract"));
+        assertNotEquals(null, version);
+        assertNotEquals("1_0", version);
+        assertNotEquals(null, new LibraryInfo("library", version, "nl", null, RESOURCE_HELPER));
+        assertNotEquals(null, new ResourceInfo(null, "theme.css", version, RESOURCE_HELPER));
+    }
+
+}


### PR DESCRIPTION
Applies #5944 on 4.0, so it can travel the usual 4.0 → 4.1 → 5.0 upmerge path, with the review feedback from that PR resolved.

### Review feedback resolved

**`equals()` keeps `getClass()`.** `ResourceInfo` has two subclasses (`ClientResourceInfo`, `FaceletResourceInfo`) and `LibraryInfo` has one (`FaceletLibraryInfo`), none of which override `equals`. Under `instanceof` they would compare equal to a bare base instance whose base fields happen to match, while their own state (`compressedPath`, `supportsEL`, `url`, …) is ignored — and `ResourceImpl.equals`/`hashCode` delegate straight to `ResourceInfo`. `ContractInfo` is `final`, so it keeps the cheaper `instanceof`.

**`this == obj` fast path** added to every `equals`.

**`ContractInfo`** drops its copy-pasted `serialVersionUID` rather than becoming `Serializable` to justify it — the field is already gone in 5.0.

**`NO_VALUE` is no longer reused as a generic empty string.** It moves to `RenderKitUtils`, next to its only two callers (`MenuRenderer`, `RadioRenderer`), with javadoc stating it is the "submitted but nothing selected" sentinel. The new `RIConstants.EMPTY_STRING` covers the plain empty strings, including the two `TransformerFactory` attributes in `Util` that were reaching for the sentinel by mistake. Applied only to the classes touched here; the remaining literal sites elsewhere in `impl` are left alone.

### Additional

**`FaceletWebappResourceHelper` equality.** It declared every instance equal (`obj instanceof FaceletWebappResourceHelper`, `hashCode()` returning a constant) while its two sibling helpers compare their configuration. It now compares its delegate and `configuredExtensions` the same way. `configuredExtensions` is a `String[]`, so `Arrays.equals`/`Arrays.hashCode` — `Objects.equals` on an array is reference identity. No behavioral change in practice: `ApplicationAssociate` creates one `ResourceManager`, which creates one of each helper per deployment.

The rest is mechanical: `Objects.equals`/`Objects.hash` throughout, `final` fields where the value never changes, `isEmpty()` over `size()`/`length()` checks, `List.of` over a one-element `ArrayList`, `indexOf(char)` over `indexOf(String)`, `static trimLeadingSlash`, a generified raw `ArrayList` in `ResourceCache.add`, and four typo fixes.

### Notes

- **4.0 targets Java 11**, so `instanceof` pattern matching is not available here. Once this reaches 4.1/5.0 (release 17) the `equals` bodies can be tightened to pattern matching if wanted.
- Nothing depends on the exact `hashCode` values that changed: `ResourceCache` keys its `MultiKeyConcurrentHashMap` on the name/library/locale/contract strings rather than on a `ResourceInfo`, and `ResourceImpl.writeExternal` rebuilds its `resourceInfo` through `ResourceManager.findResource()` instead of serializing it.

### Testing

`mvn clean test` on `impl` is green. New `ResourceMetadataEqualsTest` pins the subclass equality contract, the equal/hashCode agreement, and null/foreign-type handling; reverting `ResourceInfo.equals` to `instanceof` fails it.

🤖 Generated with Claude Opus 5
