### PR TITLE
Don't track view root postAddToView additions as dynamic components

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/view/FaceletViewHandlingStrategy.java
@@ -367,13 +367,12 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
                 htmlDoctype.setSystem(doctype.getSystem());
                 view.setDoctype(htmlDoctype);
             }
-
-            startTrackViewModifications(ctx, view);
         } finally {
             ctx.getAttributes().remove(IS_BUILDING_INITIAL_STATE);
         }
         ctx.getApplication().publishEvent(ctx, PostAddToViewEvent.class, UIViewRoot.class, view);
         markInitialState(ctx, view);
+        startTrackViewModifications(ctx, view);
 
         setViewPopulated(ctx, view);
     }

--- a/test/impl/pom.xml
+++ b/test/impl/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.mojarra.test</groupId>
+        <artifactId>pom</artifactId>
+        <version>5.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>impl</artifactId>
+    <packaging>war</packaging>
+
+    <name>Mojarra ${project.version} - IT - ${project.artifactId}</name>
+
+    <description>
+        Integration tests for behavior the TCK cannot assert because it is implementation specific, such as what ends up
+        in the saved state. Runs against the same server profiles as the other test modules.
+    </description>
+
+    <dependencies>
+        <!-- Supplies arquillian-server.xml (the bare-container server-profile Arquillian config, e.g. Tomcat). -->
+        <dependency>
+            <groupId>org.glassfish.mojarra.test</groupId>
+            <artifactId>base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- The server supplies the implementation; the probes read its internals, e.g. StateContext. -->
+        <dependency>
+            <groupId>org.glassfish.mojarra</groupId>
+            <artifactId>mojarra</artifactId>
+            <version>${mojarra.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test/impl/src/main/java/org/glassfish/mojarra/test/impl/DynamicChildInPostAddToViewBean.java
+++ b/test/impl/src/main/java/org/glassfish/mojarra/test/impl/DynamicChildInPostAddToViewBean.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.mojarra.test.impl;
+
+import java.io.Serializable;
+
+import jakarta.faces.application.Application;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.html.HtmlInputText;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.event.ComponentSystemEvent;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+/**
+ * Adds the same child to the same container from two different <code>postAddToView</code> listeners: one attached to
+ * the view root, one attached to the container itself. Both listeners run on every view build, so neither adds
+ * conditionally.
+ */
+@Named
+@ViewScoped
+public class DynamicChildInPostAddToViewBean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String CONTAINER_ID = "form:container";
+    private static final String CHILD_ID = "dynamicInput";
+    private static final String CHILD_STYLE_CLASS = "dynamic-child";
+
+    private String value;
+
+    public void addViaViewRoot(ComponentSystemEvent event) {
+        addChild(event.getComponent().findComponent(CONTAINER_ID));
+    }
+
+    public void addViaContainer(ComponentSystemEvent event) {
+        addChild(event.getComponent());
+    }
+
+    private void addChild(UIComponent container) {
+        FacesContext context = FacesContext.getCurrentInstance();
+        Application application = context.getApplication();
+
+        HtmlInputText input = (HtmlInputText) application.createComponent(HtmlInputText.COMPONENT_TYPE);
+        input.setId(CHILD_ID);
+        input.setStyleClass(CHILD_STYLE_CLASS);
+        input.setValueExpression("value", application.getExpressionFactory()
+                .createValueExpression(context.getELContext(), "#{dynamicChildInPostAddToViewBean.value}", String.class));
+
+        container.getChildren().add(input);
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/test/impl/src/main/java/org/glassfish/mojarra/test/impl/StateProbe.java
+++ b/test/impl/src/main/java/org/glassfish/mojarra/test/impl/StateProbe.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.mojarra.test.impl;
+
+import java.util.List;
+
+import org.glassfish.mojarra.context.StateContext;
+import org.glassfish.mojarra.util.ComponentStruct;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.faces.context.FacesContext;
+import jakarta.inject.Named;
+
+/**
+ * Exposes implementation state that decides what a view has to save, so a page can render it and an integration test
+ * can assert on it.
+ */
+@Named
+@RequestScoped
+public class StateProbe {
+
+    /**
+     * The number of add/remove actions recorded for this view. Every action carries a component through the saved state
+     * instead of leaving it to the view build, so a view whose tree the build fully reproduces must report zero.
+     */
+    public int getDynamicActionCount() {
+        List<ComponentStruct> dynamicActions = StateContext.getStateContext(FacesContext.getCurrentInstance()).getDynamicActions();
+        return dynamicActions == null ? 0 : dynamicActions.size();
+    }
+}

--- a/test/impl/src/main/webapp/WEB-INF/beans.xml
+++ b/test/impl/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    bean-discovery-mode="all" is required for the OpenLiberty profile: with the Faces impl bundled in the
+    WAR (facesContainer feature), Mojarra's @ViewScoped scope is registered by its CdiExtension at
+    beforeBeanDiscovery, and Liberty's container-managed Weld does not treat that extension-registered
+    scope as a bean-defining annotation during "annotated" discovery, so the @Named @ViewScoped beans go
+    undiscovered (#{formBean} resolves to null on postback). "all" discovers every type and is harmless on
+    the other servers, which discover the same annotated beans either way.
+-->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0" bean-discovery-mode="all">
+</beans>

--- a/test/impl/src/main/webapp/WEB-INF/web.xml
+++ b/test/impl/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+    version="5.0"
+>
+    <context-param>
+        <param-name>jakarta.faces.PROJECT_STAGE</param-name>
+        <param-value>Production</param-value>
+    </context-param>
+
+    <servlet>
+        <servlet-name>facesServlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>facesServlet</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/test/impl/src/main/webapp/dynamic-child-in-container.xhtml
+++ b/test/impl/src/main/webapp/dynamic-child-in-container.xhtml
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
+    <h:head>
+        <title>DynamicChildInContainer</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <h:panelGroup id="container" layout="block">
+                <f:event type="postAddToView" listener="#{dynamicChildInPostAddToViewBean.addViaContainer}"/>
+            </h:panelGroup>
+            <h:commandButton id="submit" value="Submit"/>
+        </h:form>
+        <h:outputText id="echo" value="#{dynamicChildInPostAddToViewBean.value}"/>
+        <h:outputText id="dynamicActionCount" value="#{stateProbe.dynamicActionCount}"/>
+    </h:body>
+</html>

--- a/test/impl/src/main/webapp/dynamic-child-in-view-root.xhtml
+++ b/test/impl/src/main/webapp/dynamic-child-in-view-root.xhtml
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
+    <f:view>
+        <f:event type="postAddToView" listener="#{dynamicChildInPostAddToViewBean.addViaViewRoot}"/>
+        <h:head>
+            <title>DynamicChildInViewRoot</title>
+        </h:head>
+        <h:body>
+            <h:form id="form">
+                <h:panelGroup id="container" layout="block"/>
+                <h:commandButton id="submit" value="Submit"/>
+            </h:form>
+            <h:outputText id="echo" value="#{dynamicChildInPostAddToViewBean.value}"/>
+            <h:outputText id="dynamicActionCount" value="#{stateProbe.dynamicActionCount}"/>
+        </h:body>
+    </f:view>
+</html>

--- a/test/impl/src/test/java/org/glassfish/mojarra/test/impl/DynamicChildInPostAddToViewIT.java
+++ b/test/impl/src/test/java/org/glassfish/mojarra/test/impl/DynamicChildInPostAddToViewIT.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.mojarra.test.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import ee.jakarta.tck.faces.util.selenium.BaseITNG;
+import ee.jakarta.tck.faces.util.selenium.WebPage;
+
+/**
+ * A child added from a {@code postAddToView} listener is produced again by the view build of every request, so the
+ * saved state must not carry it: no dynamic action is recorded, and the component is left to the build. This holds
+ * wherever the listener is attached, since what makes the add repeatable is the phase it runs in, not its source.
+ *
+ * @see org.glassfish.mojarra.context.StateContext
+ */
+class DynamicChildInPostAddToViewIT extends BaseITNG {
+
+    private static final By CHILD = By.className("dynamic-child");
+    private static final String SUBMITTED_VALUE = "submitted into a dynamically added input";
+
+    @Test
+    void listenerOnViewRoot() {
+        assertBuildTimeAddIsNotSaved("dynamic-child-in-view-root.xhtml");
+    }
+
+    @Test
+    void listenerOnContainer() {
+        assertBuildTimeAddIsNotSaved("dynamic-child-in-container.xhtml");
+    }
+
+    private void assertBuildTimeAddIsNotSaved(String viewId) {
+        WebPage page = getPage(viewId);
+        assertEquals(1, page.findElements(CHILD).size(), "one added child on initial render");
+        assertEquals("0", page.findElement(By.id("dynamicActionCount")).getText(), "dynamic actions on initial render");
+
+        page.findElement(CHILD).sendKeys(SUBMITTED_VALUE);
+        page.guardHttp(page.findElement(By.id("form:submit"))::click);
+
+        assertEquals(1, page.findElements(CHILD).size(), "one added child after postback");
+        assertEquals(SUBMITTED_VALUE, page.findElement(By.id("echo")).getText(), "value decoded from the added child");
+        assertEquals("0", page.findElement(By.id("dynamicActionCount")).getText(), "dynamic actions after postback");
+    }
+}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -34,6 +34,7 @@
     <modules>
         <module>../faces/tck/util</module> <!-- BaseITNG et.al. -->
         <module>base</module>
+        <module>impl</module>
         <module>perf</module>
     </modules>
 


### PR DESCRIPTION
Fixes #5958. `buildView` started view modification tracking before publishing the view root's `PostAddToViewEvent`, so a child added by a listener on that event was recorded as a dynamic action and carried in the saved state on every request — although the next build re-runs the same listener and produces it again. Tracking now starts after `markInitialState`, which leaves those additions to the build like any other build-time add. Listeners on other components were already free, since they fire during the facelet apply, before the tracking listener exists.

Beyond the wasted state, the old order had a correctness consequence: the recorded ADD was replayed on a request where the listener would not have added anything, so a conditionally added component reappeared after its condition went away.

The new `test/impl` module is for integration tests of behavior the TCK cannot assert because it is implementation specific — here, what ends up in the saved state. It mirrors `perf`'s setup (war, `base` for the Arquillian config, Mojarra as `provided` so a probe can read internals) and its first test renders `StateContext.getDynamicActions().size()` and requires zero for both listener placements. That test fails on master with `expected: <0> but was: <1>` for the view-root page and passes for the container page, which is how the defect was pinned down.

Stacked on #5957 and targeting its branch; retarget to master once that merges.

Verification: unit tests 1308 pass, `test/impl` green, and the full Jakarta Faces TCK green with this build overlaid — 6373 integration tests, zero failures, including the new vendor-neutral test in jakartaee/faces#2233.

🤖 Generated with Claude Opus 5