### PR TITLE
Skip the render-time re-apply when the build's decisions still hold

### DIFF
--- a/impl/src/main/java/com/sun/faces/RIConstants.java
+++ b/impl/src/main/java/com/sun/faces/RIConstants.java
@@ -41,14 +41,6 @@ public class RIConstants {
     public static final String SAVED_STATE = FACES_PREFIX + "savedState";
 
     /**
-     * Request-scoped flag set during a view build when a build-time-dynamic handler (a JSTL conditional/iteration or a
-     * dynamic ui:include/ui:decorate/ui:composition) participates, marking the view as one whose facelet must be
-     * re-applied on every (re)build. Read by {@code FaceletViewHandlingStrategy.buildView} to decide whether the
-     * redundant render-time re-apply may be skipped (see {@code refreshTransientBuildOnPSS}).
-     */
-    public static final String DYNAMIC_TRANSIENT_BUILD = FACES_PREFIX + "dynamicTransientBuild";
-
-    /**
      * Request-scoped flag recording whether the render-time {@code buildView} re-applied the facelet ({@code TRUE}) or
      * skipped the re-apply for an already-populated static view ({@code FALSE}, see {@code refreshTransientBuildOnPSS}).
      * Since {@code buildView} runs immediately before {@code renderView}, this reflects whether the tree the state

--- a/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -17,7 +17,6 @@
 package com.sun.faces.application.view;
 
 import static com.sun.faces.RIConstants.DYNAMIC_COMPONENT;
-import static com.sun.faces.RIConstants.DYNAMIC_TRANSIENT_BUILD;
 import static com.sun.faces.RIConstants.VIEW_REBUILT_AT_RENDER;
 import static com.sun.faces.RIConstants.FACELETS_ENCODING_KEY;
 import static com.sun.faces.RIConstants.FLOW_DEFINITION_ID_SUFFIX;
@@ -136,6 +135,7 @@ import com.sun.faces.config.WebConfiguration;
 import com.sun.faces.config.WebConfiguration.BooleanWebContextInitParameter;
 import com.sun.faces.context.StateContext;
 import com.sun.faces.facelets.compiler.FaceletDoctype;
+import com.sun.faces.facelets.tag.BuildTimeDecisions;
 import com.sun.faces.facelets.el.ContextualCompositeMethodExpression;
 import com.sun.faces.facelets.el.VariableMapperWrapper;
 import com.sun.faces.facelets.impl.DefaultFaceletFactory;
@@ -314,8 +314,8 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
 
         if (isViewPopulated(ctx, view)) {
             if (canSkipTransientBuildRefresh(ctx, view, stateCtx)) {
-                // The view was already (re)built this request and holds no build-time-dynamic content, so re-applying
-                // the facelet would reproduce the identical tree. Skip it (see refreshTransientBuildOnPSS).
+                // The view was already (re)built this request and re-applying the facelet would reproduce the
+                // identical tree. Skip it (see refreshTransientBuildOnPSS).
                 ctx.getAttributes().put(VIEW_REBUILT_AT_RENDER, Boolean.FALSE);
                 return;
             }
@@ -324,6 +324,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
             // virute of re-applying the handlers.
             try {
                 stateCtx.setTrackViewModifications(false);
+                BuildTimeDecisions.reset(ctx);
                 facelet.apply(ctx, view);
                 reapplyDynamicActions(ctx);
                 if (stateCtx.isPartialStateSaving(ctx, view.getViewId())) {
@@ -353,6 +354,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
         try {
             ctx.getAttributes().put(IS_BUILDING_INITIAL_STATE, Boolean.TRUE);
             stateCtx.setTrackViewModifications(false);
+            BuildTimeDecisions.reset(ctx);
             facelet.apply(ctx, view);
 
             if (facelet instanceof XMLFrontMatterSaver) {
@@ -395,16 +397,17 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
     /**
      * Determines whether the redundant re-apply of the facelet on an already-populated view may be skipped. Enabled by
      * default; set {@code refreshTransientBuildOnPSS} to {@code true} to restore the legacy unconditional re-apply.
-     * The skip is only safe under partial state saving for a non-transient view whose build this request involved no
-     * build-time-dynamic content ({@link RIConstants#DYNAMIC_TRANSIENT_BUILD}) and no dynamic component add/remove,
-     * since re-applying would then reproduce the identical tree.
+     * The skip is only safe under partial state saving for a non-transient view with no dynamic component add/remove
+     * whose build this request either involved no build-time-dynamic content at all or decided every piece of it on
+     * expressions that still evaluate to the value they had ({@link BuildTimeDecisions}), since re-applying would then
+     * reproduce the identical tree.
      */
     private boolean canSkipTransientBuildRefresh(FacesContext ctx, UIViewRoot view, StateContext stateCtx) {
         return !refreshTransientBuildOnPSS
                 && !view.isTransient()
                 && stateCtx.isPartialStateSaving(ctx, view.getViewId())
                 && isEmpty(stateCtx.getDynamicActions())
-                && !ctx.getAttributes().containsKey(DYNAMIC_TRANSIENT_BUILD);
+                && BuildTimeDecisions.reproducesBuild(ctx);
     }
 
     /**

--- a/impl/src/main/java/com/sun/faces/facelets/compiler/CompilationManager.java
+++ b/impl/src/main/java/com/sun/faces/facelets/compiler/CompilationManager.java
@@ -49,6 +49,8 @@ import jakarta.faces.view.facelets.TagException;
  */
 final class CompilationManager {
 
+    private boolean unreproducibleBuild;
+
     private final static Logger log = FacesLogger.FACELETS_COMPILER.getLogger();
 
     private final Compiler compiler;
@@ -230,7 +232,7 @@ final class CompilationManager {
                 viewRootUnit.removeChildren();
                 currentUnit().addChild(viewRootUnit);
             }
-            startUnit(new TrimmedTagUnit(tagLibrary, qname[0], qname[1], t, nextTagId()));
+            startUnit(new TrimmedTagUnit(this, tagLibrary, qname[0], qname[1], t, nextTagId()));
             if (log.isLoggable(Level.FINE)) {
                 log.fine("New Namespace and [Trimmed] TagUnit pushed");
             }
@@ -250,7 +252,7 @@ final class CompilationManager {
             NamespaceUnit nsUnit = namespaceManager.toNamespaceUnit(tagLibrary);
             units.add(nsUnit);
             currentUnit().addChild(iface);
-            startUnit(new ImplementationUnit(tagLibrary, qname[0], qname[1], t, nextTagId()));
+            startUnit(new ImplementationUnit(this, tagLibrary, qname[0], qname[1], t, nextTagId()));
             if (log.isLoggable(Level.FINE)) {
                 log.fine("New Namespace and ImplementationUnit pushed");
             }
@@ -259,11 +261,11 @@ final class CompilationManager {
             units.add(new RemoveUnit());
         } else if (tagLibrary.containsTagHandler(qname[0], qname[1])) {
             if (isInterface(qname[0], qname[1])) {
-                InterfaceUnit iface = new InterfaceUnit(tagLibrary, qname[0], qname[1], t, nextTagId());
+                InterfaceUnit iface = new InterfaceUnit(this, tagLibrary, qname[0], qname[1], t, nextTagId());
                 setInterfaceUnit(iface);
                 startUnit(iface);
             } else {
-                startUnit(new TagUnit(tagLibrary, qname[0], qname[1], t, nextTagId()));
+                startUnit(new TagUnit(this, tagLibrary, qname[0], qname[1], t, nextTagId()));
             }
         } else if (tagLibrary.containsNamespace(qname[0], t)) {
             throw new TagException(orig, "Tag Library supports namespace: " + qname[0] + ", but no tag was defined for name: " + qname[1]);
@@ -338,6 +340,22 @@ final class CompilationManager {
             startUnit(unit);
         }
         unit.setNamespace(prefix, uri);
+    }
+
+    /**
+     * Whether this facelet holds a tag handler that decides what it contributes to the view by means this
+     * implementation cannot know, in which case its build cannot be proven reproducible and the redundant render-time
+     * re-apply is performed rather than skipped. Set while the handlers are created, so read it after
+     * {@link #createFaceletHandler()}.
+     *
+     * @return whether this facelet holds a handler that leaves the build unreproducible
+     */
+    boolean isUnreproducibleBuild() {
+        return unreproducibleBuild;
+    }
+
+    void markUnreproducibleBuild() {
+        unreproducibleBuild = true;
     }
 
     public FaceletHandler createFaceletHandler() {

--- a/impl/src/main/java/com/sun/faces/facelets/compiler/EncodingHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/compiler/EncodingHandler.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import com.sun.faces.RIConstants;
+import com.sun.faces.facelets.tag.BuildTimeDecisions;
 
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.context.FacesContext;
@@ -31,16 +32,25 @@ public class EncodingHandler implements FaceletHandler {
     private final FaceletHandler next;
     private final String encoding;
     private final CompilationMessageHolder messageHolder;
+    private final boolean unreproducibleBuild;
 
-    public EncodingHandler(FaceletHandler next, String encoding, CompilationMessageHolder messageHolder) {
+    public EncodingHandler(FaceletHandler next, String encoding, CompilationMessageHolder messageHolder, boolean unreproducibleBuild) {
         this.next = next;
         this.encoding = encoding;
         this.messageHolder = messageHolder;
+        this.unreproducibleBuild = unreproducibleBuild;
     }
 
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
         FacesContext context = ctx.getFacesContext();
+
+        if (unreproducibleBuild) {
+            // This facelet holds a handler that decides what it contributes to the view by means unknown here, so
+            // this build cannot be proven to reproduce what a later one would build.
+            BuildTimeDecisions.markUnreproducible(context);
+        }
+
         Map<Object, Object> ctxAttributes = context.getAttributes();
         ctxAttributes.put("facelets.compilationMessages", messageHolder);
         next.apply(ctx, parent);

--- a/impl/src/main/java/com/sun/faces/facelets/compiler/ImplementationUnit.java
+++ b/impl/src/main/java/com/sun/faces/facelets/compiler/ImplementationUnit.java
@@ -22,8 +22,8 @@ import jakarta.faces.view.facelets.Tag;
 
 class ImplementationUnit extends TrimmedTagUnit {
 
-    public ImplementationUnit(TagLibrary library, String namespace, String name, Tag tag, String id) {
-        super(library, namespace, name, tag, id);
+    public ImplementationUnit(CompilationManager manager, TagLibrary library, String namespace, String name, Tag tag, String id) {
+        super(manager, library, namespace, name, tag, id);
     }
 
     @Override

--- a/impl/src/main/java/com/sun/faces/facelets/compiler/InterfaceUnit.java
+++ b/impl/src/main/java/com/sun/faces/facelets/compiler/InterfaceUnit.java
@@ -22,8 +22,8 @@ import jakarta.faces.view.facelets.Tag;
 
 final class InterfaceUnit extends TagUnit {
 
-    public InterfaceUnit(TagLibrary library, String namespace, String name, Tag tag, String id) {
-        super(library, namespace, name, tag, id);
+    public InterfaceUnit(CompilationManager manager, TagLibrary library, String namespace, String name, Tag tag, String id) {
+        super(manager, library, namespace, name, tag, id);
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/facelets/compiler/SAXCompiler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/compiler/SAXCompiler.java
@@ -399,7 +399,7 @@ public final class SAXCompiler extends Compiler {
         } catch (FaceletException e) {
             throw e;
         }
-        FaceletHandler result = new EncodingHandler(mngr.createFaceletHandler(), encoding, mngr.getCompilationMessageHolder());
+        FaceletHandler result = new EncodingHandler(mngr.createFaceletHandler(), encoding, mngr.getCompilationMessageHolder(), mngr.isUnreproducibleBuild());
         mngr.setCompilationMessageHolder(null);
 
         return result;

--- a/impl/src/main/java/com/sun/faces/facelets/compiler/TagUnit.java
+++ b/impl/src/main/java/com/sun/faces/facelets/compiler/TagUnit.java
@@ -16,6 +16,7 @@
 
 package com.sun.faces.facelets.compiler;
 
+import com.sun.faces.facelets.tag.BuildTimeDecisions;
 import com.sun.faces.facelets.tag.TagLibrary;
 import com.sun.faces.facelets.tag.ui.UILibrary;
 
@@ -31,6 +32,8 @@ import jakarta.faces.view.facelets.TagConfig;
  */
 class TagUnit extends CompilationUnit implements TagConfig {
 
+    private final CompilationManager manager;
+
     private final TagLibrary library;
 
     private final String id;
@@ -41,7 +44,8 @@ class TagUnit extends CompilationUnit implements TagConfig {
 
     private final String name;
 
-    public TagUnit(TagLibrary library, String namespace, String name, Tag tag, String id) {
+    public TagUnit(CompilationManager manager, TagLibrary library, String namespace, String name, Tag tag, String id) {
+        this.manager = manager;
         this.library = library;
         this.tag = tag;
         this.namespace = namespace;
@@ -70,7 +74,13 @@ class TagUnit extends CompilationUnit implements TagConfig {
 
     @Override
     public FaceletHandler createFaceletHandler() {
-        return library.createTagHandler(namespace, name, this);
+        FaceletHandler handler = library.createTagHandler(namespace, name, this);
+
+        if (!BuildTimeDecisions.keepsBuildReproducible(handler, tag)) {
+            manager.markUnreproducibleBuild();
+        }
+
+        return handler;
     }
 
     @Override

--- a/impl/src/main/java/com/sun/faces/facelets/compiler/TrimmedTagUnit.java
+++ b/impl/src/main/java/com/sun/faces/facelets/compiler/TrimmedTagUnit.java
@@ -22,8 +22,8 @@ import jakarta.faces.view.facelets.Tag;
 
 class TrimmedTagUnit extends TagUnit {
 
-    public TrimmedTagUnit(TagLibrary library, String namespace, String name, Tag tag, String id) {
-        super(library, namespace, name, tag, id);
+    public TrimmedTagUnit(CompilationManager manager, TagLibrary library, String namespace, String name, Tag tag, String id) {
+        super(manager, library, namespace, name, tag, id);
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/facelets/tag/BuildTimeDecisions.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/BuildTimeDecisions.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.facelets.tag;
+
+import static java.util.logging.Level.FINE;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+import jakarta.el.ValueExpression;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.view.facelets.BehaviorHandler;
+import jakarta.faces.view.facelets.ConverterHandler;
+import jakarta.faces.view.facelets.FaceletContext;
+import jakarta.faces.view.facelets.FaceletHandler;
+import jakarta.faces.view.facelets.Tag;
+import jakarta.faces.view.facelets.TagAttribute;
+import jakarta.faces.view.facelets.ValidatorHandler;
+
+import com.sun.faces.RIConstants;
+import com.sun.faces.util.FacesLogger;
+
+/**
+ * What the view build in progress decided: everything a build-time-dynamic handler evaluated to produce what it
+ * produced, in the order the build evaluated it.
+ *
+ * <p>
+ * A view holding build-time-dynamic content has its facelet re-applied on every (re)build, since what the build
+ * produces depends on more than the facelet. The re-apply is redundant when every recorded decision still yields the
+ * value it yielded: the same handlers then take the same branches, create the same components and apply the same
+ * values, so the re-apply reproduces the identical view. Proving that costs one evaluation per decision instead of a
+ * walk over the whole tree, which is what {@code FaceletViewHandlingStrategy.buildView} spends the skip on.
+ *
+ * <p>
+ * A decision is either an expression that must still evaluate to its recorded value, or a supplier that must still
+ * yield its recorded value. The latter covers what an expression cannot answer: whether the value a handler applied is
+ * still the one in effect, which the state restored over the tree after the build can replace, and whether a
+ * comparison over more than one input still holds, such as a whole item list.
+ *
+ * <p>
+ * A handler that produces something no decision can express marks the build unreproducible instead, which denies the
+ * skip for the whole build. So does a decision that yields another value or fails to be evaluated at all, which is
+ * what an expression that only holds under the branch that guarded it does.
+ *
+ * @see TagHandlerImpl#recordBuildTimeDecision(jakarta.faces.view.facelets.FaceletContext, ValueExpression, Object)
+ */
+public final class BuildTimeDecisions {
+
+    private static final Logger LOGGER = FacesLogger.FACELETS_FACELET.getLogger();
+
+    private static final String KEY = RIConstants.FACES_PREFIX + "buildTimeDecisions";
+
+    /**
+     * The package of {@code DelegatingMetaTagHandler} and its subclasses, which leave what they build to a delegate.
+     */
+    private static final String FACELETS_API_PACKAGE = "jakarta.faces.view.facelets.";
+
+    /**
+     * The package of the tag handlers of this implementation, every one of which is audited to either contribute the
+     * same thing to every build of a view or record what it decided.
+     */
+    private static final String FACELETS_IMPL_PACKAGE = "com.sun.faces.facelets.";
+
+    private static final class Decision {
+
+        private final Supplier<?> value;
+        private final Object recordedValue;
+        private final UIComponent component;
+        private final UIComponent compositeComponent;
+
+        private Decision(Supplier<?> value, Object recordedValue, UIComponent component, UIComponent compositeComponent) {
+            this.value = value;
+            this.recordedValue = recordedValue;
+            this.component = component;
+            this.compositeComponent = compositeComponent;
+        }
+
+        /**
+         * Re-evaluates this decision under the components it was recorded under. An expression reaching {@code cc} or
+         * {@code component} resolves them from the component stack rather than from a variable, and that stack is empty
+         * outside a build: {@code cc} would resolve to null, and an operator over null yields a value of its own rather
+         * than failing, which a recorded value can match.
+         */
+        private Object currentValue(FacesContext context) {
+            if (compositeComponent != null) {
+                compositeComponent.pushComponentToEL(context, compositeComponent);
+            }
+            if (component != null) {
+                component.pushComponentToEL(context, component);
+            }
+
+            try {
+                return value.get();
+            } finally {
+                if (component != null) {
+                    component.popComponentFromEL(context);
+                }
+                if (compositeComponent != null) {
+                    compositeComponent.popComponentFromEL(context);
+                }
+            }
+        }
+    }
+
+    private final List<Decision> decisions = new ArrayList<>();
+    private int unreproducibleMarks;
+
+    private BuildTimeDecisions() {
+    }
+
+    /**
+     * Whether the given tag handler leaves the build reproducible, which holds in four cases. It attaches a converter,
+     * validator or behavior to its parent, which a re-apply does not act on at all. It does not take over
+     * {@code apply} at all, leaving what it builds to the delegate of {@code ComponentHandler} and its siblings. Or the
+     * class that takes it over is one of this implementation's own, each of which is audited to either contribute the
+     * same thing to every build or record what it decided. Or its tag carries no expression at all, leaving it nothing
+     * to decide on that the lifecycle could have changed since the last build of this view: both builds are performed
+     * within the same request, so everything such a handler reads from that request - its parameters, whether it is a
+     * postback, the project stage - is the same for both, and only what an expression reaches can have changed in
+     * between.
+     *
+     * @param handler the tag handler to classify
+     * @param tag the tag it handles
+     * @return whether the given tag handler leaves the build reproducible
+     */
+    public static boolean keepsBuildReproducible(FaceletHandler handler, Tag tag) {
+        return attachesObject(handler) || !takesOverApply(handler) || !hasExpression(tag);
+    }
+
+    /**
+     * Whether the given tag handler attaches an object to its parent rather than building anything: a converter, a
+     * validator or a behavior. Such a handler acts only while its parent is new to the tree, so a re-apply is a no-op
+     * for it however it takes over {@code apply}, which is what a handler deferring the evaluation of its attributes to
+     * the render pass does.
+     */
+    private static boolean attachesObject(FaceletHandler handler) {
+        return handler instanceof ConverterHandler || handler instanceof ValidatorHandler || handler instanceof BehaviorHandler;
+    }
+
+    private static boolean takesOverApply(FaceletHandler handler) {
+        Class<?> handlerClass = handler.getClass();
+
+        try {
+            String declaringClassName = handlerClass.getMethod("apply", FaceletContext.class, UIComponent.class).getDeclaringClass().getName();
+            return !declaringClassName.startsWith(FACELETS_API_PACKAGE) && !declaringClassName.startsWith(FACELETS_IMPL_PACKAGE);
+        } catch (NoSuchMethodException e) {
+            LOGGER.log(FINE, e, () -> handlerClass + " has no apply(FaceletContext, UIComponent), treating it as unreproducible");
+            return true;
+        }
+    }
+
+    private static boolean hasExpression(Tag tag) {
+        for (TagAttribute attribute : tag.getAttributes().getAll()) {
+            if (!attribute.isLiteral()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static BuildTimeDecisions of(FacesContext context) {
+        return (BuildTimeDecisions) context.getAttributes().computeIfAbsent(KEY, key -> new BuildTimeDecisions());
+    }
+
+    public static void record(FacesContext context, ValueExpression expression, Object value) {
+        record(context, () -> expression.getValue(context.getELContext()), value);
+    }
+
+    public static void record(FacesContext context, Supplier<?> value, Object recordedValue) {
+        of(context).decisions.add(new Decision(value, recordedValue, UIComponent.getCurrentComponent(context),
+                UIComponent.getCurrentCompositeComponent(context)));
+    }
+
+    public static void markUnreproducible(FacesContext context) {
+        of(context).unreproducibleMarks++;
+    }
+
+    /**
+     * Discards the decisions of the previous build, to be called by whoever is about to apply a facelet.
+     *
+     * @param context the {@link FacesContext} for the current request
+     */
+    public static void reset(FacesContext context) {
+        context.getAttributes().remove(KEY);
+    }
+
+    /**
+     * The number of decisions the build has recorded so far, for a handler comparing it against a later count to see
+     * whether the part of the build in between recorded any of its own.
+     *
+     * @param context the {@link FacesContext} for the current request
+     * @return the number of decisions the build has recorded so far
+     */
+    public static int size(FacesContext context) {
+        return of(context).decisions.size();
+    }
+
+    /**
+     * The number of times the build has been marked unreproducible so far, for a handler comparing it against a later
+     * count to see whether the part of the build in between marked it.
+     *
+     * @param context the {@link FacesContext} for the current request
+     * @return the number of times the build has been marked unreproducible so far
+     */
+    public static int unreproducibleMarks(FacesContext context) {
+        return of(context).unreproducibleMarks;
+    }
+
+    /**
+     * Whether re-applying the facelet would reproduce what the last build of this view produced, which is the case
+     * when nothing marked the build unreproducible and every decision it recorded still yields the value it had.
+     *
+     * @param context the {@link FacesContext} for the current request
+     * @return whether re-applying the facelet would reproduce what the last build of this view produced
+     */
+    public static boolean reproducesBuild(FacesContext context) {
+        BuildTimeDecisions instance = (BuildTimeDecisions) context.getAttributes().get(KEY);
+
+        if (instance == null) {
+            return true;
+        }
+
+        if (instance.unreproducibleMarks > 0) {
+            return false;
+        }
+
+        for (Decision decision : instance.decisions) {
+            try {
+                if (!Objects.equals(decision.recordedValue, decision.currentValue(context))) {
+                    return false;
+                }
+            } catch (RuntimeException e) {
+                LOGGER.log(FINE, e, () -> "A build time decision could not be re-evaluated, rebuilding the view");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+}

--- a/impl/src/main/java/com/sun/faces/facelets/tag/TagHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/TagHandlerImpl.java
@@ -19,14 +19,15 @@ package com.sun.faces.facelets.tag;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Supplier;
 
+import jakarta.el.ValueExpression;
 import jakarta.faces.view.facelets.CompositeFaceletHandler;
 import jakarta.faces.view.facelets.FaceletContext;
 import jakarta.faces.view.facelets.FaceletHandler;
+import jakarta.faces.view.facelets.TagAttribute;
 import jakarta.faces.view.facelets.TagConfig;
 import jakarta.faces.view.facelets.TagHandler;
-
-import com.sun.faces.RIConstants;
 
 /**
  *
@@ -39,15 +40,80 @@ public abstract class TagHandlerImpl extends TagHandler {
     }
 
     /**
-     * Flag the current view build as containing build-time-dynamic content (a JSTL conditional/iteration or a dynamic
-     * include) so its facelet is re-applied on every (re)build. Build-time-dynamic handlers call this at the top of
-     * their {@code apply}; the absence of the flag lets {@code FaceletViewHandlingStrategy} skip the redundant
-     * render-time re-apply for a purely component-driven view (see {@code refreshTransientBuildOnPSS}).
+     * Mark the current view build unreproducible, so its facelet is re-applied on every (re)build. A handler calls
+     * this when what it contributes to the view follows from something no decision can express; the skip of the
+     * redundant render-time re-apply is then denied for the whole build (see {@code refreshTransientBuildOnPSS}).
      *
      * @param ctx the {@link FaceletContext} for the current build
      */
-    protected static void markDynamicTransientBuild(FaceletContext ctx) {
-        ctx.getFacesContext().getAttributes().put(RIConstants.DYNAMIC_TRANSIENT_BUILD, Boolean.TRUE);
+    protected static void markUnreproducibleBuild(FaceletContext ctx) {
+        BuildTimeDecisions.markUnreproducible(ctx.getFacesContext());
+    }
+
+    /**
+     * Record the decision this handler took: the expression it evaluated and the value it got. Re-applying the facelet
+     * is then known to reproduce what this build produced as long as that expression still evaluates to that value.
+     *
+     * @param ctx the {@link FaceletContext} for the current build
+     * @param decision the expression this handler decided on
+     * @param value the value that expression had during this build
+     */
+    protected static void recordBuildTimeDecision(FaceletContext ctx, ValueExpression decision, Object value) {
+        BuildTimeDecisions.record(ctx.getFacesContext(), decision, value);
+    }
+
+    /**
+     * Record the decision this handler took on the given tag attribute: the value it evaluated to during this build.
+     * A literal attribute cannot evaluate to anything else and is therefore no decision at all, as is an absent one.
+     *
+     * @param ctx the {@link FaceletContext} for the current build
+     * @param attribute the attribute this handler decided on, may be {@code null}
+     */
+    protected static void recordBuildTimeDecision(FaceletContext ctx, TagAttribute attribute) {
+        if (isDynamic(attribute)) {
+            ValueExpression expression = attribute.getValueExpression(ctx, Object.class);
+            recordBuildTimeDecision(ctx, expression, expression.getValue(ctx));
+        }
+    }
+
+    /**
+     * Record the decision this handler took on the given tag attribute, whose value this handler has already
+     * evaluated. Recording that value rather than evaluating the attribute again keeps the decision the one the build
+     * acted on, and spares an evaluation of an expression that may not be free.
+     *
+     * @param ctx the {@link FaceletContext} for the current build
+     * @param attribute the attribute this handler decided on, may be {@code null}
+     * @param type the type the attribute was evaluated as
+     * @param value the value it evaluated to during this build
+     */
+    protected static void recordBuildTimeDecision(FaceletContext ctx, TagAttribute attribute, Class<?> type, Object value) {
+        if (isDynamic(attribute)) {
+            recordBuildTimeDecision(ctx, attribute.getValueExpression(ctx, type), value);
+        }
+    }
+
+    /**
+     * Record the decision this handler took as a supplier of the value it must still yield, for what an expression
+     * cannot answer: whether the value this build applied is still the one in effect, which the state restored over
+     * the tree can replace, and whether a comparison over more than one input still holds.
+     *
+     * @param ctx the {@link FaceletContext} for the current build
+     * @param decision the supplier of the value this handler decided on
+     * @param value the value that supplier yielded during this build
+     */
+    protected static void recordBuildTimeDecision(FaceletContext ctx, Supplier<?> decision, Object value) {
+        BuildTimeDecisions.record(ctx.getFacesContext(), decision, value);
+    }
+
+    /**
+     * Whether the given attribute can evaluate to something other than what it evaluated to before, which an absent or
+     * literal attribute cannot.
+     *
+     * @param attribute the attribute to test, may be {@code null}
+     * @return whether the given attribute can evaluate to something other than what it evaluated to before
+     */
+    protected static boolean isDynamic(TagAttribute attribute) {
+        return attribute != null && !attribute.isLiteral();
     }
 
     /**

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/core/FacetHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/core/FacetHandler.java
@@ -56,6 +56,7 @@ public final class FacetHandler extends TagHandlerImpl implements jakarta.faces.
         if (parent == null) {
             throw new TagException(tag, "Parent UIComponent was null");
         }
+        recordBuildTimeDecision(ctx, name);
         parent.getAttributes().put(KEY, getFacetName(ctx));
         try {
             nextHandler.apply(ctx, parent);

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/core/LoadBundleHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/core/LoadBundleHandler.java
@@ -68,19 +68,14 @@ public final class LoadBundleHandler extends TagHandlerImpl {
      */
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
-        if (!basename.isLiteral()) {
-            // A non-literal basename is re-evaluated per request, so the view must be re-applied on every (re)build
-            // instead of skipped (see refreshTransientBuildOnPSS) to re-resolve the bundle under var.
-            markDynamicTransientBuild(ctx);
-        }
-
         final UIViewRoot root = ComponentSupport.getViewRoot(ctx, parent);
+        final Locale locale = root != null && root.getLocale() != null ? root.getLocale() : Locale.getDefault();
 
+        final String name;
         final ResourceBundle bundle;
         try {
-            String name = basename.getValue(ctx);
+            name = basename.getValue(ctx);
             ClassLoader cl = Thread.currentThread().getContextClassLoader();
-            Locale locale = root != null && root.getLocale() != null ? root.getLocale() : Locale.getDefault();
 
             bundle = ResourceBundle.getBundle(name, locale, cl);
         }
@@ -91,7 +86,25 @@ public final class LoadBundleHandler extends TagHandlerImpl {
         final ResourceBundleMap map = new ResourceBundleMap(bundle);
         final FacesContext faces = ctx.getFacesContext();
 
-        faces.getExternalContext().getRequestMap().put(var.getValue(ctx), map);
+        final String varValue = var.getValue(ctx);
+        faces.getExternalContext().getRequestMap().put(varValue, map);
+
+        recordDecisions(ctx, root, name, varValue);
+    }
+
+    /**
+     * Records what this build resolved the bundle from, so the redundant render-time re-apply is skipped as long as
+     * it would resolve the same bundle under the same name, and performed when it would not, which is what re-resolves
+     * it (see {@code refreshTransientBuildOnPSS}). The view locale takes a decision even for a literal basename, since
+     * a locale changed after this build resolves a different bundle from the very same basename.
+     */
+    private void recordDecisions(FaceletContext ctx, UIViewRoot root, String basename, String var) {
+        recordBuildTimeDecision(ctx, this.basename, String.class, basename);
+        recordBuildTimeDecision(ctx, this.var, String.class, var);
+
+        if (root != null) {
+            recordBuildTimeDecision(ctx, root::getLocale, root.getLocale());
+        }
     }
 
     // ResourceBundleMap ---------------------------------------------------------------------

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/core/ViewHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/core/ViewHandler.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -33,6 +34,7 @@ import jakarta.el.MethodExpression;
 import jakarta.faces.application.ProjectStage;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.PhaseEvent;
 import jakarta.faces.view.facelets.FaceletContext;
 import jakarta.faces.view.facelets.TagAttribute;
@@ -95,12 +97,6 @@ public final class ViewHandler extends TagHandlerImpl {
      */
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
-        if (hasDynamicAttribute()) {
-            // A non-literal f:view attribute (e.g. locale, contentType) is re-evaluated per request and applied to
-            // the UIViewRoot during this build, so the view must be re-applied on every (re)build instead of skipped
-            // (see refreshTransientBuildOnPSS), otherwise a value changed by a postback would not take effect.
-            markDynamicTransientBuild(ctx);
-        }
         UIViewRoot root = ComponentSupport.getViewRoot(ctx, parent);
         if (root != null) {
             if (renderKitId != null) {
@@ -176,22 +172,51 @@ public final class ViewHandler extends TagHandlerImpl {
             }
         }
 
+        recordDecisions(ctx, root);
+
         nextHandler.apply(ctx, parent);
     }
 
     /**
-     * Whether any of the view attributes applied to the {@link UIViewRoot} during the build is non-literal, i.e.
-     * re-evaluated per request. Such a view must be re-applied on every (re)build so a value changed by a postback
-     * is reflected; the {@code beforePhase}/{@code afterPhase} listener expressions are excluded as they are fixed
-     * per facelet and restored from state.
+     * Records what this build decided for every non-literal view attribute, so the redundant render-time re-apply is
+     * skipped as long as each still holds and is performed when one of them does not, which is what applies the new
+     * value (see {@code refreshTransientBuildOnPSS}). Each takes two decisions: the attribute still evaluates to the
+     * value this build got, and, for the attributes held in the state of the {@link UIViewRoot} rather than in that
+     * of the request, the value this build applied is still the one in effect, since the state restored over the tree
+     * after this build replaces it with the one the previous request saved. The resource library contracts take that
+     * second decision as well, on the {@link FacesContext} rather than on the view: restoring a view recalculates them
+     * from the configured mappings once the build that applied them has finished. The {@code beforePhase}/{@code afterPhase}
+     * listener expressions are excluded as they are fixed per facelet and restored from state.
      */
-    private boolean hasDynamicAttribute() {
-        return isDynamic(locale) || isDynamic(renderKitId) || isDynamic(contentType) || isDynamic(encoding)
-                || isDynamic(contracts) || isDynamic(transientFlag);
-    }
+    private void recordDecisions(FaceletContext ctx, UIViewRoot root) {
+        recordBuildTimeDecision(ctx, locale);
+        recordBuildTimeDecision(ctx, renderKitId);
+        recordBuildTimeDecision(ctx, contentType);
+        recordBuildTimeDecision(ctx, encoding);
+        recordBuildTimeDecision(ctx, contracts);
+        recordBuildTimeDecision(ctx, transientFlag);
 
-    private static boolean isDynamic(TagAttribute attribute) {
-        return attribute != null && !attribute.isLiteral();
+        if (root != null) {
+            if (isDynamic(locale)) {
+                recordBuildTimeDecision(ctx, root::getLocale, root.getLocale());
+            }
+            if (isDynamic(renderKitId)) {
+                recordBuildTimeDecision(ctx, root::getRenderKitId, root.getRenderKitId());
+            }
+            if (isDynamic(transientFlag)) {
+                recordBuildTimeDecision(ctx, root::isTransient, root.isTransient());
+            }
+            if (isDynamic(encoding)) {
+                Map<String, Object> attributes = root.getAttributes();
+                recordBuildTimeDecision(ctx, () -> attributes.get(RIConstants.FACELETS_ENCODING_KEY),
+                        attributes.get(RIConstants.FACELETS_ENCODING_KEY));
+            }
+        }
+
+        if (isDynamic(contracts)) {
+            FacesContext facesContext = ctx.getFacesContext();
+            recordBuildTimeDecision(ctx, facesContext::getResourceLibraryContracts, facesContext.getResourceLibraryContracts());
+        }
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/ChooseHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/ChooseHandler.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import com.sun.faces.facelets.tag.TagHandlerImpl;
 
+import jakarta.el.ValueExpression;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.view.facelets.FaceletContext;
 import jakarta.faces.view.facelets.TagConfig;
@@ -59,9 +60,11 @@ public final class ChooseHandler extends TagHandlerImpl {
 
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
-        markDynamicTransientBuild(ctx);
         for (int i = 0; i < when.length; i++) {
-            if (when[i].isTestTrue(ctx)) {
+            ValueExpression testExpression = when[i].getTestExpression(ctx);
+            boolean b = Boolean.TRUE.equals(testExpression.getValue(ctx));
+            recordBuildTimeDecision(ctx, testExpression, b);
+            if (b) {
                 when[i].apply(ctx, parent);
                 return;
             }

--- a/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/ChooseWhenHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/ChooseWhenHandler.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 
 import com.sun.faces.facelets.tag.TagHandlerImpl;
 
+import jakarta.el.ValueExpression;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.view.facelets.FaceletContext;
 import jakarta.faces.view.facelets.TagAttribute;
@@ -42,7 +43,7 @@ public final class ChooseWhenHandler extends TagHandlerImpl {
         nextHandler.apply(ctx, parent);
     }
 
-    public boolean isTestTrue(FaceletContext ctx) {
-        return test.getBoolean(ctx);
+    public ValueExpression getTestExpression(FaceletContext ctx) {
+        return test.getValueExpression(ctx, Boolean.class);
     }
 }

--- a/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/ForEachHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/ForEachHandler.java
@@ -26,14 +26,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-import com.sun.faces.RIConstants;
+import com.sun.faces.facelets.tag.BuildTimeDecisions;
 import com.sun.faces.facelets.tag.TagHandlerImpl;
 import com.sun.faces.facelets.tag.faces.ComponentSupport;
 import com.sun.faces.facelets.tag.faces.IterationIdManager;
 
+import jakarta.el.ELContext;
 import jakarta.el.ValueExpression;
 import jakarta.el.VariableMapper;
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.PhaseId;
 import jakarta.faces.view.facelets.FaceletContext;
 import jakarta.faces.view.facelets.TagAttribute;
@@ -124,7 +126,6 @@ public final class ForEachHandler extends TagHandlerImpl {
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
 
-        markDynamicTransientBuild(ctx);
         int s = getBegin(ctx);
         int e = getEnd(ctx);
         int m = getStep(ctx);
@@ -153,21 +154,26 @@ public final class ForEachHandler extends TagHandlerImpl {
         // positional index to compare against or read live - so it, and any other non-indexable Collection, is left to
         // the normal re-apply path.
         boolean indexable = src != null && (srcVE == null || src instanceof List || src.getClass().isArray());
-        Map<Object, Object> contextAttributes = ctx.getFacesContext().getAttributes();
+        FacesContext facesContext = ctx.getFacesContext();
+        Map<Object, Object> contextAttributes = facesContext.getAttributes();
         String stateKey = null;
         int[] range = null;
         List<UIComponent> childrenBeforeBuild = null;
+        int decisionsBeforeBody = 0;
+        int unreproducibleMarksBeforeBody = 0;
         if (indexable) {
+            recordDecisions(ctx, srcVE, src, s, e, m, t);
             stateKey = ITERATION_STATE + System.identityHashCode(parent) + ':' + tag.getLocation();
             range = new int[] { s, e, m };
-            if (ctx.getFacesContext().getCurrentPhaseId() == PhaseId.RESTORE_VIEW) {
+            if (facesContext.getCurrentPhaseId() == PhaseId.RESTORE_VIEW) {
                 // Restore-time (re)build under PSS rebuilds this transient subtree from scratch; snapshot the existing
-                // children so the ones created below can be recorded for the render pass to retain. Clear the
-                // build-time-dynamic marker first: if applying the body re-sets it, the body holds nested dynamic
-                // content (a nested c:forEach/c:if/...) that could change without this item list changing, so it must
-                // not be skip-retained - only a fully static body is safe.
+                // children so the ones created below can be recorded for the render pass to retain, and the decisions
+                // recorded so far so the ones the body records are recognizable: a body holding nested dynamic content
+                // (a nested c:forEach/c:if/...) could change without this item list changing, so it must not be
+                // skip-retained - only a fully static body is safe.
                 childrenBeforeBuild = new ArrayList<>(parent.getChildren());
-                contextAttributes.remove(RIConstants.DYNAMIC_TRANSIENT_BUILD);
+                decisionsBeforeBody = BuildTimeDecisions.size(facesContext);
+                unreproducibleMarksBeforeBody = BuildTimeDecisions.unreproducibleMarks(facesContext);
             } else {
                 Object[] state = (Object[]) contextAttributes.get(stateKey);
                 if (state != null && sameIteration(state, range, srcVE == null ? null : src)) {
@@ -181,6 +187,8 @@ public final class ForEachHandler extends TagHandlerImpl {
                     return;
                 }
             }
+        } else {
+            markUnreproducibleBuild(ctx);
         }
 
         if (src != null) {
@@ -260,10 +268,10 @@ public final class ForEachHandler extends TagHandlerImpl {
         }
 
         if (childrenBeforeBuild != null) {
-            // The body just applied re-set the dynamic marker iff it holds nested build-time-dynamic content; capture
-            // that, then restore the marker this handler itself set (this c:forEach is build-time-dynamic).
-            boolean nestedDynamic = contextAttributes.containsKey(RIConstants.DYNAMIC_TRANSIENT_BUILD);
-            markDynamicTransientBuild(ctx);
+            // The body just applied recorded a decision of its own, or marked the build unreproducible, iff it holds
+            // nested build-time-dynamic content.
+            boolean nestedDynamic = BuildTimeDecisions.size(facesContext) > decisionsBeforeBody
+                    || BuildTimeDecisions.unreproducibleMarks(facesContext) > unreproducibleMarksBeforeBody;
 
             List<UIComponent> created = new ArrayList<>();
             for (UIComponent child : parent.getChildren()) {
@@ -278,6 +286,37 @@ public final class ForEachHandler extends TagHandlerImpl {
                 contextAttributes.put(stateKey, new Object[] { range, srcVE == null ? null : snapshotElements(src), created });
             }
         }
+    }
+
+    /**
+     * Records what this build iterated over, so the redundant render-time re-apply is skipped as long as it would
+     * iterate the same way and is performed when it would not (see {@code refreshTransientBuildOnPSS}). The item
+     * sequence takes a decision of its own, since it is a comparison over every element rather than a single value;
+     * the body's own decisions stand beside it, each captured with this iteration's index-based var expression and
+     * therefore reading its own element live.
+     */
+    private void recordDecisions(FaceletContext ctx, ValueExpression srcVE, Object src, int begin, int end, int step, boolean tranzient) {
+        recordBuildTimeDecision(ctx, this.begin, Integer.class, begin);
+        recordBuildTimeDecision(ctx, this.end, Integer.class, end);
+        recordBuildTimeDecision(ctx, this.step, Integer.class, step);
+        recordBuildTimeDecision(ctx, this.tranzient, Boolean.class, tranzient);
+        recordBuildTimeDecision(ctx, var);
+        recordBuildTimeDecision(ctx, varStatus);
+
+        if (srcVE != null) {
+            ELContext elContext = ctx.getFacesContext().getELContext();
+            List<Object> recordedItems = snapshotElements(src);
+            recordBuildTimeDecision(ctx, () -> sameItems(recordedItems, srcVE.getValue(elContext)), Boolean.TRUE);
+        }
+    }
+
+    /**
+     * Whether the current items are still the indexable sequence of elements that was recorded, which is what makes
+     * the subtree built over them reproducible.
+     */
+    private static boolean sameItems(List<Object> recordedItems, Object currentItems) {
+        return currentItems != null && (currentItems instanceof List || currentItems.getClass().isArray())
+                && sameElements(recordedItems, currentItems);
     }
 
     /**

--- a/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/IfHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/IfHandler.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import com.sun.faces.facelets.tag.TagHandlerImpl;
 
 import jakarta.el.ELException;
+import jakarta.el.ValueExpression;
 import jakarta.faces.FacesException;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.view.facelets.FaceletContext;
@@ -47,8 +48,9 @@ public final class IfHandler extends TagHandlerImpl {
 
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException, FacesException, ELException {
-        markDynamicTransientBuild(ctx);
-        boolean b = test.getBoolean(ctx);
+        ValueExpression testExpression = test.getValueExpression(ctx, Boolean.class);
+        boolean b = Boolean.TRUE.equals(testExpression.getValue(ctx));
+        recordBuildTimeDecision(ctx, testExpression, b);
         if (var != null) {
             ctx.setAttribute(var.getValue(ctx), b);
         }

--- a/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/SetHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/jstl/core/SetHandler.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 
 import com.sun.faces.facelets.tag.TagHandlerImpl;
 
+import jakarta.el.ELContext;
 import jakarta.el.ValueExpression;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.view.facelets.FaceletContext;
@@ -59,8 +60,6 @@ public class SetHandler extends TagHandlerImpl {
 
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
-
-        markDynamicTransientBuild(ctx);
 
         StringBuilder bodyValue = new StringBuilder();
 
@@ -114,8 +113,15 @@ public class SetHandler extends TagHandlerImpl {
                 // Conjure up an expression
                 expr = "#{" + scopeStr + "." + varStr + "}";
                 lhs = ctx.getExpressionFactory().createValueExpression(ctx, expr, Object.class);
-                lhs.setValue(ctx, veObj.getValue(ctx));
+                Object scopedValue = veObj.getValue(ctx);
+                lhs.setValue(ctx, scopedValue);
+                recordBuildTimeDecision(ctx, var);
+                recordBuildTimeDecision(ctx, scope);
+                recordWrite(ctx, veObj, lhs, scopedValue);
             } else {
+                // The variable is mapped to the expression itself, so what this build produced does not depend on its
+                // value at all; only on the name under which the rest of the build captured it.
+                recordBuildTimeDecision(ctx, var);
                 ctx.getVariableMapper().setVariable(varStr, veObj);
             }
         } else {
@@ -139,9 +145,27 @@ public class SetHandler extends TagHandlerImpl {
             }
             ValueExpression targetVe = target.getValueExpression(ctx, Object.class);
             Object targetValue = targetVe.getValue(ctx);
-            ctx.getFacesContext().getELContext().getELResolver().setValue(ctx, targetValue, propertyStr, veObj.getValue(ctx));
+            Object propertyValue = veObj.getValue(ctx);
+            ctx.getFacesContext().getELContext().getELResolver().setValue(ctx, targetValue, propertyStr, propertyValue);
 
+            ELContext elContext = ctx.getFacesContext().getELContext();
+            String resolvedProperty = propertyStr;
+            recordBuildTimeDecision(ctx, property);
+            recordBuildTimeDecision(ctx, veObj, propertyValue);
+            recordBuildTimeDecision(ctx, targetVe, targetValue);
+            recordBuildTimeDecision(ctx, () -> elContext.getELResolver().getValue(elContext, targetValue, resolvedProperty), propertyValue);
         }
+    }
+
+    /**
+     * Records the write this build performed: the value it wrote, and that value still being the one at the location it
+     * wrote it to. The second is what a write the application performed after this build breaks, which re-applying
+     * would put back.
+     */
+    private static void recordWrite(FaceletContext ctx, ValueExpression valueExpression, ValueExpression location, Object value) {
+        ELContext elContext = ctx.getFacesContext().getELContext();
+        recordBuildTimeDecision(ctx, valueExpression, value);
+        recordBuildTimeDecision(ctx, () -> location.getValue(elContext), value);
     }
 
     // Swallow children - if they're text, we've already handled them.

--- a/impl/src/main/java/com/sun/faces/facelets/tag/ui/CompositionHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/ui/CompositionHandler.java
@@ -101,10 +101,6 @@ public final class CompositionHandler extends TagHandlerImpl implements Template
 
         if (template != null) {
 
-            if (!template.isLiteral()) {
-                markDynamicTransientBuild(ctx);
-            }
-
             FacesContext facesContext = ctx.getFacesContext();
             Integer compositionCount = (Integer) facesContext.getAttributes().get("com.sun.faces.uiCompositionCount");
             if (compositionCount == null) {
@@ -127,6 +123,7 @@ public final class CompositionHandler extends TagHandlerImpl implements Template
             String path = null;
             try {
                 path = template.getValue(ctx);
+                recordBuildTimeDecision(ctx, template, String.class, path);
                 if (path.trim().length() == 0) {
                     throw new TagAttributeException(tag, template, "Invalid path : " + path);
                 }

--- a/impl/src/main/java/com/sun/faces/facelets/tag/ui/DecorateHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/ui/DecorateHandler.java
@@ -90,9 +90,6 @@ public final class DecorateHandler extends TagHandlerImpl implements TemplateCli
      */
     @Override
     public void apply(FaceletContext ctxObj, UIComponent parent) throws IOException {
-        if (!template.isLiteral()) {
-            markDynamicTransientBuild(ctxObj);
-        }
         FaceletContextImplBase ctx = (FaceletContextImplBase) ctxObj;
         VariableMapper orig = ctx.getVariableMapper();
         if (params != null) {
@@ -107,6 +104,7 @@ public final class DecorateHandler extends TagHandlerImpl implements TemplateCli
         String path = null;
         try {
             path = template.getValue(ctx);
+            recordBuildTimeDecision(ctx, template, String.class, path);
             if (path.trim().length() == 0) {
                 throw new TagAttributeException(tag, template, "Invalid path : " + path);
             }

--- a/impl/src/main/java/com/sun/faces/facelets/tag/ui/IncludeHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/ui/IncludeHandler.java
@@ -67,10 +67,8 @@ public final class IncludeHandler extends TagHandlerImpl {
      */
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
-        if (!src.isLiteral()) {
-            markDynamicTransientBuild(ctx);
-        }
         String path = src.getValue(ctx);
+        recordBuildTimeDecision(ctx, src, String.class, path);
         if (path == null || path.length() == 0) {
             return;
         }

--- a/impl/src/main/java/com/sun/faces/facelets/tag/ui/ParamHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/ui/ParamHandler.java
@@ -52,6 +52,7 @@ public class ParamHandler extends TagHandlerImpl {
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
         String nameStr = name.getValue(ctx);
+        recordBuildTimeDecision(ctx, name);
         ValueExpression valueVE = value.getValueExpression(ctx, Object.class);
         ctx.getVariableMapper().setVariable(nameStr, valueVE);
     }

--- a/impl/src/test/java/com/sun/faces/facelets/tag/BuildTimeDecisionsTest.java
+++ b/impl/src/test/java/com/sun/faces/facelets/tag/BuildTimeDecisionsTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.facelets.tag;
+
+import static com.sun.faces.facelets.tag.BuildTimeDecisions.keepsBuildReproducible;
+import static com.sun.faces.facelets.tag.BuildTimeDecisions.markUnreproducible;
+import static com.sun.faces.facelets.tag.BuildTimeDecisions.record;
+import static com.sun.faces.facelets.tag.BuildTimeDecisions.reproducesBuild;
+import static com.sun.faces.facelets.tag.BuildTimeDecisions.reset;
+import static com.sun.faces.facelets.tag.BuildTimeDecisions.size;
+import static com.sun.faces.facelets.tag.BuildTimeDecisions.unreproducibleMarks;
+import static java.nio.file.Files.readString;
+import static java.nio.file.Files.walk;
+import static java.util.stream.Collectors.toCollection;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.faces.test.tag.ForeignTagHandler;
+
+import jakarta.el.ELContext;
+import jakarta.el.PropertyNotFoundException;
+import jakarta.el.ValueExpression;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.view.facelets.BehaviorHandler;
+import jakarta.faces.view.facelets.ConverterHandler;
+import jakarta.faces.view.facelets.FaceletHandler;
+import jakarta.faces.view.facelets.Tag;
+import jakarta.faces.view.facelets.TagAttribute;
+import jakarta.faces.view.facelets.TagAttributes;
+import jakarta.faces.view.facelets.TagConfig;
+import jakarta.faces.view.facelets.ValidatorHandler;
+
+/**
+ * A view whose build takes a decision this implementation cannot see is built as unreproducible, so the redundant
+ * render-time re-apply is performed rather than skipped ({@link BuildTimeDecisions}). Every tag handler of this
+ * implementation is exempt from that, since each is audited to either contribute the same thing to every build of a
+ * view or to record what it decided. This holds the audited set, so a handler added or changed since fails here until
+ * it has been audited too.
+ */
+class BuildTimeDecisionsTest {
+
+    private static final Path TAG_HANDLER_SOURCES = Path.of("src/main/java/com/sun/faces/facelets/tag");
+
+    private static final Pattern APPLY_DECLARATION = Pattern.compile(
+            "public\\s+void\\s+apply\\s*\\(\\s*(jakarta\\.faces\\.view\\.facelets\\.)?FaceletContext");
+
+    private static final Set<String> AUDITED_TAG_HANDLERS = new TreeSet<>(Set.of(
+            "composite.AttachedObjectTargetHandler",
+            "composite.AttributeHandler",
+            "composite.DeclareFacetHandler",
+            "composite.ExtensionHandler",
+            "composite.ImplementationHandler",
+            "composite.InsertChildrenHandler",
+            "composite.InsertFacetHandler",
+            "composite.InterfaceHandler",
+            "composite.PropertyHandlerManager",
+            "faces.BehaviorTagHandlerDelegateImpl",
+            "faces.ComponentTagHandlerDelegateImpl",
+            "faces.ConverterTagHandlerDelegateImpl",
+            "faces.core.ActionListenerHandlerBase",
+            "faces.core.AjaxHandler",
+            "faces.core.AttributeHandler",
+            "faces.core.AttributesHandler",
+            "faces.core.EventHandler",
+            "faces.core.FacetHandler",
+            "faces.core.LoadBundleHandler",
+            "faces.core.MetadataHandler",
+            "faces.core.PassThroughAttributeHandler",
+            "faces.core.PassThroughAttributesHandler",
+            "faces.core.PhaseListenerHandler",
+            "faces.core.SetPropertyActionListenerHandler",
+            "faces.core.ValueChangeListenerHandler",
+            "faces.core.ViewHandler",
+            "faces.ValidatorTagHandlerDelegateImpl",
+            "jstl.core.CatchHandler",
+            "jstl.core.ChooseHandler",
+            "jstl.core.ChooseOtherwiseHandler",
+            "jstl.core.ChooseWhenHandler",
+            "jstl.core.ForEachHandler",
+            "jstl.core.IfHandler",
+            "jstl.core.SetHandler",
+            "ui.CompositionHandler",
+            "ui.DecorateHandler",
+            "ui.DefineHandler",
+            "ui.IncludeHandler",
+            "ui.InsertHandler",
+            "ui.ParamHandler",
+            "ui.SchemaCompliantRemoveHandler",
+            "UserTagHandler"));
+
+    /**
+     * Every tag handler that takes over {@code apply} must be one of the audited ones. A new or renamed handler is
+     * exempted from the re-apply by the package it lives in, so it must be audited before it is added here: it either
+     * contributes the same thing to every build, or it records the expression it decided on, or it marks the build
+     * unreproducible.
+     *
+     * @see BuildTimeDecisions#keepsBuildReproducible(jakarta.faces.view.facelets.FaceletHandler, jakarta.faces.view.facelets.Tag)
+     */
+    @Test
+    void everyTagHandlerTakingOverApplyIsAudited() throws IOException {
+        assertEquals(AUDITED_TAG_HANDLERS, tagHandlersTakingOverApply(), "audited tag handlers");
+    }
+
+    /**
+     * A decision that still yields the value it was recorded with lets the re-apply be skipped, and one that yields
+     * anything else, or cannot be evaluated at all, does not.
+     */
+    @Test
+    void aDecisionHoldsOnlyWhileItYieldsTheValueItWasRecordedWith() {
+        FacesContext context = mockFacesContext();
+        assertTrue(reproducesBuild(context), "a build that recorded nothing");
+
+        ValueExpression expression = mock(ValueExpression.class);
+        when(expression.getValue(any())).thenReturn("a");
+        record(context, expression, "a");
+        assertTrue(reproducesBuild(context), "a decision still yielding its recorded value");
+
+        when(expression.getValue(any())).thenReturn("b");
+        assertFalse(reproducesBuild(context), "a decision yielding another value");
+
+        when(expression.getValue(any())).thenThrow(new PropertyNotFoundException());
+        assertFalse(reproducesBuild(context), "a decision that cannot be evaluated");
+    }
+
+    /**
+     * A build marked unreproducible is not skipped however its decisions come out, and resetting discards both.
+     */
+    @Test
+    void markingTheBuildUnreproducibleOverridesItsDecisions() {
+        FacesContext context = mockFacesContext();
+        ValueExpression expression = mock(ValueExpression.class);
+        when(expression.getValue(any())).thenReturn("a");
+
+        record(context, expression, "a");
+        record(context, () -> "b", "b");
+        assertEquals(2, size(context), "recorded decisions");
+        assertEquals(0, unreproducibleMarks(context), "unreproducible marks");
+        assertTrue(reproducesBuild(context), "decisions all holding");
+
+        markUnreproducible(context);
+        assertEquals(1, unreproducibleMarks(context), "unreproducible marks");
+        assertFalse(reproducesBuild(context), "a build marked unreproducible");
+
+        reset(context);
+        assertEquals(0, size(context), "recorded decisions after a reset");
+        assertTrue(reproducesBuild(context), "a build that recorded nothing after a reset");
+    }
+
+    /**
+     * A tag handler of another tag library is taken to keep the build reproducible only while its tag carries no
+     * expression, except when it attaches a converter, validator or behavior, which a re-apply does not act on.
+     */
+    @Test
+    void aForeignTagHandlerKeepsTheBuildReproducibleOnlyWithoutAnExpression() {
+        FaceletHandler foreign = new ForeignTagHandler(mockTagConfig());
+
+        assertTrue(keepsBuildReproducible(foreign, mockTag(true)), "a foreign handler whose tag is all literal");
+        assertFalse(keepsBuildReproducible(foreign, mockTag(false)), "a foreign handler whose tag carries an expression");
+
+        assertTrue(keepsBuildReproducible(mock(ConverterHandler.class), mockTag(false)), "a converter handler");
+        assertTrue(keepsBuildReproducible(mock(ValidatorHandler.class), mockTag(false)), "a validator handler");
+        assertTrue(keepsBuildReproducible(mock(BehaviorHandler.class), mockTag(false)), "a behavior handler");
+    }
+
+    private static FacesContext mockFacesContext() {
+        FacesContext context = mock(FacesContext.class);
+        when(context.getAttributes()).thenReturn(new HashMap<>());
+        when(context.getELContext()).thenReturn(mock(ELContext.class));
+        return context;
+    }
+
+    private static TagConfig mockTagConfig() {
+        Tag tag = mockTag(true);
+        TagConfig config = mock(TagConfig.class);
+        when(config.getTag()).thenReturn(tag);
+        return config;
+    }
+
+    private static Tag mockTag(boolean literal) {
+        TagAttribute attribute = mock(TagAttribute.class);
+        when(attribute.isLiteral()).thenReturn(literal);
+        TagAttributes attributes = mock(TagAttributes.class);
+        when(attributes.getAll()).thenReturn(new TagAttribute[] { attribute });
+        Tag tag = mock(Tag.class);
+        when(tag.getAttributes()).thenReturn(attributes);
+        return tag;
+    }
+
+    private static Set<String> tagHandlersTakingOverApply() throws IOException {
+        try (Stream<Path> sources = walk(TAG_HANDLER_SOURCES)) {
+            return sources.filter(source -> source.toString().endsWith(".java"))
+                          .filter(BuildTimeDecisionsTest::declaresApply)
+                          .map(BuildTimeDecisionsTest::toClassName)
+                          .collect(toCollection(TreeSet::new));
+        }
+    }
+
+    private static boolean declaresApply(Path source) {
+        try {
+            return APPLY_DECLARATION.matcher(readString(source)).find();
+        } catch (IOException e) {
+            throw new IllegalStateException(source.toString(), e);
+        }
+    }
+
+    private static String toClassName(Path source) {
+        return TAG_HANDLER_SOURCES.relativize(source).toString().replace(".java", "").replace('/', '.');
+    }
+}

--- a/impl/src/test/java/com/sun/faces/test/tag/ForeignTagHandler.java
+++ b/impl/src/test/java/com/sun/faces/test/tag/ForeignTagHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) Contributors to Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,42 +14,28 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package com.sun.faces.facelets.tag.jstl.core;
+package com.sun.faces.test.tag;
 
 import java.io.IOException;
 
-import com.sun.faces.facelets.tag.TagHandlerImpl;
-
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.view.facelets.FaceletContext;
-import jakarta.faces.view.facelets.TagAttribute;
 import jakarta.faces.view.facelets.TagConfig;
+import jakarta.faces.view.facelets.TagHandler;
 
 /**
- * @author Jacob Hookom
+ * A tag handler taking over {@code apply} from outside the packages of this implementation, which is what every tag
+ * handler of another tag library does. It lives here rather than beside the test using it so that it does not fall
+ * under the package this implementation audits.
  */
-public final class CatchHandler extends TagHandlerImpl {
+public class ForeignTagHandler extends TagHandler {
 
-    private final TagAttribute var;
-
-    /**
-     * @param config
-     */
-    public CatchHandler(TagConfig config) {
+    public ForeignTagHandler(TagConfig config) {
         super(config);
-        var = getAttribute("var");
     }
 
     @Override
     public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
-        markUnreproducibleBuild(ctx);
-        try {
-            nextHandler.apply(ctx, parent);
-        } catch (Exception e) {
-            if (var != null) {
-                ctx.setAttribute(var.getValue(ctx), e);
-            }
-        }
+        // Whatever this contributes to the view is exactly what this implementation cannot know.
     }
-
 }


### PR DESCRIPTION
A view holding any build-time-dynamic tag re-applies its whole facelet before rendering, because the skip was denied on the mere presence of such a tag. One `c:if` governing 0.25% of the tree therefore re-applied 100% of it, at ~75% of a full initial build.

Such a handler now records what it decided, and the skip goes ahead when every recorded decision still holds: the same handlers then take the same branches, create the same components and apply the same values, so re-applying would reproduce the identical view. That is N evaluations instead of a walk over N components. A decision that yields another value, or cannot be evaluated at all (as one that only holds under the branch that guarded it), falls back to the full re-apply.

A decision is either an expression that must still evaluate to its recorded value, or a supplier that must still yield it. The latter answers what an expression cannot: whether the value a handler applied is still the one in effect. Under partial state saving the saved state is applied over the tree the restore-time build produced, so a `UIViewRoot` property that build set is replaced by the one the previous request saved, and the re-apply is what asserts it again. The resource library contracts need the same for another reason: restoring a view recalculates them from the configured mappings once the build that applied them has finished.

A decision is re-evaluated under the components it was recorded under. An expression reaching `cc` or `component` resolves them from the component stack rather than from a variable, and that stack is empty outside a build: `cc` would resolve to null, and an operator over null yields a value of its own rather than failing, which a recorded value can match.

| tag | decision |
| - | - |
| `c:if`, `c:choose` | the test they evaluated |
| `f:view` | each non-literal attribute twice: the value it evaluated to and the value it applied |
| `f:loadBundle` | basename and var, and the view locale even for a literal basename, which a changed locale resolves a different bundle from |
| `c:forEach` | its range and, element-wise, its item sequence, for a positionally indexable source |
| `ui:include`, `ui:composition`, `ui:decorate` | the path they applied; the facelet at that path recorded its own decisions into the same list while it was being applied |
| `c:set` | the value it wrote and that value still being the one at the location it wrote it to; its var-only form maps the unevaluated expression and needs no decision at all |

The attributes naming what a handler binds to — a variable, a scope, a property, a facet — are recorded like any other, the tag libraries declaring them as expressions rather than as literals.

## Handlers this implementation does not know

Such a handler was granted the skip silently, since nothing marked the build — a third-party tag that branches on its attributes at build time has been skipped since 4.0.19. The compiler now classifies every tag handler it creates, once per facelet compile rather than per build, and a facelet holding one whose contribution is unaccounted for is built as unreproducible. A handler is accounted for when:

1. it attaches a converter, validator or behavior to its parent — re-executable during a render rather than defining what is built, and acting only while the parent is new to the tree (this is what keeps `o:converter` and `o:validator` on the fast path despite taking over `apply`);
2. it leaves `apply` to the delegate of `ComponentHandler` and its siblings — nearly every component tag of every component library;
3. it is one of this implementation's own, each of which `BuildTimeDecisionsTest` holds to having been audited;
4. or its tag carries no expression at all, which leaves nothing the lifecycle could have changed since the last build — both builds are performed within the same request, so everything the handler reads from that request is the same for both.

Nothing is required of a third-party library: the safe verdict is the default, and no mojarra-specific annotation or dependency is involved.

## What still denies the skip

`c:catch`, whose body having thrown is knowable only by applying it, and a `c:forEach` over a Map or other non-indexable Collection, which iterates over a snapshotted entry with no positional index to compare or read live.

`f:attribute` and `f:passThroughAttribute` need no decision, being applied only while their parent is new to the tree.

`RIConstants.DYNAMIC_TRANSIENT_BUILD` is dropped — the record answers what the flag was consulted for, and `c:forEach` compares the record's size around its body where it previously cleared and re-set that flag.

## Measurements

Second `buildView` of the same request, GlassFish, ~815 components, 1500 iterations:

| page | before | after |
| - | - | - |
| no build-time-dynamic tag | 832 ns | ~1 us (existing skip) |
| one `c:if`, 4 levels deep | 489,955 ns | 7,843 ns |
| same with `c:choose` | 457,426 ns | 4,367 ns |

## Testing

The 5.0 equivalent of this change (identical logic, `org.glassfish.mojarra` packages) is green against the full TCK. That includes the guards which exercise a decision changing mid-request — `Issue4086IT` (`f:view locale` switched across five postbacks), `LoadBundleIT`, `Issue3982IT` and `Issue1849IT` (`c:if` flipped by an action), `Issue2631IT`/`Issue2896IT` (`c:forEach` mutated on postback) — plus `IfPostbackIT`, `ChoosePostbackIT` and `CompositeIfPostbackIT` in jakartaee/faces#2236, the last of which fails without the component context restored around a re-evaluated decision.

On this branch: 1342 unit tests green at source level 11, covering the record itself (a decision holding, changing, failing to evaluate, being overridden by an unreproducible mark, and being discarded by a reset) and the classification of a handler from another tag library.

Part of #5856

🤖 Generated with Claude Opus 5