### PR TITLE
Reject a value expression in ui:repeat var and varStatus

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/component/UIRepeat.java
+++ b/impl/src/main/java/com/sun/faces/facelets/component/UIRepeat.java
@@ -183,6 +183,21 @@ public class UIRepeat extends UINamingContainer {
 
     }
 
+    /**
+     * A value expression cannot name the variable this component exports, since the body of the tag resolves that name
+     * as it is written. One is therefore rejected rather than accepted and then ignored.
+     *
+     * @throws IllegalArgumentException when the given name is {@code var} or {@code varStatus}
+     */
+    @Override
+    public void setValueExpression(String name, ValueExpression binding) {
+        if ("var".equals(name) || "varStatus".equals(name)) {
+            throw new IllegalArgumentException(name);
+        }
+
+        super.setValueExpression(name, binding);
+    }
+
     public String getVar() {
         return var;
     }

--- a/impl/src/test/java/com/sun/faces/facelets/component/UIRepeatTest.java
+++ b/impl/src/test/java/com/sun/faces/facelets/component/UIRepeatTest.java
@@ -17,6 +17,7 @@
 package com.sun.faces.facelets.component;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
@@ -26,6 +27,7 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import jakarta.el.ValueExpression;
 import jakarta.faces.application.FacesMessage;
 import jakarta.faces.application.FacesMessage.Severity;
 import jakarta.faces.context.FacesContext;
@@ -37,6 +39,15 @@ public class UIRepeatTest {
 	private FacesMessage.Severity maximumSeverity = FacesMessage.SEVERITY_WARN;
 
 	private Method uiRepeatHasErrorMessages;
+
+	@Test
+	public void testVarAndVarStatusRejectValueExpression() {
+		UIRepeat repeat = new UIRepeat();
+		ValueExpression expression = Mockito.mock(ValueExpression.class);
+
+		assertThrows(IllegalArgumentException.class, () -> repeat.setValueExpression("var", expression));
+		assertThrows(IllegalArgumentException.class, () -> repeat.setValueExpression("varStatus", expression));
+	}
 
 	@Test
 	public void testHasErrorMessages() throws Exception {


### PR DESCRIPTION
`<ui:repeat var="#{bean.name}">` was accepted and then did nothing: the loop variable was never set, so the body could resolve nothing.

`RepeatHandler` uses the standard component meta ruleset, so a non-literal attribute is applied through `ComponentRule.ValueExpressionMetadata`, which calls `setValueExpression("var", …)`. `UIRepeat` keeps `var` and `varStatus` in plain fields with plain getters, so the stored expression was never consulted. A literal works only because the property-aware attributes map routes it to `setVar`.

`UIRepeat` now rejects both with `IllegalArgumentException`, exactly as `UIData` does for `var` and `rowIndex`, and `UISelectItems`, `UIImportConstants` and `UIWebsocket` do for theirs. The body of the tag resolves the name as it is written, so nothing can name it that is not known when the page is.

`value`, `offset`, `size`, `begin`, `end` and `step` are untouched and still take expressions.

The tag library side of the same defect is jakartaee/faces#2239, which stops documenting these attributes as value expressions.

## Testing

`UIRepeatTest` asserts both rejections. The full `impl` unit suite is green (1339). No page in the TCK passes an expression to either attribute — 164 `ui:repeat` usages, none of them dynamic in `var` or `varStatus` — so nothing existing trips the new throw.

Closes #5962

🤖 Generated with Claude Opus 5