### PR TITLE
Report where the restore rebuilds another view than was rendered

### DIFF
--- a/impl/src/main/java/com/sun/faces/RIConstants.java
+++ b/impl/src/main/java/com/sun/faces/RIConstants.java
@@ -87,6 +87,14 @@ public class RIConstants {
     public static final String DYNAMIC_ACTIONS = FACES_PREFIX + "DynamicActions";
 
     /**
+     * Marker used when saving, under {@link jakarta.faces.application.ProjectStage#Development} only, the tag each
+     * client id was built from, so that the build which restores the view can be told where it produced another
+     * component than the one that was rendered. It holds every component rather than only those carrying a delta: a
+     * component the restore fails to produce is the one to report, and it need never have held state of its own.
+     */
+    public static final String RENDERED_TAGS = FACES_PREFIX + "RenderedTags";
+
+    /**
      * Marker attached to a component that has dynamic children.
      */
     public static final String DYNAMIC_CHILD_COUNT = FACES_PREFIX + "DynamicChildCount";

--- a/impl/src/main/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategy.java
@@ -18,6 +18,7 @@ package com.sun.faces.application.view;
 
 import static com.sun.faces.RIConstants.DYNAMIC_ACTIONS;
 import static com.sun.faces.RIConstants.DYNAMIC_COMPONENT;
+import static com.sun.faces.RIConstants.RENDERED_TAGS;
 import static com.sun.faces.RIConstants.VIEW_REBUILT_AT_RENDER;
 import static com.sun.faces.util.ComponentStruct.ADD;
 import static com.sun.faces.util.ComponentStruct.REMOVE;
@@ -37,6 +38,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.sun.faces.context.StateContext;
+import com.sun.faces.facelets.tag.faces.ComponentSupport;
 import com.sun.faces.renderkit.RenderKitUtils;
 import com.sun.faces.util.ComponentStruct;
 import com.sun.faces.util.FacesLogger;
@@ -75,6 +77,32 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
      * Stores the skip and lifecycle hints.
      */
     private static final Set<VisitHint> SKIP_ITERATION_AND_EXECUTE_LIFECYCLE_HINTS = EnumSet.of(VisitHint.SKIP_ITERATION, VisitHint.EXECUTE_LIFECYCLE);
+
+    /**
+     * How many client ids at most are named when reporting a mismatch between the rendered and the rebuilt view.
+     */
+    private static final int MAX_REPORTED_CLIENT_IDS = 10;
+
+    /**
+     * What resolves a mismatch between the rendered and the rebuilt view, appended to the report of either.
+     */
+    private static final String REMEDY = " A build time condition such as c:if, c:choose or a variable ui:include path must evaluate to the"
+            + " same value while the postback is restored as it did while the response was rendered. Hold what it depends on in a @ViewScoped"
+            + " bean, or recompute it from the relevant request parameters in the @PostConstruct of the request scoped one.";
+
+    /**
+     * Reported for the components the rendered view held which the rebuilt one does not.
+     */
+    static final String NOT_REBUILT_REPORT = "The view rebuilt for this postback does not hold {0} of the components the response was rendered"
+            + " from, so their state is restored into nothing: {1}. Of these, {2} carry a submitted value which is therefore decoded by"
+            + " nothing: {3}." + REMEDY;
+
+    /**
+     * Reported for the client ids another tag occupies in the rebuilt view than the one that rendered them.
+     */
+    static final String REBUILT_FROM_ANOTHER_TAG_REPORT = "The view rebuilt for this postback holds {0} client ids built from another tag than"
+            + " the one the response was rendered from, so the state saved by one tag is restored into the component of another: {1}. The"
+            + " facelet may also have been edited since the response was rendered, which moves every tag." + REMEDY;
 
     /**
      * Constructor.
@@ -341,7 +369,7 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
                 boolean hasDynamicActions = !isEmpty(savedActions);
                 stateContext.setHasDynamicComponents(hasDynamicActions);
 
-                if (!hasDynamicActions && isViewRootOnlyState(context, viewRoot, state)) {
+                if (!hasDynamicActions && isViewRootOnlyState(viewRoot.getClientId(context), state)) {
                     // No dynamic actions and no per-component delta (or only the view root's): restore the
                     // view root in isolation and skip the full O(N) restore traversal. Any component whose
                     // state actually changed carries a non-null delta in the map, which forces the walk via
@@ -372,6 +400,10 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
                     });
                     restoreDynamicActions(context, stateContext, state);
                 }
+
+                if (context.isProjectStage(ProjectStage.Development)) {
+                    logRebuildMismatches(context, viewRoot, state);
+                }
             } finally {
                 stateContext.setHasDynamicComponents(true);
                 stateContext.setTrackViewModifications(true);
@@ -385,18 +417,128 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
 
     /**
      * Determine whether the saved state holds no per-component delta other than (optionally) the view
-     * root's own state. The {@code DYNAMIC_ACTIONS} entry is bookkeeping rather than a component delta,
-     * so it is excluded from the count.
+     * root's own state. The {@code DYNAMIC_ACTIONS} and {@code RENDERED_TAGS} entries are bookkeeping
+     * rather than a component delta, so they are excluded from the count.
+     *
+     * @param viewRootClientId the client id of the view root.
+     * @param state the saved state map.
+     * @return true if only the view root needs restoring, allowing the full restore traversal to be skipped.
+     */
+    static boolean isViewRootOnlyState(String viewRootClientId, Map<String, Object> state) {
+        int componentStateCount = state.size();
+        if (state.containsKey(DYNAMIC_ACTIONS)) {
+            componentStateCount--;
+        }
+        if (state.containsKey(RENDERED_TAGS)) {
+            componentStateCount--;
+        }
+        return componentStateCount == 0
+                || componentStateCount == 1 && state.containsKey(viewRootClientId);
+    }
+
+    /**
+     * The tag a component was built from, which tells two components apart that share a client id because only one of
+     * them is ever built. Every component a facelet creates carries it; the ones that no facelet created - the view
+     * root, and anything added programmatically - fall back to their type, which the restore reproduces as well.
+     *
+     * @param component the component.
+     * @return the identity of what built the given component.
+     */
+    static String tagOf(UIComponent component) {
+        String tagId = (String) component.getAttributes().get(ComponentSupport.MARK_CREATED);
+        return tagId != null ? tagId : component.getClass().getName();
+    }
+
+    /**
+     * The client ids the rendered view held which the rebuilt one does not, so that the state saved for them is
+     * restored into nothing and a value submitted for them is decoded by nothing.
+     *
+     * @param renderedTags the tag per client id of the view that rendered the response.
+     * @param rebuiltTags the tag per client id of the view rebuilt for this postback.
+     * @return the client ids that were not rebuilt.
+     */
+    static List<String> clientIdsNotRebuilt(Map<String, String> renderedTags, Map<String, String> rebuiltTags) {
+        List<String> clientIds = new ArrayList<>();
+        for (Map.Entry<String, String> renderedTag : renderedTags.entrySet()) {
+            if (!rebuiltTags.containsKey(renderedTag.getKey())) {
+                clientIds.add(renderedTag.getKey());
+            }
+        }
+        return clientIds;
+    }
+
+    /**
+     * The client ids another tag occupies in the rebuilt view than the one that rendered them, so that the state
+     * saved by one tag is restored into the component of another. Two tags sharing a client id is legitimate as long
+     * as only one of them is ever built, which a build time conditional deciding differently breaks.
+     *
+     * @param renderedTags the tag per client id of the view that rendered the response.
+     * @param rebuiltTags the tag per client id of the view rebuilt for this postback.
+     * @return the client ids that were rebuilt from another tag.
+     */
+    static List<String> clientIdsRebuiltFromAnotherTag(Map<String, String> renderedTags, Map<String, String> rebuiltTags) {
+        List<String> clientIds = new ArrayList<>();
+        for (Map.Entry<String, String> renderedTag : renderedTags.entrySet()) {
+            String rebuiltTag = rebuiltTags.get(renderedTag.getKey());
+            if (rebuiltTag != null && !rebuiltTag.equals(renderedTag.getValue())) {
+                clientIds.add(renderedTag.getKey());
+            }
+        }
+        return clientIds;
+    }
+
+    /**
+     * Report where the view rebuilt for this postback holds another component than the one the response was rendered
+     * from, which is what a build time conditional evaluating to another value than it did produces. The state of such
+     * a component is restored into nothing or into the wrong component, and a value submitted for it is decoded by
+     * neither, none of which fails loudly on its own.
      *
      * @param context the Faces context.
      * @param viewRoot the view root.
      * @param state the saved state map.
-     * @return true if only the view root needs restoring, allowing the full restore traversal to be skipped.
      */
-    private boolean isViewRootOnlyState(FacesContext context, UIViewRoot viewRoot, Map<String, Object> state) {
-        int componentStateCount = state.containsKey(DYNAMIC_ACTIONS) ? state.size() - 1 : state.size();
-        return componentStateCount == 0
-                || componentStateCount == 1 && state.containsKey(viewRoot.getClientId(context));
+    private void logRebuildMismatches(FacesContext context, UIViewRoot viewRoot, Map<String, Object> state) {
+        @SuppressWarnings("unchecked")
+        Map<String, String> renderedTags = (Map<String, String>) state.get(RENDERED_TAGS);
+        if (renderedTags == null || !LOGGER.isLoggable(Level.WARNING)) {
+            return;
+        }
+
+        Map<String, String> rebuiltTags = new HashMap<>(renderedTags.size());
+        VisitContext visitContext = VisitContext.createVisitContext(context, null, SKIP_ITERATION_HINT);
+        viewRoot.visitTree(visitContext, (context1, target) -> {
+            if (target.isTransient()) {
+                return VisitResult.REJECT;
+            }
+            rebuiltTags.put(target.getClientId(context1.getFacesContext()), tagOf(target));
+            return ACCEPT;
+        });
+
+        List<String> notRebuilt = clientIdsNotRebuilt(renderedTags, rebuiltTags);
+        if (!notRebuilt.isEmpty()) {
+            Set<String> requestParameterNames = context.getExternalContext().getRequestParameterMap().keySet();
+            List<String> submittedNotRebuilt = new ArrayList<>(notRebuilt);
+            submittedNotRebuilt.retainAll(requestParameterNames);
+            LOGGER.log(Level.WARNING, NOT_REBUILT_REPORT,
+                    new Object[] { notRebuilt.size(), truncated(notRebuilt), submittedNotRebuilt.size(), truncated(submittedNotRebuilt) });
+        }
+
+        List<String> rebuiltFromAnotherTag = clientIdsRebuiltFromAnotherTag(renderedTags, rebuiltTags);
+        if (!rebuiltFromAnotherTag.isEmpty()) {
+            LOGGER.log(Level.WARNING, REBUILT_FROM_ANOTHER_TAG_REPORT,
+                    new Object[] { rebuiltFromAnotherTag.size(), truncated(rebuiltFromAnotherTag) });
+        }
+    }
+
+    /**
+     * The given client ids, cut down to what is worth reading: a conditional over a collection can drop as many
+     * components as the collection had elements, of which the first few say the same as all of them.
+     *
+     * @param clientIds the client ids.
+     * @return the client ids to log.
+     */
+    static List<String> truncated(List<String> clientIds) {
+        return clientIds.size() <= MAX_REPORTED_CLIENT_IDS ? clientIds : clientIds.subList(0, MAX_REPORTED_CLIENT_IDS);
     }
 
     /**
@@ -487,6 +629,7 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
 
         final Map<String, Object> stateMap = new HashMap<>();
         final StateContext stateContext = StateContext.getStateContext(context);
+        final Map<String, String> renderedTags = context.isProjectStage(ProjectStage.Development) ? new HashMap<>() : null;
 
         VisitContext visitContext = VisitContext.createVisitContext(context, null, SKIP_ITERATION_HINT);
         final FacesContext finalContext = context;
@@ -501,14 +644,24 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
                 } else {
                     stateObj = target.saveState(context1.getFacesContext());
                 }
-                if (stateObj != null) {
-                    stateMap.put(target.getClientId(context1.getFacesContext()), stateObj);
+                if (renderedTags != null || stateObj != null) {
+                    String clientId = target.getClientId(context1.getFacesContext());
+                    if (renderedTags != null) {
+                        renderedTags.put(clientId, tagOf(target));
+                    }
+                    if (stateObj != null) {
+                        stateMap.put(clientId, stateObj);
+                    }
                 }
             } else {
                 return VisitResult.REJECT;
             }
             return result;
         });
+
+        if (renderedTags != null) {
+            stateMap.put(RENDERED_TAGS, renderedTags);
+        }
 
         saveDynamicActions(context, stateContext, stateMap);
         StateContext.release(context);

--- a/impl/src/test/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategyTest.java
+++ b/impl/src/test/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategyTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.faces.application.view;
+
+import static com.sun.faces.RIConstants.DYNAMIC_ACTIONS;
+import static com.sun.faces.RIConstants.RENDERED_TAGS;
+import static com.sun.faces.application.view.FaceletPartialStateManagementStrategy.NOT_REBUILT_REPORT;
+import static com.sun.faces.application.view.FaceletPartialStateManagementStrategy.REBUILT_FROM_ANOTHER_TAG_REPORT;
+import static com.sun.faces.application.view.FaceletPartialStateManagementStrategy.clientIdsNotRebuilt;
+import static com.sun.faces.application.view.FaceletPartialStateManagementStrategy.clientIdsRebuiltFromAnotherTag;
+import static com.sun.faces.application.view.FaceletPartialStateManagementStrategy.isViewRootOnlyState;
+import static com.sun.faces.application.view.FaceletPartialStateManagementStrategy.tagOf;
+import static com.sun.faces.application.view.FaceletPartialStateManagementStrategy.truncated;
+import static com.sun.faces.facelets.tag.faces.ComponentSupport.MARK_CREATED;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIOutput;
+
+/**
+ * A postback rebuilds its view from the markup rather than from the response it was submitted from, so a build time
+ * conditional evaluating to another value than it did leaves the state of a rendered component with nothing to be
+ * restored into, or with the wrong component. Under {@code ProjectStage.Development} the tag each client id was built
+ * from is saved with the state, and comparing it against the rebuilt view is what turns that into a diagnosable
+ * report. This holds what the comparison reports.
+ */
+class FaceletPartialStateManagementStrategyTest {
+
+    private static final Pattern LONE_APOSTROPHE = Pattern.compile("(?<!\')\'(?!\')");
+
+    private static Map<String, String> tags(String... clientIdsAndTags) {
+        Map<String, String> tags = new HashMap<>();
+        for (int i = 0; i < clientIdsAndTags.length; i += 2) {
+            tags.put(clientIdsAndTags[i], clientIdsAndTags[i + 1]);
+        }
+        return tags;
+    }
+
+    private static Map<String, Object> state(String... keys) {
+        Map<String, Object> state = new HashMap<>();
+        for (String key : keys) {
+            state.put(key, new Object());
+        }
+        return state;
+    }
+
+    @Test
+    void aClientIdTheRebuildDidNotProduceIsReportedAsNotRebuilt() {
+        Map<String, String> rendered = tags("form", "1a", "form:input", "1b");
+        Map<String, String> rebuilt = tags("form", "1a");
+
+        assertEquals(singletonList("form:input"), clientIdsNotRebuilt(rendered, rebuilt));
+    }
+
+    @Test
+    void aClientIdTheRebuildProducedFromAnotherTagIsNotReportedAsNotRebuilt() {
+        Map<String, String> rendered = tags("form:value", "1b");
+        Map<String, String> rebuilt = tags("form:value", "1c");
+
+        assertEquals(emptyList(), clientIdsNotRebuilt(rendered, rebuilt));
+    }
+
+    /**
+     * Two tags may carry the same component id as long as only one of them is ever built, which is what sibling
+     * {@code c:if} tags and the branches of a {@code c:choose} do. Their components then share a client id and, when
+     * they are of the same type, everything else the state knows about them, so the tag is what tells them apart.
+     */
+    @Test
+    void aClientIdTheRebuildProducedFromAnotherTagIsReportedAsRebuiltFromAnotherTag() {
+        Map<String, String> rendered = tags("form", "1a", "form:value", "1b");
+        Map<String, String> rebuilt = tags("form", "1a", "form:value", "1c");
+
+        assertEquals(singletonList("form:value"), clientIdsRebuiltFromAnotherTag(rendered, rebuilt));
+    }
+
+    @Test
+    void aClientIdTheRebuildDidNotProduceIsNotReportedAsRebuiltFromAnotherTag() {
+        Map<String, String> rendered = tags("form:input", "1b");
+        Map<String, String> rebuilt = tags();
+
+        assertEquals(emptyList(), clientIdsRebuiltFromAnotherTag(rendered, rebuilt));
+    }
+
+    @Test
+    void aRebuildReproducingTheRenderedViewReportsNothing() {
+        Map<String, String> rendered = tags("form", "1a", "form:input", "1b");
+        Map<String, String> rebuilt = tags("form", "1a", "form:input", "1b");
+
+        assertEquals(emptyList(), clientIdsNotRebuilt(rendered, rebuilt));
+        assertEquals(emptyList(), clientIdsRebuiltFromAnotherTag(rendered, rebuilt));
+    }
+
+    /**
+     * A rebuild adding components the render did not produce is what a build time conditional turning true does, and
+     * it costs nothing: they hold no state to be restored and no value was submitted for them.
+     */
+    @Test
+    void aClientIdOnlyTheRebuildProducedReportsNothing() {
+        Map<String, String> rendered = tags("form", "1a");
+        Map<String, String> rebuilt = tags("form", "1a", "form:input", "1b");
+
+        assertEquals(emptyList(), clientIdsNotRebuilt(rendered, rebuilt));
+        assertEquals(emptyList(), clientIdsRebuiltFromAnotherTag(rendered, rebuilt));
+    }
+
+    /**
+     * Two components of the same type built from two tags are told apart by the tag, which is what a shared component
+     * id leaves as the only difference between them.
+     */
+    @Test
+    void twoComponentsOfTheSameTypeAreIdentifiedByTheTagThatBuiltThem() {
+        UIComponent one = new UIOutput();
+        one.getAttributes().put(MARK_CREATED, "1b");
+        UIComponent other = new UIOutput();
+        other.getAttributes().put(MARK_CREATED, "1c");
+
+        assertEquals("1b", tagOf(one));
+        assertEquals("1c", tagOf(other));
+    }
+
+    /**
+     * A component no facelet built carries no tag, so it is identified by its type, which is what the restore
+     * reproduces it from.
+     */
+    @Test
+    void aComponentBuiltByNoTagIsIdentifiedByItsType() {
+        assertEquals(UIOutput.class.getName(), tagOf(new UIOutput()));
+    }
+
+    @Test
+    void stateHoldingNoComponentDeltaAtAllNeedsOnlyTheViewRootRestored() {
+        assertTrue(isViewRootOnlyState("root", state()));
+        assertTrue(isViewRootOnlyState("root", state(DYNAMIC_ACTIONS)));
+        assertTrue(isViewRootOnlyState("root", state(RENDERED_TAGS)));
+        assertTrue(isViewRootOnlyState("root", state(DYNAMIC_ACTIONS, RENDERED_TAGS)));
+    }
+
+    @Test
+    void stateHoldingOnlyTheViewRootDeltaNeedsOnlyTheViewRootRestored() {
+        assertTrue(isViewRootOnlyState("root", state("root")));
+        assertTrue(isViewRootOnlyState("root", state("root", DYNAMIC_ACTIONS)));
+        assertTrue(isViewRootOnlyState("root", state("root", RENDERED_TAGS)));
+        assertTrue(isViewRootOnlyState("root", state("root", DYNAMIC_ACTIONS, RENDERED_TAGS)));
+    }
+
+    @Test
+    void stateHoldingAnotherComponentDeltaNeedsTheFullRestoreTraversal() {
+        assertFalse(isViewRootOnlyState("root", state("form:input")));
+        assertFalse(isViewRootOnlyState("root", state("form:input", DYNAMIC_ACTIONS)));
+        assertFalse(isViewRootOnlyState("root", state("form:input", RENDERED_TAGS)));
+        assertFalse(isViewRootOnlyState("root", state("root", "form:input", DYNAMIC_ACTIONS, RENDERED_TAGS)));
+    }
+
+    @Test
+    void aReportNamesAtMostTenClientIdsAndLeavesAShorterListWhole() {
+        List<String> ten = clientIds(10);
+        assertSame(ten, truncated(ten));
+        assertEquals(ten, truncated(clientIds(11)));
+    }
+
+    /**
+     * Each report is logged with the arguments its placeholders name.
+     */
+    @Test
+    void everyPlaceholderOfBothReportsIsSubstituted() {
+        assertEveryPlaceholderSubstituted(NOT_REBUILT_REPORT, 2, clientIds(2), 1, clientIds(1));
+        assertEveryPlaceholderSubstituted(REBUILT_FROM_ANOTHER_TAG_REPORT, 2, clientIds(2));
+    }
+
+    /**
+     * Both reports are {@link MessageFormat} patterns, in which a lone apostrophe quotes the text that follows it
+     * rather than fail, so it silently swallows both the placeholders it precedes and itself.
+     */
+    @Test
+    void neitherReportHoldsALoneApostrophe() {
+        assertFalse(LONE_APOSTROPHE.matcher(NOT_REBUILT_REPORT).find(), NOT_REBUILT_REPORT);
+        assertFalse(LONE_APOSTROPHE.matcher(REBUILT_FROM_ANOTHER_TAG_REPORT).find(), REBUILT_FROM_ANOTHER_TAG_REPORT);
+    }
+
+    private static List<String> clientIds(int count) {
+        List<String> clientIds = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            clientIds.add("form:input" + i);
+        }
+        return clientIds;
+    }
+
+    private static void assertEveryPlaceholderSubstituted(String report, Object... arguments) {
+        String message = MessageFormat.format(report, arguments);
+        assertFalse(message.contains("{"), message);
+        for (Object argument : arguments) {
+            assertTrue(message.contains(String.valueOf(argument)), message);
+        }
+    }
+}


### PR DESCRIPTION
Proposal (1) of #5961, taken on its own: a Development mode report, no behavior change, no agreement needed about the semantics that (2) turns on.

## What it reports

A postback rebuilds its view from the markup, so a build time condition evaluating to another value than it did while the response was rendered produces another view than the one that was submitted. Under `ProjectStage.Development` the tag each client id was built from is saved with the state, and the restore compares it against the view it rebuilt, logging two things at `WARNING`:

- **Not rebuilt** — client ids the rendered view held which the rebuilt one does not, so their state is restored into nothing. The ones for which a request parameter of that exact name was submitted are counted separately: those are the silently dropped values.
- **Rebuilt from another tag** — client ids another tag now occupies than the one that rendered them, so the state saved by one tag is restored into the component of another.

Both name what resolves it: the value the condition depends on has to survive the postback, so hold it in a `@ViewScoped` bean or recompute it from the relevant request parameters in the `@PostConstruct` of the request scoped one.

## Why the tag, and not the state map or the component type

The obvious implementation — diff `state.keySet()` against the client ids the restore walk visited — does not catch the reproducer in the issue. `saveView` only puts an entry in the map `if (stateObj != null)`, so an `h:inputText` created by the render which produced the response, and never touched after `markInitialState`, has a null delta and **no entry at all**. There is no orphan key to find. The comparison therefore has to be against what the previous render actually built, which is why the saved side is collected in `saveView`'s existing walk rather than derived from the state map.

The component type is not a sufficient discriminator either. Two tags may carry the same component id as long as only one of them is ever built, which is exactly what the branches of a `c:choose` and sibling `c:if` tags do:

```xhtml
<c:if test="#{bean.a}"><h:inputText id="value" value="#{bean.x}" /></c:if>
<c:if test="#{not bean.a}"><h:inputText id="value" value="#{bean.y}" /></c:if>
```

Same id, same class, different tag. When the decision flips, the first input's `submittedValue`/`localValue`/`valid` are restored into the second, which binds to a different property. Nothing throws, because the state shape is identical. That is the quietest variant of the family, and only the tag tells the two apart. Facelets already stamps it as `ComponentSupport.MARK_CREATED`, derived from the tag's compile time position, so it is stable per tag across rebuilds and costs nothing to collect. A component no facelet built — the view root, anything added programmatically — falls back to its type, which the restore reproduces as well.

The both-tests-true variant needs nothing: that produces a genuine duplicate id and `Util.checkIdUniqueness` already errors on it.

## Scope

This reports the `c:if` / `c:choose` / variable `ui:include` class only. A flipped `rendered` leaves the component in the tree and is re-evaluated at decode identically under both state saving strategies, so it stays quiet there — the two are different axes, as established in the issue thread.

## No effect outside Development

`saveView` collects nothing, the state map gains no entry, and the restore compares nothing. The one non-gated addition is `isViewRootOnlyState` excluding the new key from its entry count, which is an `O(1)` map lookup per restore and keeps its fast path intact in Development. `getClientId()` is still only called when `saveState()` returned non-null, as before.

The state format gains a key in Development only; state saved before this change simply lacks it and the check no-ops.

## Reproducer

One page exercises both reports in a single postback, with a `@Named @RequestScoped` bean whose `shown` flag `show()` sets:

```xhtml
<h:form id="form">
    <h:commandButton id="show" value="show" action="#{issue5961.show}" />

    <c:if test="#{issue5961.shown}">
        <h:inputText id="guarded" value="#{issue5961.guarded}" />
    </c:if>

    <c:if test="#{issue5961.shown}">
        <h:inputText id="shared" value="#{issue5961.whenShown}" />
    </c:if>
    <c:if test="#{not issue5961.shown}">
        <h:inputText id="shared" value="#{issue5961.whenHidden}" />
    </c:if>

    <h:commandButton id="submit" value="submit" />
</h:form>
```

GET, click `show`, fill out both inputs, click `submit`. The flag is true during the render which puts them in the response and false again during the restore of the postback which submits them. Before this change `form:guarded` is dropped silently and what was typed into `form:shared` lands in `whenHidden` rather than `whenShown`, with nothing logged. After it, that postback reports `form:guarded` as not rebuilt and as carrying a submitted value, and `form:shared` as built from another tag.

## Tests

`FaceletPartialStateManagementStrategyTest` covers the two comparisons in both directions, the tag identity and its fallback, the report truncation boundary, and `isViewRootOnlyState` for each bookkeeping key in isolation and together. Both reports are `MessageFormat` patterns, so a further test pins that neither holds a lone apostrophe — one would quote the text after it and silently swallow what follows rather than fail.

Closes #5961 partially; (2) remains open and targets 5.0.

🤖 Generated with Claude Opus 5
