### PR TITLE
Render an event attribute only for an event the component supports

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/component/PassthroughElement.java
+++ b/impl/src/main/java/org/glassfish/mojarra/component/PassthroughElement.java
@@ -16,12 +16,12 @@
 
 package org.glassfish.mojarra.component;
 
-import static jakarta.faces.component.html.HtmlEvents.getHtmlBodyElementEventNames;
+import static jakarta.faces.component.html.HtmlEvents.getHtmlElementEventNames;
 
 import java.util.Collection;
 
 import jakarta.faces.component.behavior.ClientBehaviorHolder;
-import jakarta.faces.component.html.HtmlEvents.HtmlDocumentElementEvent;
+import jakarta.faces.component.html.HtmlEvents.HtmlElementEvent;
 
 /**
  * <p>
@@ -344,12 +344,12 @@ public class PassthroughElement extends jakarta.faces.component.UIPanel implemen
 
     @Override
     public Collection<String> getEventNames() {
-        return getHtmlBodyElementEventNames(getFacesContext()); 
+        return getHtmlElementEventNames(getFacesContext()); 
     }
 
     @Override
     public String getDefaultEventName() {
-        return HtmlDocumentElementEvent.click.name();
+        return HtmlElementEvent.click.name();
     }
 
 }

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/RenderKitUtils.java
@@ -706,10 +706,12 @@ public class RenderKitUtils {
                 continue;
             }
 
-            if (knownAttributes.get(name) != null || isBehaviorEventAttribute(name)) {
+            boolean supportedBehaviorEventAttribute = isSupportedBehaviorEventAttribute(component, name);
+
+            if (knownAttributes.get(name) != null || supportedBehaviorEventAttribute) {
                 Object value = attrMap.get(name);
                 if (value != null && shouldRenderAttribute(value)) {
-                    if (isBehaviorEventAttribute(name)) {
+                    if (supportedBehaviorEventAttribute) {
                         String eventName = name.substring(BEHAVIOR_EVENT_ATTRIBUTE_PREFIX.length());
                         addBehaviorEventListener(context, component, null, null, name, value, eventName, eventName, null, false, false);
                         if (eventName.equals(behaviorEventName)) {
@@ -776,7 +778,7 @@ public class RenderKitUtils {
         behaviorEventNames.addAll(behaviors.keySet());
 
         if (setAttributes != null) {
-            setAttributes.stream().filter(RenderKitUtils::isBehaviorEventAttribute).map(a -> a.substring(BEHAVIOR_EVENT_ATTRIBUTE_PREFIX.length())).forEach(behaviorEventNames::add);
+            setAttributes.stream().filter(name -> isSupportedBehaviorEventAttribute(component, name)).map(a -> a.substring(BEHAVIOR_EVENT_ATTRIBUTE_PREFIX.length())).forEach(behaviorEventNames::add);
         }
 
         for (Attribute attribute : knownAttributes) {
@@ -814,6 +816,31 @@ public class RenderKitUtils {
         } else if (hasValue) {
             writer.writeAttribute(prefixAttribute(attrName, isXhtml), value, attrName);
         }
+    }
+
+    /**
+     * <p>
+     * A behavior event attribute is only rendered when the component names the event after "on" in
+     * {@link ClientBehaviorHolder#getEventNames()}, as required by the behavior event attribute rule of the standard
+     * HTML render kit. A component which is no {@link ClientBehaviorHolder} has no such list to check against, so its
+     * behavior event attributes are all rendered.
+     * </p>
+     *
+     * @param component the component whose attribute is being rendered
+     * @param name the attribute name
+     * @return whether the given attribute is a behavior event attribute which the given component supports
+     */
+    private static boolean isSupportedBehaviorEventAttribute(UIComponent component, String name) {
+        if (!isBehaviorEventAttribute(name)) {
+            return false;
+        }
+
+        if (!(component instanceof ClientBehaviorHolder clientBehaviorHolder)) {
+            return true;
+        }
+
+        Collection<String> eventNames = clientBehaviorHolder.getEventNames();
+        return eventNames != null && eventNames.contains(name.substring(BEHAVIOR_EVENT_ATTRIBUTE_PREFIX.length()));
     }
 
     public static boolean isBehaviorEventAttribute(String name) {

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/RenderKitUtils.java
@@ -60,7 +60,7 @@ import jakarta.faces.component.behavior.ClientBehavior;
 import jakarta.faces.component.behavior.ClientBehaviorContext;
 import jakarta.faces.component.behavior.ClientBehaviorHint;
 import jakarta.faces.component.behavior.ClientBehaviorHolder;
-import jakarta.faces.component.html.HtmlEvents.HtmlDocumentElementEvent;
+import jakarta.faces.component.html.HtmlEvents.HtmlElementEvent;
 import jakarta.faces.component.html.HtmlMessages;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -348,7 +348,7 @@ public class RenderKitUtils {
      * @throws IOException if an error occurs writing the attributes
      */
     public static void renderPassThruAttributes(FacesContext context, ResponseWriter writer, UIComponent component, String clientId, boolean incExec,
-            Attributes attributes, HtmlDocumentElementEvent defaultDomEvent, FacesComponentEvent defaultComponentEvent) throws IOException {
+            Attributes attributes, HtmlElementEvent defaultDomEvent, FacesComponentEvent defaultComponentEvent) throws IOException {
 
         Map<String, List<ClientBehavior>> behaviors = null;
         boolean hasValueChangeBehavior = false;
@@ -464,7 +464,7 @@ public class RenderKitUtils {
     }
 
     private static void renderValueChangeEventListener(FacesContext context, UIComponent component, String clientId,
-            HtmlDocumentElementEvent defaultDomEvent, String componentEventName, String domEventName,
+            HtmlElementEvent defaultDomEvent, String componentEventName, String domEventName,
             boolean hasBehaviorForDefaultEvent, boolean incExec) throws IOException {
 
         String handlerName = BEHAVIOR_EVENT_ATTRIBUTE_PREFIX + domEventName;
@@ -495,7 +495,7 @@ public class RenderKitUtils {
         final String handlerName = "onclick";
         final Object userHandler = component.getAttributes().get(handlerName);
         String behaviorEventName = FacesComponentEvent.action.name();
-        String domEventName = HtmlDocumentElementEvent.click.name();
+        String domEventName = HtmlElementEvent.click.name();
         if (component instanceof ClientBehaviorHolder) {
             Map<String, List<ClientBehavior>> behaviors = ((ClientBehaviorHolder) component).getClientBehaviors();
             boolean mixed = null != behaviors && behaviors.containsKey(domEventName) && behaviors.containsKey(behaviorEventName);
@@ -1284,7 +1284,7 @@ public class RenderKitUtils {
         // request params.
         String partialEvent = PARTIAL_EVENT_PARAM.getValue(context);
 
-        return HtmlDocumentElementEvent.click.name().equals(partialEvent);
+        return HtmlElementEvent.click.name().equals(partialEvent);
     }
 
     /**
@@ -1653,7 +1653,7 @@ public class RenderKitUtils {
         // If we're submitting (either via a behavior, or by rendering
         // a submit script), we need to prevent the
         // default button/link action event.
-        if (submitting && (FacesComponentEvent.action.name().equals(behaviorEventName) || HtmlDocumentElementEvent.click.name().equals(behaviorEventName))) {
+        if (submitting && (FacesComponentEvent.action.name().equals(behaviorEventName) || HtmlElementEvent.click.name().equals(behaviorEventName))) {
             builder.append(";event.preventDefault()");
         }
 

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/ButtonRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/ButtonRenderer.java
@@ -27,7 +27,7 @@ import jakarta.faces.component.UICommand;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.behavior.ClientBehaviorContext;
 import jakarta.faces.component.html.HtmlCommandButton;
-import jakarta.faces.component.html.HtmlEvents.HtmlDocumentElementEvent;
+import jakarta.faces.component.html.HtmlEvents.HtmlElementEvent;
 import jakarta.faces.component.html.HtmlOutcomeTargetButton;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
@@ -132,7 +132,7 @@ public class ButtonRenderer extends HtmlBasicRenderer {
             writer.writeAttribute("value", label, "value");
         }
 
-        RenderKitUtils.renderPassThruAttributes(context, writer, component, null, false, ATTRIBUTES, HtmlDocumentElementEvent.click, FacesComponentEvent.action);
+        RenderKitUtils.renderPassThruAttributes(context, writer, component, null, false, ATTRIBUTES, HtmlElementEvent.click, FacesComponentEvent.action);
         RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, component);
 
         String styleClass = (String) RenderKitUtils.getAttributeIfSet(component, "styleClass");

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/CheckboxRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/CheckboxRenderer.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.logging.Level;
 
 import jakarta.faces.component.UIComponent;
-import jakarta.faces.component.html.HtmlEvents.HtmlDocumentElementEvent;
+import jakarta.faces.component.html.HtmlEvents.HtmlElementEvent;
 import jakarta.faces.component.html.HtmlSelectBooleanCheckbox;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
@@ -109,7 +109,7 @@ public class CheckboxRenderer extends HtmlBasicInputRenderer {
             writer.writeAttribute("checked", Boolean.TRUE, "value");
         }
         writeStyleClassAttributeIfNecessary(writer, component);
-        RenderKitUtils.renderPassThruAttributes(context, writer, component, null, false, ATTRIBUTES, HtmlDocumentElementEvent.click, FacesComponentEvent.valueChange);
+        RenderKitUtils.renderPassThruAttributes(context, writer, component, null, false, ATTRIBUTES, HtmlElementEvent.click, FacesComponentEvent.valueChange);
         RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, component);
 
         writer.endElement("input");

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/CommandLinkRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/CommandLinkRenderer.java
@@ -29,7 +29,7 @@ import jakarta.faces.component.UICommand;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.behavior.ClientBehaviorContext;
 import jakarta.faces.component.html.HtmlCommandLink;
-import jakarta.faces.component.html.HtmlEvents.HtmlDocumentElementEvent;
+import jakarta.faces.component.html.HtmlEvents.HtmlElementEvent;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
 import jakarta.faces.event.ActionEvent;
@@ -170,7 +170,7 @@ public class CommandLinkRenderer extends LinkRenderer {
         writer.startElement("a", command);
         writeIdAttributeIfNecessary(context, writer, command);
         writer.writeAttribute("href", "#", "href");
-        RenderKitUtils.renderPassThruAttributes(context, writer, command, null, false, ATTRIBUTES, HtmlDocumentElementEvent.click, FacesComponentEvent.action);
+        RenderKitUtils.renderPassThruAttributes(context, writer, command, null, false, ATTRIBUTES, HtmlElementEvent.click, FacesComponentEvent.action);
 
         RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, command);
 

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/MenuRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/MenuRenderer.java
@@ -67,7 +67,7 @@ import jakarta.faces.component.UISelectItems;
 import jakarta.faces.component.UISelectMany;
 import jakarta.faces.component.UISelectOne;
 import jakarta.faces.component.ValueHolder;
-import jakarta.faces.component.html.HtmlEvents.HtmlDocumentElementEvent;
+import jakarta.faces.component.html.HtmlEvents.HtmlElementEvent;
 import jakarta.faces.component.html.HtmlSelectManyCheckbox;
 import jakarta.faces.component.html.HtmlSelectManyListbox;
 import jakarta.faces.component.html.HtmlSelectManyMenu;
@@ -706,7 +706,7 @@ public class MenuRenderer extends HtmlBasicInputRenderer {
 
         writeDefaultSize(writer, size);
 
-        renderPassThruAttributes(context, writer, component, null, false, ATTRIBUTES, HtmlDocumentElementEvent.change, FacesComponentEvent.valueChange);
+        renderPassThruAttributes(context, writer, component, null, false, ATTRIBUTES, HtmlElementEvent.change, FacesComponentEvent.valueChange);
         renderXHTMLStyleBooleanAttributes(writer, component);
 
         // Now, write the buffered option content

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/OutcomeTargetButtonRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/OutcomeTargetButtonRenderer.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 
 import jakarta.faces.application.NavigationCase;
 import jakarta.faces.component.UIComponent;
-import jakarta.faces.component.html.HtmlEvents.HtmlDocumentElementEvent;
+import jakarta.faces.component.html.HtmlEvents.HtmlElementEvent;
 import jakarta.faces.component.html.HtmlOutcomeTargetButton;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
@@ -114,7 +114,7 @@ public class OutcomeTargetButtonRenderer extends OutcomeTargetRenderer {
             if (navCase != null) {
                 String hrefVal = getEncodedTargetURL(context, component, navCase);
                 hrefVal += getFragment(component);
-                RenderKitUtils.addEventListener(context, component, HtmlDocumentElementEvent.click.name(), getOnclick(component, hrefVal));
+                RenderKitUtils.addEventListener(context, component, HtmlElementEvent.click.name(), getOnclick(component, hrefVal));
             }
         }
 

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/PassthroughRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/PassthroughRenderer.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 import jakarta.faces.FacesException;
 import jakarta.faces.component.UIComponent;
-import jakarta.faces.component.html.HtmlEvents.HtmlDocumentElementEvent;
+import jakarta.faces.component.html.HtmlEvents.HtmlElementEvent;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
 import jakarta.faces.event.BehaviorEvent.FacesComponentEvent;
@@ -64,7 +64,7 @@ public class PassthroughRenderer extends HtmlBasicRenderer {
         // render the default click/action behavior separately - both are queued as CSP-safe event
         // listeners that encodeEnd() flushes via flushPendingBehaviorEventListeners().
         RenderKitUtils.renderPassThruAttributes(context, writer, component, null, false, ATTRIBUTES,
-                HtmlDocumentElementEvent.click, FacesComponentEvent.action);
+                HtmlElementEvent.click, FacesComponentEvent.action);
         RenderKitUtils.renderOnclickEventListener(context, component, null, null, false);
 
     }

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/RadioRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/RadioRenderer.java
@@ -38,7 +38,7 @@ import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.UINamingContainer;
 import jakarta.faces.component.UISelectItem;
 import jakarta.faces.component.UISelectOne;
-import jakarta.faces.component.html.HtmlEvents.HtmlDocumentElementEvent;
+import jakarta.faces.component.html.HtmlEvents.HtmlElementEvent;
 import jakarta.faces.component.html.HtmlSelectOneRadio;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
@@ -307,7 +307,7 @@ public class RadioRenderer extends SelectManyCheckboxListRenderer implements Com
         // Apply HTML 4.x attributes specified on UISelectMany component to all
         // items in the list except styleClass and style which are rendered as
         // attributes of outer most table.
-        RenderKitUtils.renderPassThruAttributes(context, writer, component, clientId, false, ATTRIBUTES, HtmlDocumentElementEvent.click, FacesComponentEvent.valueChange);
+        RenderKitUtils.renderPassThruAttributes(context, writer, component, clientId, false, ATTRIBUTES, HtmlElementEvent.click, FacesComponentEvent.valueChange);
         RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, component);
 
         writer.endElement("input");

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/SecretRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/SecretRenderer.java
@@ -21,7 +21,7 @@ package org.glassfish.mojarra.renderkit.html_basic;
 import java.io.IOException;
 
 import jakarta.faces.component.UIComponent;
-import jakarta.faces.component.html.HtmlEvents.HtmlDocumentElementEvent;
+import jakarta.faces.component.html.HtmlEvents.HtmlElementEvent;
 import jakarta.faces.component.html.HtmlInputSecret;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
@@ -83,7 +83,7 @@ public class SecretRenderer extends HtmlBasicInputRenderer {
             writer.writeAttribute("value", currentValue, "value");
         }
 
-        RenderKitUtils.renderPassThruAttributes(context, writer, component, null, false, ATTRIBUTES, HtmlDocumentElementEvent.change, FacesComponentEvent.valueChange);
+        RenderKitUtils.renderPassThruAttributes(context, writer, component, null, false, ATTRIBUTES, HtmlElementEvent.change, FacesComponentEvent.valueChange);
         RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, component);
 
         writeStyleClassAttributeIfNecessary(writer, component);

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/SelectManyCheckboxListRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/SelectManyCheckboxListRenderer.java
@@ -27,7 +27,7 @@ import java.util.Iterator;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.UINamingContainer;
 import jakarta.faces.component.ValueHolder;
-import jakarta.faces.component.html.HtmlEvents.HtmlDocumentElementEvent;
+import jakarta.faces.component.html.HtmlEvents.HtmlElementEvent;
 import jakarta.faces.component.html.HtmlSelectManyCheckbox;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
@@ -270,7 +270,7 @@ public class SelectManyCheckboxListRenderer extends MenuRenderer {
         // Apply HTML 4.x attributes specified on UISelectMany component to all
         // items in the list except styleClass and style which are rendered as
         // attributes of outer most table.
-        RenderKitUtils.renderPassThruAttributes(context, writer, component, idString, false, ATTRIBUTES, HtmlDocumentElementEvent.click, FacesComponentEvent.valueChange);
+        RenderKitUtils.renderPassThruAttributes(context, writer, component, idString, false, ATTRIBUTES, HtmlElementEvent.click, FacesComponentEvent.valueChange);
         RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, component);
 
         writer.endElement("input");

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/TextRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/TextRenderer.java
@@ -30,7 +30,7 @@ import jakarta.faces.application.ProjectStage;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.UIInput;
 import jakarta.faces.component.UIOutput;
-import jakarta.faces.component.html.HtmlEvents.HtmlDocumentElementEvent;
+import jakarta.faces.component.html.HtmlEvents.HtmlElementEvent;
 import jakarta.faces.component.html.HtmlInputFile;
 import jakarta.faces.component.html.HtmlInputText;
 import jakarta.faces.component.html.HtmlOutputText;
@@ -148,7 +148,7 @@ public class TextRenderer extends HtmlBasicInputRenderer {
 
             // style is rendered as a passthru attribute
             Attributes attributes = component instanceof HtmlInputFile ? INPUTFILE_ATTRIBUTES : INPUTTEXT_ATTRIBUTES;
-            RenderKitUtils.renderPassThruAttributes(context, writer, component, null, false, attributes, HtmlDocumentElementEvent.change, FacesComponentEvent.valueChange);
+            RenderKitUtils.renderPassThruAttributes(context, writer, component, null, false, attributes, HtmlElementEvent.change, FacesComponentEvent.valueChange);
             RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, component);
 
             writer.endElement("input");

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/TextareaRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/TextareaRenderer.java
@@ -21,7 +21,7 @@ package org.glassfish.mojarra.renderkit.html_basic;
 import java.io.IOException;
 
 import jakarta.faces.component.UIComponent;
-import jakarta.faces.component.html.HtmlEvents.HtmlDocumentElementEvent;
+import jakarta.faces.component.html.HtmlEvents.HtmlElementEvent;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
 import jakarta.faces.event.BehaviorEvent.FacesComponentEvent;
@@ -58,7 +58,7 @@ public class TextareaRenderer extends HtmlBasicInputRenderer {
         writeStyleClassAttributeIfNecessary(writer, component);
 
         // style is rendered as a passthru attribute
-        RenderKitUtils.renderPassThruAttributes(context, writer, component, null, false, ATTRIBUTES, HtmlDocumentElementEvent.change, FacesComponentEvent.valueChange);
+        RenderKitUtils.renderPassThruAttributes(context, writer, component, null, false, ATTRIBUTES, HtmlElementEvent.change, FacesComponentEvent.valueChange);
         RenderKitUtils.renderXHTMLStyleBooleanAttributes(writer, component);
 
         if (component.getAttributes().containsKey("org.glassfish.mojarra.addNewLineAtStart")

--- a/impl/src/test/java/org/glassfish/mojarra/renderkit/BehaviorEventAttributeTest.java
+++ b/impl/src/test/java/org/glassfish/mojarra/renderkit/BehaviorEventAttributeTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.mojarra.renderkit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.StringWriter;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.html.HtmlBody;
+import jakarta.faces.component.html.HtmlOutputText;
+import jakarta.faces.component.html.HtmlPanelGroup;
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.context.PartialViewContext;
+import jakarta.faces.context.ResponseWriter;
+
+import org.glassfish.mojarra.renderkit.AttributeManager.Key;
+import org.glassfish.mojarra.renderkit.html_basic.TestResponseWriter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * An attribute whose name starts with "on" becomes a client event listener only when the component names the event
+ * after "on" in its <code>ClientBehaviorHolder#getEventNames()</code>, so that a page author writing an event the
+ * component cannot chain behaviors on does not silently get a listener for it. A component which is no
+ * <code>ClientBehaviorHolder</code> has no such list to check against, so all of its event attributes are honored.
+ */
+class BehaviorEventAttributeTest {
+
+    private FacesContext facesContext;
+    private ResponseWriter writer;
+    private List<String> scripts;
+
+    @BeforeEach
+    void setUpCurrentFacesContext() throws Exception {
+        ExternalContext externalContext = mock(ExternalContext.class);
+        when(externalContext.getApplicationMap()).thenReturn(new HashMap<>());
+
+        scripts = new ArrayList<>();
+        PartialViewContext partialViewContext = mock(PartialViewContext.class);
+        when(partialViewContext.isAjaxRequest()).thenReturn(true);
+        when(partialViewContext.getEvalScripts()).thenReturn(scripts);
+
+        facesContext = mock(FacesContext.class);
+        when(facesContext.getExternalContext()).thenReturn(externalContext);
+        when(facesContext.getPartialViewContext()).thenReturn(partialViewContext);
+
+        writer = new TestResponseWriter(new StringWriter());
+        setCurrentInstance(facesContext);
+    }
+
+    @AfterEach
+    void tearDownCurrentFacesContext() throws Exception {
+        setCurrentInstance(null);
+    }
+
+    @Test
+    void aSupportedEventAttributeBecomesAListener() throws Exception {
+        assertTrue(render(new HtmlPanelGroup(), Key.PANELGROUP, "oninput").contains("'input',['handle()']"));
+    }
+
+    @Test
+    void anUnsupportedEventAttributeIsIgnored() throws Exception {
+        assertEquals("", render(new HtmlPanelGroup(), Key.PANELGROUP, "onclck"));
+    }
+
+    @Test
+    void aWindowEventAttributeIsSupportedByTheBodyOnly() throws Exception {
+        assertTrue(render(new HtmlBody(), Key.OUTPUTBODY, "onpagehide").contains("'pagehide',['handle()']"));
+        assertEquals("", render(new HtmlPanelGroup(), Key.PANELGROUP, "onpagehide"));
+    }
+
+    @Test
+    void anEventAttributeOfANonBehaviorHolderBecomesAListener() throws Exception {
+        assertTrue(render(new HtmlOutputText(), Key.OUTPUTTEXT, "onclick").contains("'click',['handle()']"));
+    }
+
+    private String render(UIComponent component, Key key, String name) throws Exception {
+        component.getAttributes().put(name, "handle()");
+        scripts.clear();
+
+        RenderKitUtils.renderPassThruAttributes(facesContext, writer, component, AttributeManager.getAttributes(key));
+        RenderKitUtils.flushPendingBehaviorEventListeners(facesContext, component, "j_id1");
+
+        return String.join(";", scripts);
+    }
+
+    private static void setCurrentInstance(FacesContext facesContext) throws Exception {
+        Method setCurrentInstance = FacesContext.class.getDeclaredMethod("setCurrentInstance", FacesContext.class);
+        setCurrentInstance.setAccessible(true);
+        setCurrentInstance.invoke(null, facesContext);
+    }
+}


### PR DESCRIPTION
Two commits, both following jakartaee/faces#2241.

**Follow the three HTML event handler groups of the API.** `HtmlEvents` now names its enums after what they group — `HtmlElementEvent`, `HtmlBodyEvent`, `HtmlWindowEvent` — with `getHtmlElementEventNames()` for every component and `getHtmlBodyEventNames()` for the one rendering the body element. Rename ripple only, across `RenderKitUtils`, eleven renderers and `PassthroughElement`; `jsf:element` keeps the all-element set, matching MyFaces.

**Render an event attribute only for an event the component supports.** The standard HTML render kit ties an `on*` attribute to a client behavior event of the same name when the substring after `on` is contained in `ClientBehaviorHolder#getEventNames()`. Pass-through rendering honored the prefix alone, so an attribute naming an event the component does not support — a typo such as `onclck`, or `onresize` on a component whose element does not fire it — still became a client event listener, while MyFaces renders nothing for it. The gate is one helper consulted from `renderPassThruAttributesOptimized` and `renderPassThruAttributesUnoptimized`. Behaviors themselves need no gate: `UIComponentBase#addClientBehavior` already rejects unsupported event names.

A known renderer attribute that happens to be `on*` but is not in `getEventNames()` now falls to the plain `writeAttribute` branch instead of the behavior branch — same output, since an unsupported event cannot carry behaviors.

Scope call worth reviewing: the gate applies only to `ClientBehaviorHolder` components, which is exactly the premise of the render kit rule. A non-holder — `h:outputText`, `h:outputFormat`, `h:message` — has no event-name list to consult, so `<h:outputText onclick="...">` keeps working as before. MyFaces drops those too, so a sliver of divergence remains, but there it is "component has no event list at all" rather than "event is not in the list". Tightening that further would silently kill a common idiom, so it belongs in the spec discussion on jakartaee/faces#2241 rather than here.

New `BehaviorEventAttributeTest` asserts on the listener path rather than on rendered attributes, since master parks handlers via `addEventListener` and emits `mojarra.ael(...)` on flush: a supported event attaches, a typo attaches nothing, `onpagehide` attaches on `h:body` but not on `h:panelGroup`, and a non-holder still attaches. Full impl suite green at 1334 tests, and the full TCK is green.

Merging is blocked on jakartaee/faces#2241: the faces submodule pin has to be bumped to that merge commit and amended into the first commit here, so the builds will fail until 2241 is merged and PR is updated with bumped submodule pin.

Refs jakartaee/faces#1507

🤖 Generated with Claude Opus 5
