### PR TITLE
Report only on the components a facelet built (#5970)

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategy.java
@@ -446,15 +446,22 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
 
     /**
      * The tag a component was built from, which tells two components apart that share a client id because only one of
-     * them is ever built. Every component a facelet creates carries it; the ones that no facelet created - the view
-     * root, and anything added programmatically - fall back to their type, which the restore reproduces as well.
+     * them is ever built.
+     *
+     * <p>
+     * Only a component a facelet built carries one, and only such a component is worth comparing across the two
+     * builds: a build time condition governs which tags are applied, so it can add or drop only what a tag built. A
+     * component the facelet did not build - the view root, a component resource, anything added programmatically -
+     * holds no tag, and one of those left without an id of its own does not even hold a stable client id:
+     * {@link UIViewRoot#createUniqueId(FacesContext, String)} numbers it from a counter which the view root's state
+     * restores past the number the rebuild reached, so it is numbered anew on every request.
+     * </p>
      *
      * @param component the component.
-     * @return the identity of what built the given component.
+     * @return the tag the given component was built from, or {@code null} when no facelet built it.
      */
     static String tagOf(UIComponent component) {
-        String tagId = (String) component.getAttributes().get(ComponentSupport.MARK_CREATED);
-        return tagId != null ? tagId : component.getClass().getName();
+        return (String) component.getAttributes().get(ComponentSupport.MARK_CREATED);
     }
 
     /**
@@ -518,7 +525,10 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
             if (target.isTransient()) {
                 return VisitResult.REJECT;
             }
-            rebuiltTags.put(target.getClientId(context1.getFacesContext()), tagOf(target));
+            String tag = tagOf(target);
+            if (tag != null) {
+                rebuiltTags.put(target.getClientId(context1.getFacesContext()), tag);
+            }
             return ACCEPT;
         });
 
@@ -652,10 +662,11 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
                 } else {
                     stateObj = target.saveState(context1.getFacesContext());
                 }
-                if (renderedTags != null || stateObj != null) {
+                String tag = renderedTags != null ? tagOf(target) : null;
+                if (tag != null || stateObj != null) {
                     String clientId = target.getClientId(context1.getFacesContext());
-                    if (renderedTags != null) {
-                        renderedTags.put(clientId, tagOf(target));
+                    if (tag != null) {
+                        renderedTags.put(clientId, tag);
                     }
                     if (stateObj != null) {
                         stateMap.put(clientId, stateObj);

--- a/impl/src/test/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategyTest.java
+++ b/impl/src/test/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategyTest.java
@@ -31,6 +31,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -148,12 +149,15 @@ class FaceletPartialStateManagementStrategyTest {
     }
 
     /**
-     * A component no facelet built carries no tag, so it is identified by its type, which is what the restore
-     * reproduces it from.
+     * A component no facelet built - the view root, a component resource, anything added programmatically - is not
+     * compared across the two builds at all. No build time condition governs whether it is there, and one left
+     * without an id of its own is numbered from a counter which the build leaves where the previous request's state
+     * then moves it, so it holds another client id on every request and comparing it by client id would report it as
+     * vanished on every postback.
      */
     @Test
-    void aComponentBuiltByNoTagIsIdentifiedByItsType() {
-        assertEquals(UIOutput.class.getName(), tagOf(new UIOutput()));
+    void aComponentBuiltByNoTagIsNotCompared() {
+        assertNull(tagOf(new UIOutput()));
     }
 
     @Test

--- a/test/issue5970/pom.xml
+++ b/test/issue5970/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.mojarra.test</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.0.24-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>issue5970</artifactId>
+    <packaging>war</packaging>
+
+    <name>Mojarra ${project.version} - INTEGRATION TESTS - ${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.mojarra.test</groupId>
+            <artifactId>base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test/issue5970/src/main/java/org/eclipse/mojarra/test/issue5970/Issue5970Bean.java
+++ b/test/issue5970/src/main/java/org/eclipse/mojarra/test/issue5970/Issue5970Bean.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.eclipse.mojarra.test.issue5970;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Named;
+
+/**
+ * A request scoped bean whose {@code shown} flag a build time condition evaluates over. The flag is therefore true
+ * during the render which puts the guarded input in the response, and false again during the restore of the postback
+ * which submits it.
+ */
+@Named
+@RequestScoped
+public class Issue5970Bean {
+
+    private boolean shown;
+    private String value;
+
+    public void show() {
+        shown = true;
+    }
+
+    public boolean isShown() {
+        return shown;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/test/issue5970/src/main/java/org/eclipse/mojarra/test/issue5970/Issue5970Filter.java
+++ b/test/issue5970/src/main/java/org/eclipse/mojarra/test/issue5970/Issue5970Filter.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.eclipse.mojarra.test.issue5970;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.annotation.WebFilter;
+
+/**
+ * What the state management strategy reports about the view rebuilt for a postback goes to the log and nowhere else,
+ * which leaves it invisible to a test. This collects the reports of the request being served into the
+ * {@value #REPORTS} request attribute, from where a view renders them for the response to be asserted against.
+ */
+@WebFilter("/*")
+public class Issue5970Filter implements Filter {
+
+    /**
+     * The request attribute holding the reports logged while the request is served.
+     */
+    public static final String REPORTS = "issue5970Reports";
+
+    private static final String LOGGER_NAME = "jakarta.enterprise.resource.webcontainer.faces.application.view";
+
+    private static final ThreadLocal<List<String>> CURRENT = new ThreadLocal<>();
+
+    /**
+     * Held onto for as long as the handler is installed on it, since a logger nothing references is collectable
+     * along with the handlers it was given.
+     */
+    private Logger logger;
+
+    private Handler collector;
+
+    @Override
+    public void init(FilterConfig config) {
+        collector = new ReportCollector();
+        logger = Logger.getLogger(LOGGER_NAME);
+        logger.addHandler(collector);
+    }
+
+    @Override
+    public void destroy() {
+        logger.removeHandler(collector);
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        List<String> reports = new ArrayList<>();
+        request.setAttribute(REPORTS, reports);
+        CURRENT.set(reports);
+
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            CURRENT.remove();
+        }
+    }
+
+    private static class ReportCollector extends Handler {
+
+        private final SimpleFormatter formatter = new SimpleFormatter();
+
+        @Override
+        public void publish(LogRecord record) {
+            List<String> reports = CURRENT.get();
+
+            if (reports != null && record.getLevel().intValue() >= Level.WARNING.intValue()) {
+                reports.add(formatter.formatMessage(record));
+            }
+        }
+
+        @Override
+        public void flush() {
+            // Nothing to flush, the reports are collected in memory.
+        }
+
+        @Override
+        public void close() {
+            // Nothing to close, the reports are collected in memory.
+        }
+    }
+}

--- a/test/issue5970/src/main/webapp/WEB-INF/beans.xml
+++ b/test/issue5970/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/test/issue5970/src/main/webapp/WEB-INF/web.xml
+++ b/test/issue5970/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+    version="6.0"
+>
+    <context-param>
+        <param-name>jakarta.faces.PROJECT_STAGE</param-name>
+        <param-value>Development</param-value>
+    </context-param>
+
+    <servlet>
+        <servlet-name>facesServlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>facesServlet</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+    </servlet-mapping>
+
+    <session-config>
+        <tracking-mode>COOKIE</tracking-mode>
+    </session-config>
+</web-app>

--- a/test/issue5970/src/main/webapp/conditional.xhtml
+++ b/test/issue5970/src/main/webapp/conditional.xhtml
@@ -1,0 +1,37 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:f="jakarta.faces.core"
+      xmlns:h="jakarta.faces.html"
+      xmlns:c="jakarta.tags.core">
+    <h:head><title>conditional</title></h:head>
+    <h:body>
+        <h:form id="form">
+            <h:commandButton id="show" value="show" action="#{issue5970Bean.show}" />
+            <c:if test="#{issue5970Bean.shown}">
+                <h:inputText id="input" value="#{issue5970Bean.value}" />
+            </c:if>
+            <h:commandButton id="submit" value="submit" />
+            <h:commandButton id="ajaxSubmit" value="ajax submit">
+                <f:ajax execute="@form" render="@form" />
+            </h:commandButton>
+            <h:outputText id="reports" value="#{requestScope.issue5970Reports}" />
+        </h:form>
+    </h:body>
+</html>

--- a/test/issue5970/src/main/webapp/resources.xhtml
+++ b/test/issue5970/src/main/webapp/resources.xhtml
@@ -1,0 +1,33 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:f="jakarta.faces.core"
+      xmlns:h="jakarta.faces.html">
+    <h:head><title>resources</title></h:head>
+    <h:body>
+        <h:form id="form">
+            <h:inputText id="input" value="#{issue5970Bean.value}" />
+            <h:commandButton id="submit" value="submit" />
+            <h:commandButton id="ajaxSubmit" value="ajax submit">
+                <f:ajax execute="@form" render="@form" />
+            </h:commandButton>
+            <h:outputText id="reports" value="#{requestScope.issue5970Reports}" />
+        </h:form>
+    </h:body>
+</html>

--- a/test/issue5970/src/test/java/org/eclipse/mojarra/test/issue5970/Issue5970IT.java
+++ b/test/issue5970/src/test/java/org/eclipse/mojarra/test/issue5970/Issue5970IT.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.eclipse.mojarra.test.issue5970;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.mojarra.test.base.BaseIT;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * A postback rebuilds its view from the markup rather than from the response it was submitted from, so a build time
+ * condition evaluating to another value than it did leaves the state of a rendered component with nothing to be
+ * restored into. Under {@code ProjectStage.Development} that is reported, which is only worth reading when the
+ * components it names are the ones a build time condition governs: the components a facelet built. A component no
+ * facelet built is none of the report's business, and one of those left without an id of its own does not even hold
+ * a stable client id, so comparing it would report every view holding one on every postback.
+ */
+class Issue5970IT extends BaseIT {
+
+    @FindBy(id = "form:show")
+    private WebElement show;
+
+    @FindBy(id = "form:input")
+    private WebElement input;
+
+    @FindBy(id = "form:submit")
+    private WebElement submit;
+
+    @FindBy(id = "form:ajaxSubmit")
+    private WebElement ajaxSubmit;
+
+    @FindBy(id = "form:reports")
+    private WebElement reports;
+
+    /**
+     * The input a <code>c:if</code> held while the response was rendered, and no longer holds while the postback is
+     * restored, is named by the report.
+     */
+    @Test
+    void testComponentDroppedByABuildTimeCondition() {
+        open("conditional.xhtml");
+        guardHttp(show::click);
+        assertEquals("[]", reports.getText(), "the rebuild reproduces the view the response was rendered from");
+        input.sendKeys("test");
+        guardHttp(submit::click);
+        assertTrue(reports.getText().contains("form:input"), reports.getText());
+    }
+
+    /**
+     * A view holding no build time condition at all is reported on by neither postback, even though it holds the
+     * component resources which <code>f:ajax</code> installs: no facelet built those, and they are numbered from a
+     * counter which the build leaves where the state of the previous request then moves it, so they hold another
+     * client id on every request.
+     */
+    @Test
+    void testViewHoldingOnlyComponentsNoBuildTimeConditionGoverns() {
+        open("resources.xhtml");
+        input.sendKeys("test");
+        guardHttp(submit::click);
+        assertEquals("[]", reports.getText(), reports.getText());
+        guardAjax(ajaxSubmit::click);
+        assertEquals("[]", reports.getText(), reports.getText());
+    }
+}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -63,6 +63,7 @@
         <module>issue5844</module>
         <module>issue5918</module>
         <module>issue5920</module>
+        <module>issue5970</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
The `ProjectStage.Development` report on the view rebuilt for a postback compared every component by client id, including the ones no facelet built. A component resource holds no id of its own, so `UIComponentBase.getClientId` numbers it from `UIViewRoot`'s `lastId`, which the view root's state restores past the number the rebuild reached — it is numbered anew on every request. Any view holding an `f:ajax` or a `@ResourceDependency` therefore had its resources reported as restored into nothing on every postback, naming client ids no build time condition governs and a remedy that could not apply.

A build time condition decides which tags are applied, so it can add or drop only what a tag built. `tagOf` now yields the tag alone, and both the save side and the compare side pass over what carries none. The report is unchanged for everything a facelet built, which is the population it can say something actionable about: if a `c:if` drops a component carrying a `@ResourceDependency` the resource goes with it, and the report still names the component the `c:if` dropped.

Outside `Development` nothing changes at all — `RENDERED_TAGS` is only saved there, so the new branch reduces to the one it replaces.

## Test

New test module `test/issue5970` pins both directions:

- a component a `c:if` held while the response was rendered, and no longer holds while the postback is restored, **is** named by the report;
- a view holding only components no build time condition governs is reported on by neither a full nor an ajax postback.

The report goes to the log and nowhere else, which is what left it unreachable by a test — the module collects what the strategy logs into a request attribute a view renders. No test module ran in `Development` before, which is why the report went unexercised.

Verified against the pre-fix jar: both tests fail there, the second with exactly the reported symptom (`j_id2`, the `faces.js` component resource that `f:ajax` installs). `impl` unit tests 1365/1365, `test/issue5970` 2/2, `test/restoreBuildTimeDecisions` 17/17.

Closes #5970

🤖 Generated with Claude Opus 5
