### PR TITLE
Do not log JSF1091 for a resource name carrying a query string

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
@@ -585,7 +585,21 @@ public class ResourceHandlerImpl extends ResourceHandler {
      * @return the content type for this resource
      */
     private String getContentType(FacesContext ctx, String resourceName) {
-        return ctx.getExternalContext().getMimeType(resourceName);
+        return ctx.getExternalContext().getMimeType(removeQueryString(resourceName));
+    }
+
+    /**
+     * @param resourceName the resource name, optionally carrying a query string as supported by
+     * {@link com.sun.faces.renderkit.html_basic.ScriptStyleBaseRenderer}
+     * @return the resource name without its query string, as only the part before the '?' identifies the file
+     */
+    static String removeQueryString(String resourceName) {
+        if (resourceName == null) {
+            return null;
+        }
+
+        int queryStringIndex = resourceName.indexOf('?');
+        return queryStringIndex == -1 ? resourceName : resourceName.substring(0, queryStringIndex);
     }
 
     /**

--- a/impl/src/test/java/com/sun/faces/application/resource/ResourceHandlerImplQueryStringTest.java
+++ b/impl/src/test/java/com/sun/faces/application/resource/ResourceHandlerImplQueryStringTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.faces.application.resource;
+
+import static com.sun.faces.application.resource.ResourceHandlerImpl.removeQueryString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that a resource name carrying a query string, as supported by
+ * {@link com.sun.faces.renderkit.html_basic.ScriptStyleBaseRenderer}, is reduced to the file identifying part before the
+ * content type and hence the renderer type are derived from it.
+ */
+class ResourceHandlerImplQueryStringTest {
+
+    @Test
+    void keepsResourceNameWithoutQueryString() {
+        assertNull(removeQueryString(null));
+        assertEquals("", removeQueryString(""));
+        assertEquals("theme.css", removeQueryString("theme.css"));
+        assertEquals("css/theme.css", removeQueryString("css/theme.css"));
+    }
+
+    @Test
+    void removesQueryString() {
+        assertEquals("theme.css", removeQueryString("theme.css?v=1"));
+        assertEquals("css/theme.css", removeQueryString("css/theme.css?v=1"));
+        assertEquals("theme.css", removeQueryString("theme.css?first=1&second=2"));
+        assertEquals("theme.css", removeQueryString("theme.css?"));
+    }
+
+    /**
+     * A resource name is a file name, so a '?' in any but the first position still starts the query string.
+     */
+    @Test
+    void removesQueryStringFromFirstQuestionMarkOn() {
+        assertEquals("theme.css", removeQueryString("theme.css?v=1?v=2"));
+        assertEquals("", removeQueryString("?v=1"));
+    }
+}


### PR DESCRIPTION
Closes #5969

`h:outputScript` and `h:outputStylesheet` accept a query string in the `name` attribute and split it off before resolving the resource, re-appending it to the request path. Every other consumer of the name passes it to `ExternalContext#getMimeType` verbatim, where the extension resolves as `css?v=1` and yields no mime type. In Development stage that logs a JSF1091 warning, and `getRendererTypeForResourceName` returns `null` for such a resource.

`ResourceHandlerImpl#getContentType` now removes the query string before deriving the mime type. That is the single seam through which `createResource`, `createViewResource`, `createResourceFromId` and `getRendererTypeForResourceName` all pass.

Verified on Tomcat 11 against 4.0.22 and this branch, same app, Development stage:

| case | 4.0.22 | this branch |
| --- | --- | --- |
| ajax postback with `theme.css?v=1` in the head | JSF1091 logged per request | no warning |
| `h:outputStylesheet name="theme.css?v=1"` on GET | link with `?ln=css&v=1` | unchanged |
| `h:graphicImage` / `#{resource['css:theme.css?v=1']}` | `RES_NOT_FOUND` / empty, plus JSF1091 | same output, no warning |
| resource already in the restored view, on ajax | not re-sent | not re-sent |

The last row is the one to watch: `PartialViewContextImpl#renderComponentResources` calls `isResourceRendered` with the raw name and `UIViewRoot#processEvent` marks with the raw name on `PostRestoreStateEvent`, so both sides keep matching and an already rendered resource stays skipped.

Resolving such a name to an actual resource remains out of scope. A query string is not valid in a `resourceName` segment (the spec allows XML NameChar minus the path separator and `:`, and requires an invalid resource identifier to be ignored silently), so `h:graphicImage` and `#{resource[...]}` keep returning `RES_NOT_FOUND` and empty respectively -- just without the warning.

🤖 Generated with Claude Opus 5
