### PR TITLE
Key the rendered resource marker on the name without query string

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
@@ -56,8 +56,6 @@ import jakarta.faces.context.FacesContext;
 
 import com.sun.faces.application.ApplicationAssociate;
 import com.sun.faces.config.WebConfiguration;
-import com.sun.faces.renderkit.html_basic.ScriptRenderer;
-import com.sun.faces.renderkit.html_basic.StylesheetRenderer;
 import com.sun.faces.util.FacesLogger;
 import com.sun.faces.util.RequestStateManager;
 import com.sun.faces.util.Util;
@@ -280,21 +278,6 @@ public class ResourceHandlerImpl extends ResourceHandler {
     @Override
     public boolean isResourceRendered(FacesContext context, String resourceName, String libraryName) {
         return super.isResourceRendered(context, removeQueryString(resourceName), libraryName);
-    }
-
-    private static String getResourceType(String contentType) {
-        if (contentType == null) {
-            return null;
-        }
-
-        final String type = contentType.toLowerCase(ROOT);
-        if (type.equals(ScriptRenderer.DEFAULT_CONTENT_TYPE)) {
-            return "script";
-        } else if (type.equals(StylesheetRenderer.DEFAULT_CONTENT_TYPE)) {
-            return "style";
-        }
-
-        return null;
     }
 
     /**

--- a/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/resource/ResourceHandlerImpl.java
@@ -266,6 +266,22 @@ public class ResourceHandlerImpl extends ResourceHandler {
         return rendererType;
     }
 
+    /**
+     * @see ResourceHandler#markResourceRendered(FacesContext, String, String)
+     */
+    @Override
+    public void markResourceRendered(FacesContext context, String resourceName, String libraryName) {
+        super.markResourceRendered(context, removeQueryString(resourceName), libraryName);
+    }
+
+    /**
+     * @see ResourceHandler#isResourceRendered(FacesContext, String, String)
+     */
+    @Override
+    public boolean isResourceRendered(FacesContext context, String resourceName, String libraryName) {
+        return super.isResourceRendered(context, removeQueryString(resourceName), libraryName);
+    }
+
     private static String getResourceType(String contentType) {
         if (contentType == null) {
             return null;


### PR DESCRIPTION
Two unrelated changes to `ResourceHandlerImpl`, one commit each, discovered during work on #5969.

### Key the rendered resource marker on the name without query string

`h:outputScript` and `h:outputStylesheet` accept a query string in the `name` attribute and split it off before resolving the resource, so they mark and check the rendered marker with the stripped name. `UIViewRoot#processEvent` and `PartialViewContextImpl#renderComponentResources` pass the name as authored. `ResourceHandler` keys the marker on `libraryName + ':' + resourceName` verbatim, so `theme.css?v=1` and `theme.css` register as two different resources.

Stripping the query string in the `markResourceRendered` and `isResourceRendered` overrides gives one key per file for every caller, including third party components that call either method with the name as authored. No API class is touched, which keeps the 5.0 upmerge free of a `com.sun.faces` dependency in `jakarta.faces`.

Probe over the public API, marking `marker.css?v=1` and then querying both spellings, on 4.0.22 and on this branch:

```
4.0.22       markedWithQuery/checkedWithout=false  checkedWithQuery=true  unrelated=false
this branch  markedWithQuery/checkedWithout=true   checkedWithQuery=true  unrelated=false
```

Rendered output is unchanged, verified byte for byte on the same app.

Inside Mojarra alone the old mismatch was latent rather than visible: the two raw-name call sites pair with each other and the stripped one pairs with itself. This makes the key well defined rather than accidentally consistent.

### Remove unused getResourceType

d15db8aad9 backported the method from Mojarra 5 without its caller. On 5.0 `getRendererTypeForResourceName` delegates to it; on this branch that method derives the renderer type from the content type directly, so the copy has never been called. Removed along with the `ScriptRenderer` and `StylesheetRenderer` imports it was the sole user of.

Note for the 5.0 upmerge: master uses the method, so master's version wins there.

🤖 Generated with Claude Opus 5
