### PR TITLE
Resolve a resource name carrying a query string centrally

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/application/resource/ResourceHandlerImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/resource/ResourceHandlerImpl.java
@@ -224,33 +224,32 @@ public class ResourceHandlerImpl extends ResourceHandler {
 
     @Override
     public String getRendererTypeForResourceName(String resourceName) {
-        if (resourceName == null) {
-            return null;
-        }
-
-        String resourceType = getResourceType(getContentType(FacesContext.getCurrentInstance(), resourceName));
-
-        if (resourceType == null) {
-            return null;
-        }
-
-        return switch (resourceType) {
-            case "script" -> "jakarta.faces.resource.Script";
-            case "style" -> "jakarta.faces.resource.Stylesheet";
-            default -> null;
-        };
+        return getRendererType(resourceName);
     }
 
-    private static String getResourceType(String contentType) {
-        if (contentType == null) {
+    /**
+     * @param resourceName the resource name, optionally carrying a query string as specified in section 2.6.1.3
+     * "Resource Identifiers" of the Jakarta Faces Specification Document
+     * @return the renderer type of the renderer capable of rendering the resource, or <code>null</code> if there is none
+     */
+    static String getRendererType(String resourceName) {
+        String name = removeQueryString(resourceName);
+
+        if (name == null) {
             return null;
         }
 
-        return switch (contentType.toLowerCase(ROOT)) {
-            case ScriptRenderer.DEFAULT_CONTENT_TYPE -> "script";
-            case StylesheetRenderer.DEFAULT_CONTENT_TYPE -> "style";
-            default -> null;
-        };
+        String lowerCaseName = name.toLowerCase(ROOT);
+
+        if (lowerCaseName.endsWith(ScriptRenderer.FILE_EXTENSION)) {
+            return ScriptRenderer.RENDERER_TYPE;
+        }
+
+        if (lowerCaseName.endsWith(StylesheetRenderer.FILE_EXTENSION)) {
+            return StylesheetRenderer.RENDERER_TYPE;
+        }
+
+        return null;
     }
 
     /**

--- a/impl/src/main/java/org/glassfish/mojarra/application/resource/ResourceHandlerImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/resource/ResourceHandlerImpl.java
@@ -123,14 +123,16 @@ public class ResourceHandlerImpl extends ResourceHandler {
 
         FacesContext ctx = FacesContext.getCurrentInstance();
 
-        String ctype = contentType != null ? contentType : getContentType(ctx, resourceName);
-        ResourceInfo info = manager.findResource(libraryName, resourceName, ctype, ctx);
+        String name = removeQueryString(resourceName);
+        String queryString = getQueryString(resourceName);
+        String ctype = contentType != null ? contentType : getContentType(ctx, name);
+        ResourceInfo info = manager.findResource(libraryName, name, ctype, ctx);
 
         if (info == null) {
             return null;
         }
 
-        return new ResourceImpl(info, ctype, creationTime, maxAge);
+        return new ResourceImpl(info, ctype, creationTime, maxAge, queryString);
     }
 
     @Override
@@ -249,22 +251,6 @@ public class ResourceHandlerImpl extends ResourceHandler {
             case StylesheetRenderer.DEFAULT_CONTENT_TYPE -> "style";
             default -> null;
         };
-    }
-
-    /**
-     * @see ResourceHandler#markResourceRendered(FacesContext, String, String)
-     */
-    @Override
-    public void markResourceRendered(FacesContext context, String resourceName, String libraryName) {
-        super.markResourceRendered(context, removeQueryString(resourceName), libraryName);
-    }
-
-    /**
-     * @see ResourceHandler#isResourceRendered(FacesContext, String, String)
-     */
-    @Override
-    public boolean isResourceRendered(FacesContext context, String resourceName, String libraryName) {
-        return super.isResourceRendered(context, removeQueryString(resourceName), libraryName);
     }
 
     /**
@@ -545,8 +531,8 @@ public class ResourceHandlerImpl extends ResourceHandler {
     }
 
     /**
-     * @param resourceName the resource name, optionally carrying a query string as supported by
-     * {@link org.glassfish.mojarra.renderkit.html_basic.ScriptStyleBaseRenderer}
+     * @param resourceName the resource name, optionally carrying a query string as specified in section 2.6.1.3
+     * "Resource Identifiers" of the Jakarta Faces Specification Document
      * @return the resource name without its query string, as only the part before the '?' identifies the file
      */
     static String removeQueryString(String resourceName) {
@@ -556,6 +542,21 @@ public class ResourceHandlerImpl extends ResourceHandler {
 
         int queryStringIndex = resourceName.indexOf('?');
         return queryStringIndex == -1 ? resourceName : resourceName.substring(0, queryStringIndex);
+    }
+
+    /**
+     * @param resourceName the resource name, optionally carrying a query string as specified in section 2.6.1.3
+     * "Resource Identifiers" of the Jakarta Faces Specification Document
+     * @return the query string of the resource name without its introducing '?', or <code>null</code> if there is none
+     */
+    static String getQueryString(String resourceName) {
+        if (resourceName == null) {
+            return null;
+        }
+
+        int queryStringIndex = resourceName.indexOf('?');
+        return queryStringIndex == -1 || queryStringIndex == resourceName.length() - 1 ? null
+                : resourceName.substring(queryStringIndex + 1);
     }
 
     /**

--- a/impl/src/main/java/org/glassfish/mojarra/application/resource/ResourceHandlerImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/resource/ResourceHandlerImpl.java
@@ -27,8 +27,10 @@ import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.WARNING;
 import static org.glassfish.mojarra.util.RequestStateManager.RESOURCE_REQUEST;
 import static org.glassfish.mojarra.util.Util.getFacesMapping;
+import static org.glassfish.mojarra.util.Util.getQueryString;
 import static org.glassfish.mojarra.util.Util.notNegative;
 import static org.glassfish.mojarra.util.Util.notNull;
+import static org.glassfish.mojarra.util.Util.removeQueryString;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -177,13 +179,14 @@ public class ResourceHandlerImpl extends ResourceHandler {
     public Resource createResourceFromId(String resourceId) {
         notNull("resourceId", resourceId);
         FacesContext ctx = FacesContext.getCurrentInstance();
-        ResourceInfo info = manager.findResource(resourceId);
-        String ctype = getContentType(ctx, resourceId);
+        String id = removeQueryString(resourceId);
+        ResourceInfo info = manager.findResource(id);
+        String ctype = getContentType(ctx, id);
         if (info == null) {
-            logMissingResource(ctx, resourceId, null);
+            logMissingResource(ctx, id, null);
             return null;
         } else {
-            return new ResourceImpl(info, ctype, creationTime, maxAge);
+            return new ResourceImpl(info, ctype, creationTime, maxAge, getQueryString(resourceId));
         }
 
     }
@@ -527,35 +530,6 @@ public class ResourceHandlerImpl extends ResourceHandler {
      */
     private String getContentType(FacesContext ctx, String resourceName) {
         return ctx.getExternalContext().getMimeType(removeQueryString(resourceName));
-    }
-
-    /**
-     * @param resourceName the resource name, optionally carrying a query string as specified in section 2.6.1.3
-     * "Resource Identifiers" of the Jakarta Faces Specification Document
-     * @return the resource name without its query string, as only the part before the '?' identifies the file
-     */
-    static String removeQueryString(String resourceName) {
-        if (resourceName == null) {
-            return null;
-        }
-
-        int queryStringIndex = resourceName.indexOf('?');
-        return queryStringIndex == -1 ? resourceName : resourceName.substring(0, queryStringIndex);
-    }
-
-    /**
-     * @param resourceName the resource name, optionally carrying a query string as specified in section 2.6.1.3
-     * "Resource Identifiers" of the Jakarta Faces Specification Document
-     * @return the query string of the resource name without its introducing '?', or <code>null</code> if there is none
-     */
-    static String getQueryString(String resourceName) {
-        if (resourceName == null) {
-            return null;
-        }
-
-        int queryStringIndex = resourceName.indexOf('?');
-        return queryStringIndex == -1 || queryStringIndex == resourceName.length() - 1 ? null
-                : resourceName.substring(queryStringIndex + 1);
     }
 
     /**

--- a/impl/src/main/java/org/glassfish/mojarra/application/resource/ResourceImpl.java
+++ b/impl/src/main/java/org/glassfish/mojarra/application/resource/ResourceImpl.java
@@ -103,6 +103,11 @@ public class ResourceImpl extends Resource implements Externalizable {
      */
     private URL resolvedUrl = null;
 
+    /**
+     * The query string carried by the resource name, without its introducing '?', or null if there is none.
+     */
+    private String queryString;
+
     // ------------------------------------------------------------ Constructors
 
     /**
@@ -119,6 +124,18 @@ public class ResourceImpl extends Resource implements Externalizable {
      * @param maxAge the resource max age
      */
     public ResourceImpl(ResourceInfo resourceInfo, String contentType, long initialTime, long maxAge) {
+        this(resourceInfo, contentType, initialTime, maxAge, null);
+    }
+
+    /**
+     * Creates a new instance of ResourceBase
+     * @param resourceInfo the resource info
+     * @param contentType the resource content type
+     * @param initialTime the resource initial time
+     * @param maxAge the resource max age
+     * @param queryString the query string carried by the resource name, without its introducing '?', may be null
+     */
+    public ResourceImpl(ResourceInfo resourceInfo, String contentType, long initialTime, long maxAge, String queryString) {
 
         this.resourceInfo = resourceInfo;
         super.setResourceName(resourceInfo.getName());
@@ -126,6 +143,7 @@ public class ResourceImpl extends Resource implements Externalizable {
         super.setContentType(contentType);
         this.initialTime = initialTime;
         this.maxAge = maxAge;
+        this.queryString = queryString;
     }
 
     @Override
@@ -318,6 +336,11 @@ public class ResourceImpl extends Resource implements Externalizable {
             queryStarted = true;
         }
 
+        if (queryString != null) {
+            uri += (queryStarted ? "&" : "?") + queryString;
+            queryStarted = true;
+        }
+
         if (FACES_SCRIPT_RESOURCE_NAME.equals(getResourceName()) && FACES_SCRIPT_LIBRARY_NAME.equals(getLibraryName())) {
             ProjectStage stage = context.getApplication().getProjectStage();
             switch (stage) {
@@ -425,6 +448,7 @@ public class ResourceImpl extends Resource implements Externalizable {
         out.writeObject(getContentType());
         out.writeLong(initialTime);
         out.writeLong(maxAge);
+        out.writeObject(queryString);
 
     }
 
@@ -436,6 +460,7 @@ public class ResourceImpl extends Resource implements Externalizable {
         setContentType((String) in.readObject());
         initialTime = in.readLong();
         maxAge = in.readLong();
+        queryString = (String) in.readObject();
     }
 
     private void initResourceInfo() {

--- a/impl/src/main/java/org/glassfish/mojarra/el/ResourceELResolver.java
+++ b/impl/src/main/java/org/glassfish/mojarra/el/ResourceELResolver.java
@@ -18,6 +18,8 @@
 package org.glassfish.mojarra.el;
 
 
+import static org.glassfish.mojarra.util.Util.removeQueryString;
+
 import jakarta.el.ELContext;
 import jakarta.el.ELException;
 import jakarta.el.ELResolver;
@@ -52,6 +54,8 @@ public class ResourceELResolver extends ELResolver {
      * library name, and the content after the <code>:</code> to be the resource name and pass both to
      * {@link jakarta.faces.application.ResourceHandler#createResource(String, String)}</li>
      * <li>If <code>property</code> contains more than one <code>:</code> then throw a <code>ELException</code></li>
+     * <li>A query string carried by <code>property</code> is left out of the above: the colons are counted over the
+     * part preceding the first <code>?</code>, and the query string stays with the resource name</li>
      * <li>If one of the above steps resulted in the creation of a {@link Resource} instance, call
      * <code>ELContext.setPropertyResolved(true)</code> and return the result of
      * {@link jakarta.faces.application.Resource#getRequestPath()}</li>
@@ -69,16 +73,17 @@ public class ResourceELResolver extends ELResolver {
         if (base instanceof ResourceHandler) {
             ResourceHandler handler = (ResourceHandler) base;
             String prop = property.toString();
+            String resourceIdentifier = removeQueryString(prop);
             Resource res;
-            if (!prop.contains(":")) {
+            if (!resourceIdentifier.contains(":")) {
                 res = handler.createResource(prop);
             } else {
-                if (!isPropertyValid(prop)) {
+                if (!isPropertyValid(resourceIdentifier)) {
                     // RELEASE_PENDING i18n
                     throw new ELException("Invalid resource format.  Property " + prop + " contains more than one colon (:)");
                 }
 
-                String[] parts = Util.split(prop, ':');
+                String[] parts = Util.split(prop, ':', 2);
 
                 // If the enclosing entity for this expression is itself
                 // a resource, the "this" syntax for the library name must

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/ComponentSupport.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/ComponentSupport.java
@@ -50,6 +50,8 @@ import org.glassfish.mojarra.facelets.FaceletContextImplBase;
 import org.glassfish.mojarra.facelets.impl.IdMapper;
 import org.glassfish.mojarra.facelets.tag.TagAttributesImpl;
 import org.glassfish.mojarra.facelets.tag.faces.core.FacetHandler;
+import org.glassfish.mojarra.renderkit.html_basic.ScriptRenderer;
+import org.glassfish.mojarra.renderkit.html_basic.StylesheetRenderer;
 import org.glassfish.mojarra.util.Util;
 
 /**
@@ -109,7 +111,7 @@ public final class ComponentSupport {
         }
 
         String rendererType = config.getRendererType();
-        return "jakarta.faces.resource.Script".equals(rendererType) || "jakarta.faces.resource.Stylesheet".equals(rendererType);
+        return ScriptRenderer.RENDERER_TYPE.equals(rendererType) || StylesheetRenderer.RENDERER_TYPE.equals(rendererType);
     }
 
     public static boolean isBuildingNewComponentTree(FacesContext context) {

--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/html/HtmlLibrary.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/faces/html/HtmlLibrary.java
@@ -52,6 +52,9 @@ import jakarta.faces.component.html.HtmlSelectOneListbox;
 import jakarta.faces.component.html.HtmlSelectOneMenu;
 import jakarta.faces.component.html.HtmlSelectOneRadio;
 
+import org.glassfish.mojarra.renderkit.html_basic.ScriptRenderer;
+import org.glassfish.mojarra.renderkit.html_basic.StylesheetRenderer;
+
 /**
  * @author Jacob Hookom
  */
@@ -115,9 +118,9 @@ public final class HtmlLibrary extends AbstractHtmlLibrary {
 
         addHtmlComponent("outputText", HtmlOutputText.COMPONENT_TYPE, "jakarta.faces.Text");
 
-        this.addComponent("outputScript", UIOutput.COMPONENT_TYPE, "jakarta.faces.resource.Script", ScriptResourceHandler.class);
+        this.addComponent("outputScript", UIOutput.COMPONENT_TYPE, ScriptRenderer.RENDERER_TYPE, ScriptResourceHandler.class);
 
-        this.addComponent("outputStylesheet", UIOutput.COMPONENT_TYPE, "jakarta.faces.resource.Stylesheet", StylesheetResourceHandler.class);
+        this.addComponent("outputStylesheet", UIOutput.COMPONENT_TYPE, StylesheetRenderer.RENDERER_TYPE, StylesheetResourceHandler.class);
 
         addHtmlComponent("panelGrid", HtmlPanelGrid.COMPONENT_TYPE, "jakarta.faces.Grid");
 

--- a/impl/src/main/java/org/glassfish/mojarra/push/WebsocketFacesListener.java
+++ b/impl/src/main/java/org/glassfish/mojarra/push/WebsocketFacesListener.java
@@ -34,6 +34,8 @@ import jakarta.faces.event.SystemEvent;
 import jakarta.faces.event.SystemEventListener;
 import jakarta.faces.push.Push;
 
+import org.glassfish.mojarra.renderkit.html_basic.ScriptRenderer;
+
 /**
  * <p class="changed_added_2_3">
  * This Faces listener for {@link UIViewRoot} ensures that the necessary JavaScript code to open or close the
@@ -108,7 +110,7 @@ public class WebsocketFacesListener implements SystemEventListener {
                     context.getPartialViewContext().getEvalScripts().add(script);
                 } else {
                     UIOutput outputScript = new UIOutput();
-                    outputScript.setRendererType("jakarta.faces.resource.Script");
+                    outputScript.setRendererType(ScriptRenderer.RENDERER_TYPE);
                     UIOutput content = new UIOutput();
                     content.setValue(script);
                     outputScript.getChildren().add(content);

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/RenderKitUtils.java
@@ -1132,7 +1132,7 @@ public class RenderKitUtils {
     private static UIComponent createFacesJs() {
 
         UIOutput output = new UIOutput();
-        output.setRendererType("jakarta.faces.resource.Script");
+        output.setRendererType(ScriptRenderer.RENDERER_TYPE);
         output.getAttributes().put("name", FACES_SCRIPT_RESOURCE_NAME);
         output.getAttributes().put("library", FACES_SCRIPT_LIBRARY_NAME);
         return output;

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/ScriptRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/ScriptRenderer.java
@@ -31,6 +31,10 @@ import org.glassfish.mojarra.renderkit.RenderKitUtils;
  */
 public class ScriptRenderer extends ScriptStyleBaseRenderer {
 
+    public static final String RENDERER_TYPE = "jakarta.faces.resource.Script";
+
+    public static final String FILE_EXTENSION = ".js";
+
     public static final String DEFAULT_CONTENT_TYPE = "text/javascript";
     
     @Override

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/ScriptStyleBaseRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/ScriptStyleBaseRenderer.java
@@ -171,16 +171,6 @@ public abstract class ScriptStyleBaseRenderer extends Renderer<UIComponent> impl
             return;
         }
 
-        // Special case of resource names that have query strings.
-        // These resources actually use their query strings internally, not externally, so we don't need the resource to know
-        // about them.
-        int queryPos = name.indexOf("?");
-        String query = null;
-        if (queryPos > -1 && name.length() > queryPos) {
-            query = name.substring(queryPos + 1);
-            name = name.substring(0, queryPos);
-        }
-
         String library = (String) attributes.get("library");
 
         // Ensure this resource is not rendered more than once per request.
@@ -195,7 +185,7 @@ public abstract class ScriptStyleBaseRenderer extends Renderer<UIComponent> impl
         ResponseWriter writer = context.getResponseWriter();
         startExternalElement(context, writer, component);
 
-        if (library == null && name != null && ApplicationAssociate.getInstance(context).getResourceManager().isContractsResource(name)) {
+        if (library == null && ApplicationAssociate.getInstance(context).getResourceManager().isContractsResource(name)) {
             if (context.isProjectStage(ProjectStage.Development)) {
                 String msg = "Illegal path, direct contract references are not allowed: " + name;
                 context.addMessage(component.getClientId(context), new FacesMessage(FacesMessage.Severity.ERROR, msg, msg));
@@ -209,11 +199,7 @@ public abstract class ScriptStyleBaseRenderer extends Renderer<UIComponent> impl
                 context.addMessage(component.getClientId(context), new FacesMessage(FacesMessage.Severity.ERROR, msg, msg));
             }
         } else {
-            resourceUrl = resource.getRequestPath();
-            if (query != null) {
-                resourceUrl = resourceUrl + (resourceUrl.indexOf("?") > -1 ? "&amp;" : "?") + query;
-            }
-            resourceUrl = context.getExternalContext().encodeResourceURL(resourceUrl);
+            resourceUrl = context.getExternalContext().encodeResourceURL(resource.getRequestPath());
         }
 
         endExternalElement(writer, component, resourceUrl);

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/StylesheetRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/StylesheetRenderer.java
@@ -31,6 +31,10 @@ import org.glassfish.mojarra.renderkit.RenderKitUtils;
  */
 public class StylesheetRenderer extends ScriptStyleBaseRenderer {
 
+    public static final String RENDERER_TYPE = "jakarta.faces.resource.Stylesheet";
+
+    public static final String FILE_EXTENSION = ".css";
+
     public static final String DEFAULT_CONTENT_TYPE = "text/css";
 
     @Override

--- a/impl/src/main/java/org/glassfish/mojarra/util/Util.java
+++ b/impl/src/main/java/org/glassfish/mojarra/util/Util.java
@@ -1113,6 +1113,35 @@ public class Util {
     }
 
     /**
+     * @param resourceName the resource name, optionally carrying a query string as specified in section 2.6.1.3
+     * "Resource Identifiers" of the Jakarta Faces Specification Document
+     * @return the resource name without its query string, as only the part before the '?' identifies the file
+     */
+    public static String removeQueryString(String resourceName) {
+        if (resourceName == null) {
+            return null;
+        }
+
+        int queryStringIndex = resourceName.indexOf('?');
+        return queryStringIndex == -1 ? resourceName : resourceName.substring(0, queryStringIndex);
+    }
+
+    /**
+     * @param resourceName the resource name, optionally carrying a query string as specified in section 2.6.1.3
+     * "Resource Identifiers" of the Jakarta Faces Specification Document
+     * @return the query string of the resource name without its introducing '?', or <code>null</code> if there is none
+     */
+    public static String getQueryString(String resourceName) {
+        if (resourceName == null) {
+            return null;
+        }
+
+        int queryStringIndex = resourceName.indexOf('?');
+        return queryStringIndex == -1 || queryStringIndex == resourceName.length() - 1 ? null
+                : resourceName.substring(queryStringIndex + 1);
+    }
+
+    /**
      * <p>
      * Returns the URL pattern of the {@link jakarta.faces.webapp.FacesServlet} that is executing the current request. If
      * there are multiple URL patterns, the value returned by <code>HttpServletRequest.getServletPath()</code> and

--- a/impl/src/test/java/org/glassfish/mojarra/application/resource/ResourceHandlerImplQueryStringTest.java
+++ b/impl/src/test/java/org/glassfish/mojarra/application/resource/ResourceHandlerImplQueryStringTest.java
@@ -15,6 +15,7 @@
  */
 package org.glassfish.mojarra.application.resource;
 
+import static org.glassfish.mojarra.application.resource.ResourceHandlerImpl.getQueryString;
 import static org.glassfish.mojarra.application.resource.ResourceHandlerImpl.removeQueryString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -22,9 +23,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests that a resource name carrying a query string, as supported by
- * {@link org.glassfish.mojarra.renderkit.html_basic.ScriptStyleBaseRenderer}, is reduced to the file identifying part before the
- * content type and hence the renderer type are derived from it.
+ * Tests that a resource name carrying a query string, as specified in section 2.6.1.3 "Resource Identifiers" of the
+ * Jakarta Faces Specification Document, is split into the file identifying part, which resolves the resource, and the
+ * query string, which is appended to the request path.
  */
 class ResourceHandlerImplQueryStringTest {
 
@@ -51,5 +52,30 @@ class ResourceHandlerImplQueryStringTest {
     void removesQueryStringFromFirstQuestionMarkOn() {
         assertEquals("theme.css", removeQueryString("theme.css?v=1?v=2"));
         assertEquals("", removeQueryString("?v=1"));
+    }
+
+    @Test
+    void hasNoQueryStringWithoutQuestionMark() {
+        assertNull(getQueryString(null));
+        assertNull(getQueryString(""));
+        assertNull(getQueryString("theme.css"));
+        assertNull(getQueryString("css/theme.css"));
+    }
+
+    /**
+     * A '?' in the last position introduces an empty query string, which is no query string at all.
+     */
+    @Test
+    void hasNoQueryStringWithTrailingQuestionMark() {
+        assertNull(getQueryString("theme.css?"));
+        assertNull(getQueryString("?"));
+    }
+
+    @Test
+    void keepsQueryStringWithoutItsIntroducingQuestionMark() {
+        assertEquals("v=1", getQueryString("theme.css?v=1"));
+        assertEquals("v=1", getQueryString("css/theme.css?v=1"));
+        assertEquals("first=1&second=2", getQueryString("theme.css?first=1&second=2"));
+        assertEquals("v=1?v=2", getQueryString("theme.css?v=1?v=2"));
     }
 }

--- a/impl/src/test/java/org/glassfish/mojarra/application/resource/ResourceHandlerImplRendererTypeTest.java
+++ b/impl/src/test/java/org/glassfish/mojarra/application/resource/ResourceHandlerImplRendererTypeTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.mojarra.application.resource;
+
+import static org.glassfish.mojarra.application.resource.ResourceHandlerImpl.getRendererType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that the renderer type is derived from the resource name itself, as specified by
+ * {@link jakarta.faces.application.ResourceHandler#getRendererTypeForResourceName(String)}, and hence does not depend on
+ * the content type the container happens to map the file extension to.
+ */
+class ResourceHandlerImplRendererTypeTest {
+
+    private static final String SCRIPT = "jakarta.faces.resource.Script";
+    private static final String STYLESHEET = "jakarta.faces.resource.Stylesheet";
+
+    @Test
+    void rendersScriptForJavaScriptFileExtension() {
+        assertEquals(SCRIPT, getRendererType("mycomponent.js"));
+        assertEquals(SCRIPT, getRendererType("js/mycomponent.js"));
+        assertEquals(SCRIPT, getRendererType("mycomponent.JS"));
+    }
+
+    @Test
+    void rendersStylesheetForCascadingStyleSheetFileExtension() {
+        assertEquals(STYLESHEET, getRendererType("mystyle.css"));
+        assertEquals(STYLESHEET, getRendererType("css/mystyle.css"));
+        assertEquals(STYLESHEET, getRendererType("mystyle.CSS"));
+    }
+
+    /**
+     * The query string is not part of the resource name identifying the file, so it does not hide the file extension.
+     */
+    @Test
+    void rendersSameTypeForResourceNameCarryingQueryString() {
+        assertEquals(SCRIPT, getRendererType("mycomponent.js?v=1"));
+        assertEquals(STYLESHEET, getRendererType("mystyle.css?v=1"));
+    }
+
+    @Test
+    void rendersNothingForAnyOtherResourceName() {
+        assertNull(getRendererType(null));
+        assertNull(getRendererType(""));
+        assertNull(getRendererType("duke.gif"));
+        assertNull(getRendererType("mycomponent.js.gz"));
+        assertNull(getRendererType("js"));
+    }
+
+}

--- a/impl/src/test/java/org/glassfish/mojarra/application/resource/ResourceImplTest.java
+++ b/impl/src/test/java/org/glassfish/mojarra/application/resource/ResourceImplTest.java
@@ -165,6 +165,10 @@ public class ResourceImplTest extends JUnitFacesTestCaseBase {
     }
 
     private ResourceImpl createResource(String resourceName, String libraryName, String libraryVersion, String resourceVersion, String localePrefix, String contract) {
+        return createResource(resourceName, libraryName, libraryVersion, resourceVersion, localePrefix, contract, null);
+    }
+
+    private ResourceImpl createResource(String resourceName, String libraryName, String libraryVersion, String resourceVersion, String localePrefix, String contract, String queryString) {
         ContractInfo contractInfo = contract != null ? new ContractInfo(contract) : null;
         VersionInfo libraryVersionInfo = libraryVersion != null ? new VersionInfo(libraryVersion, null) : null;
         VersionInfo resourceVersionInfo = resourceVersion != null ? new VersionInfo(resourceVersion, extensionOf(resourceName)) : null;
@@ -177,7 +181,25 @@ public class ResourceImplTest extends JUnitFacesTestCaseBase {
             resourceInfo = new ResourceInfo(contractInfo, resourceName, resourceVersionInfo, RESOURCE_HELPER);
         }
 
-        return new ResourceImpl(resourceInfo, "text/css", 0, 0);
+        return new ResourceImpl(resourceInfo, "text/css", 0, 0, queryString);
+    }
+
+    @Test
+    public void getRequestPathStartsTheQueryStringWhenThereIsNoResourceMetaData() {
+        ResourceImpl resource = createResource("theme.css", null, null, null, null, null, "v=1");
+
+        configureRequest(MockFacesMappingSupport.mapping(PATH, "/faces/*", "theme"), "/exact", "/faces/*");
+
+        assertEquals("/app/faces/jakarta.faces.resource/theme.css?v=1", resource.getRequestPath());
+    }
+
+    @Test
+    public void getRequestPathAppendsTheQueryStringToTheResourceMetaData() {
+        ResourceImpl resource = createResource("theme.css", "layout", "1_0", null, "en", "blue", "a=1&b=2");
+
+        configureRequest(MockFacesMappingSupport.mapping(PATH, "/faces/*", "theme"), "/exact", "/faces/*");
+
+        assertEquals("/app/faces/jakarta.faces.resource/theme.css?ln=layout&v=1_0&loc=en&con=blue&a=1&b=2", resource.getRequestPath());
     }
 
     private String extensionOf(String resourceName) {

--- a/impl/src/test/java/org/glassfish/mojarra/el/ResourceELResolverQueryStringTest.java
+++ b/impl/src/test/java/org/glassfish/mojarra/el/ResourceELResolverQueryStringTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.mojarra.el;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.el.ELContext;
+import jakarta.el.ELException;
+import jakarta.faces.application.Resource;
+import jakarta.faces.application.ResourceHandler;
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A resource name may carry a query string, as specified in section 2.6.1.3 "Resource Identifiers" of the Jakarta
+ * Faces Specification Document. The colon separating the library name is therefore the one preceding the first '?',
+ * and the query string, which may hold colons of its own, stays with the resource name.
+ */
+class ResourceELResolverQueryStringTest {
+
+    private static final String REQUEST_PATH = "/jakarta.faces.resource/theme.css.xhtml";
+
+    private final ResourceELResolver elResolver = new ResourceELResolver();
+    private final ResourceHandler resourceHandler = mock(ResourceHandler.class);
+    private final ELContext elContext = mock(ELContext.class);
+
+    @BeforeEach
+    void letEveryResourceResolveToOneRequestPath() {
+        Resource resource = mock(Resource.class);
+        when(resource.getRequestPath()).thenReturn(REQUEST_PATH);
+        when(resourceHandler.createResource(anyString())).thenReturn(resource);
+        when(resourceHandler.createResource(anyString(), anyString())).thenReturn(resource);
+
+        FacesContext facesContext = mock(FacesContext.class);
+        ExternalContext externalContext = mock(ExternalContext.class);
+        when(elContext.getContext(FacesContext.class)).thenReturn(facesContext);
+        when(facesContext.getExternalContext()).thenReturn(externalContext);
+        when(externalContext.encodeResourceURL(REQUEST_PATH)).thenReturn(REQUEST_PATH);
+    }
+
+    @Test
+    void aColonInTheQueryStringDoesNotSeparateTheLibraryName() {
+        assertEquals(REQUEST_PATH, elResolver.getValue(elContext, resourceHandler, "lib:theme.css?v=1:2"));
+
+        verify(resourceHandler).createResource("theme.css?v=1:2", "lib");
+    }
+
+    @Test
+    void aColonInTheQueryStringDoesNotIntroduceALibraryName() {
+        assertEquals(REQUEST_PATH, elResolver.getValue(elContext, resourceHandler, "theme.css?v=1:2"));
+
+        verify(resourceHandler).createResource("theme.css?v=1:2");
+    }
+
+    @Test
+    void aQueryStringMayHoldMoreThanOneColon() {
+        assertEquals(REQUEST_PATH, elResolver.getValue(elContext, resourceHandler, "lib:theme.css?a=1:2&b=3:4"));
+
+        verify(resourceHandler).createResource("theme.css?a=1:2&b=3:4", "lib");
+    }
+
+    @Test
+    void moreThanOneColonBeforeTheQueryStringIsStillInvalid() {
+        assertThrows(ELException.class, () -> elResolver.getValue(elContext, resourceHandler, "lib:sub:theme.css?v=1"));
+    }
+
+}

--- a/impl/src/test/java/org/glassfish/mojarra/util/UtilQueryStringTest.java
+++ b/impl/src/test/java/org/glassfish/mojarra/util/UtilQueryStringTest.java
@@ -13,10 +13,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-package org.glassfish.mojarra.application.resource;
+package org.glassfish.mojarra.util;
 
-import static org.glassfish.mojarra.application.resource.ResourceHandlerImpl.getQueryString;
-import static org.glassfish.mojarra.application.resource.ResourceHandlerImpl.removeQueryString;
+import static org.glassfish.mojarra.util.Util.getQueryString;
+import static org.glassfish.mojarra.util.Util.removeQueryString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
  * Jakarta Faces Specification Document, is split into the file identifying part, which resolves the resource, and the
  * query string, which is appended to the request path.
  */
-class ResourceHandlerImplQueryStringTest {
+class UtilQueryStringTest {
 
     @Test
     void keepsResourceNameWithoutQueryString() {


### PR DESCRIPTION
Implements jakartaee/faces#2242, which blesses a resource name carrying a query string and specifies it centrally rather than per renderer.

**Depends on jakartaee/faces#2244.** The `faces` submodule is pinned to that PR's branch, because dropping the `markResourceRendered()`/`isResourceRendered()` overrides here relies on the API default it introduces. The submodule needs re-pointing at 5.0 once it merges; the two cannot merge independently.

### Resolve a resource name carrying a query string centrally

`createResource()` splits the query string off and hands it to `ResourceImpl`, which appends it to the resource metadata it builds for `getRequestPath()`. Previously `ScriptStyleBaseRenderer` did this by itself, which left `h:graphicImage` and `#{resource['lib:name?v=1']}` without it, and left every other consumer of the name looking at a string that does not identify a file.

With the handling central, the renderer needs no part in it, so its splitting and re-appending is gone. The rendered URL is unchanged: `HtmlUtils.encodeURIString` escapes the ampersand joining two query parameters exactly as the renderer did by hand, and `isAmpEscaped` is what kept its pre-escaped `&amp;` from being escaped twice.

### Derive the renderer type from the resource name, not the content type

`ResourceHandler.getRendererTypeForResourceName()` states its mapping over the resource name — `mycomponent.js` is a script, `mystyle.css` is a stylesheet. Reading it from `ExternalContext.getMimeType()` made it depend on the container's mime table: WildFly maps `.js` to `application/javascript`, so the match against `text/javascript` failed and a `@ResourceDependency` on a script silently lost its renderer type.

Note the behavior change: a resource with no recognizable extension whose container mime type happened to be `text/javascript` now maps to `null` where it previously mapped to Script.

### Take the renderer type of a script or stylesheet from its renderer

`ScriptRenderer` and `StylesheetRenderer` now state their own renderer type and file extension next to the content type they already state, and the eight places that repeated the literal name it instead. `MojarraRuntimePopulator` keeps its literals — its table states every component family, renderer type and renderer class the same way, and two rows reading differently from the other forty costs more than the repetition saves.

### Testing

`ResourceImplTest` covers the query string appended with and without other resource metadata; `ResourceHandlerImplQueryStringTest` covers the split, including a trailing bare `?`; `ResourceHandlerImplRendererTypeTest` pins the extension mapping, its case insensitivity, and its tolerance of a query string. Full `impl` unit suite green.

TCK green on `faces20/resource`, `faces22/render-kit`, `faces22/ajax-lifecycle`, `faces23/resource-basic-in-jar`, `faces50/facelets` and `faces50/misc`, including `Issue2172IT`, `Issue4345IT`, `Issue5676IT` and the new `Spec2242IT`.

🤖 Generated with Claude Opus 5
