### PR TITLE
Fix #5976: Do not defer a pass-through on* attribute where mojarra.ael() cannot reach it

### DIFF
--- a/impl/src/main/java/org/glassfish/mojarra/facelets/tag/ui/UIDebug.java
+++ b/impl/src/main/java/org/glassfish/mojarra/facelets/tag/ui/UIDebug.java
@@ -104,7 +104,7 @@ public final class UIDebug extends UIComponentBase {
             writer.startElement("span", this);
             writer.writeAttribute("id", getClientId(facesContext), "id");
             
-            RenderKitUtils.renderScript(facesContext, this, null, sb.toString());
+            RenderKitUtils.renderScript(facesContext, null, sb.toString());
 
             writer.endElement("span");
         }

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/RenderKitUtils.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/RenderKitUtils.java
@@ -24,9 +24,12 @@ import static org.glassfish.mojarra.renderkit.RenderKitUtils.PredefinedPostbackP
 import static org.glassfish.mojarra.renderkit.RenderKitUtils.PredefinedPostbackParameter.BEHAVIOR_SOURCE_PARAM;
 import static org.glassfish.mojarra.renderkit.RenderKitUtils.PredefinedPostbackParameter.PARTIAL_EVENT_PARAM;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Writer;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -35,6 +38,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
@@ -152,6 +156,39 @@ public class RenderKitUtils {
     private static final String PENDING_BEHAVIOR_EVENT_LISTENERS_KEY = UIComponentBase.class.getName() + ".pendingBehaviorEventListeners";
 
     private static final String BEHAVIOR_EVENT_ATTRIBUTE_PREFIX = "on";
+
+    /**
+     * The elements whose fetch of an external resource starts as the element is parsed, and whose {@code load} and
+     * {@code error} can therefore already have been dispatched by the time any script following the element runs.
+     */
+    private static final Set<String> DELEGATED_BEHAVIOR_EVENT_ELEMENTS = Set.of("script", "link", "img", "iframe");
+
+    /**
+     * The behavior event attributes which are delegated to {@code behavior-event-bootstrap.ts} instead of being wired
+     * afterwards by {@code mojarra.ael()}. Their events are dispatched at an element whose fetch of an external
+     * resource starts as the element is parsed, so they can already have fired by the time any script following the
+     * element runs. Only a listener installed before the element is parsed observes them.
+     */
+    private static final Set<String> DELEGATED_BEHAVIOR_EVENT_ATTRIBUTES = Set.of("onload", "onerror");
+
+    /**
+     * The name prefix of the attribute which carries a delegated behavior event attribute's script to the bootstrap.
+     * The bootstrap derives the very same name from the event type, so the two must spell it identically.
+     */
+    public static final String DELEGATED_BEHAVIOR_EVENT_ATTRIBUTE_PREFIX = "data-mojarra-";
+
+    /**
+     * The name of the attribute which marks a script that depends on nothing around it. The ajax response matches this
+     * very name to run such a script before the markup it came with goes live, so the two must spell it identically.
+     */
+    public static final String INDEPENDENT_SCRIPT_ATTRIBUTE = DELEGATED_BEHAVIOR_EVENT_ATTRIBUTE_PREFIX + "independent";
+
+    /**
+     * The name of the classpath resource holding the bootstrap of the delegated behavior event attributes. It is
+     * produced from {@code behavior-event-bootstrap.ts} by the same build which produces {@code faces.js}, but is
+     * rendered inline rather than served, as it must run before the first element which can carry one is parsed.
+     */
+    private static final String BEHAVIOR_EVENT_BOOTSTRAP_RESOURCE_NAME = "behavior-event-bootstrap.js";
 
     protected static final Logger LOGGER = FacesLogger.RENDERKIT.getLogger();
 
@@ -520,7 +557,7 @@ public class RenderKitUtils {
         ClientBehaviorContext behaviorContext = ClientBehaviorContext.createClientBehaviorContext(context, component, FacesComponentEvent.action.name(), submitTarget, params);
         AjaxBehavior behavior = (AjaxBehavior) context.getApplication().createBehavior(AjaxBehavior.BEHAVIOR_ID);
         mapAttributes(component, behavior, "execute", "render", "onerror", "onevent", "resetValues");
-        renderScript(context, component, null, behavior.getScript(behaviorContext));
+        renderScript(context, null, behavior.getScript(behaviorContext));
     }
 
     private static void mapAttributes(UIComponent component, AjaxBehavior behavior, String... attributeNames) {
@@ -845,6 +882,167 @@ public class RenderKitUtils {
 
     public static boolean isBehaviorEventAttribute(String name) {
         return name.startsWith(BEHAVIOR_EVENT_ATTRIBUTE_PREFIX) && name.length() > 2;
+    }
+
+    /**
+     * Returns whether the given component carries a behavior event attribute, as a renderer specific attribute or as a
+     * pass-through attribute. All but the delegated ones are wired by {@code mojarra.ael()}, which locates its element
+     * by the component's client id, so an element carrying one must also carry that id.
+     *
+     * @param component the component to check
+     * @return whether the given component carries a behavior event attribute
+     */
+    public static boolean hasBehaviorEventAttribute(UIComponent component) {
+        Map<String, Object> passThroughAttributes = component.getPassThroughAttributes(false);
+
+        if (passThroughAttributes != null) {
+            for (String name : passThroughAttributes.keySet()) {
+                if (isBehaviorEventAttribute(name)) {
+                    return true;
+                }
+            }
+        }
+
+        if (component.getClass().getName().startsWith(OPTIMIZED_PACKAGE)) {
+            for (String name : getAttributesThatAreSet(component)) {
+                if (isSupportedBehaviorEventAttribute(component, name)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        // A component outside that package maintains no set-attributes list, and a typed on* property of it is in
+        // neither that list nor the attribute map's key set, so it is read the way the render path reads it.
+        if (component instanceof ClientBehaviorHolder clientBehaviorHolder) {
+            Collection<String> eventNames = clientBehaviorHolder.getEventNames();
+
+            if (eventNames != null) {
+                for (String eventName : eventNames) {
+                    if (component.getAttributes().get(BEHAVIOR_EVENT_ATTRIBUTE_PREFIX + eventName) != null) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        for (String name : component.getAttributes().keySet()) {
+            if (isBehaviorEventAttribute(name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns whether the given attribute on the given element is to be delegated to the behavior event bootstrap.
+     * Only the elements whose fetch of an external resource starts as the element is parsed qualify, as those are the
+     * ones whose event can be dispatched before any script following the element runs. On any other element the event
+     * is dispatched late enough for {@code mojarra.ael()} to have been wired, and on {@code body} the event is
+     * dispatched at the window rather than at the element, where the bootstrap would never see it.
+     *
+     * @param elementName the name of the element being written
+     * @param name the attribute name
+     * @return whether the given attribute on the given element is to be delegated
+     */
+    public static boolean isDelegatedBehaviorEventAttribute(String elementName, String name) {
+        return isDelegatedBehaviorEventElement(elementName) && DELEGATED_BEHAVIOR_EVENT_ATTRIBUTES.contains(toLowerCase(name));
+    }
+
+    /**
+     * Returns the name under which a delegated behavior event attribute is carried to the bootstrap. The bootstrap
+     * derives the very same name from the event type, which is always lower case.
+     *
+     * @param name the attribute name
+     * @return the name under which the given attribute is carried to the bootstrap
+     */
+    public static String getDelegatedBehaviorEventAttributeName(String name) {
+        return DELEGATED_BEHAVIOR_EVENT_ATTRIBUTE_PREFIX + toLowerCase(name);
+    }
+
+    /**
+     * Returns whether any of the given pass-through attributes of the given element is to be delegated, which is what
+     * tells the writer that it must put the bootstrap ahead of that element.
+     *
+     * @param elementName the name of the element being written
+     * @param passThroughAttributes the pass-through attributes of the element being written
+     * @return whether any of the given pass-through attributes of the given element is to be delegated
+     */
+    public static boolean hasDelegatedBehaviorEventAttribute(String elementName, Map<String, Object> passThroughAttributes) {
+        if (!isDelegatedBehaviorEventElement(elementName)) {
+            return false;
+        }
+
+        for (String name : passThroughAttributes.keySet()) {
+            if (DELEGATED_BEHAVIOR_EVENT_ATTRIBUTES.contains(toLowerCase(name))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean isDelegatedBehaviorEventElement(String elementName) {
+        return elementName != null && DELEGATED_BEHAVIOR_EVENT_ELEMENTS.contains(toLowerCase(elementName));
+    }
+
+    private static String toLowerCase(String name) {
+        return name.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Returns the behavior event bootstrap, for the writer to put ahead of the first element carrying a delegated
+     * attribute.
+     *
+     * @return the behavior event bootstrap
+     */
+    public static String getBehaviorEventBootstrap() {
+        return BehaviorEventBootstrap.get();
+    }
+
+    /**
+     * Reads {@value #BEHAVIOR_EVENT_BOOTSTRAP_RESOURCE_NAME} on first use, so that a build which failed to produce it
+     * takes down only the views which need it rather than every use of this class.
+     */
+    private static final class BehaviorEventBootstrap {
+
+        private static final String SCRIPT;
+        private static final IOException FAILURE;
+
+        static {
+            String script = null;
+            IOException failure = null;
+
+            try (InputStream input = RenderKitUtils.class.getResourceAsStream(BEHAVIOR_EVENT_BOOTSTRAP_RESOURCE_NAME)) {
+                if (input == null) {
+                    throw new FileNotFoundException(BEHAVIOR_EVENT_BOOTSTRAP_RESOURCE_NAME);
+                }
+
+                script = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+            }
+            catch (IOException e) {
+                failure = e;
+            }
+
+            SCRIPT = script;
+            FAILURE = failure;
+        }
+
+        /**
+         * Returns the script, or throws the failure of reading it. The failure is thrown from here rather than from
+         * the static initializer, so that every caller gets it and not only the first one.
+         */
+        private static String get() {
+            if (FAILURE != null) {
+                throw new FacesException("Cannot read " + BEHAVIOR_EVENT_BOOTSTRAP_RESOURCE_NAME, FAILURE);
+            }
+
+            return SCRIPT;
+        }
     }
 
     /**
@@ -1828,7 +2026,7 @@ public class RenderKitUtils {
         }
         else {
             renderFacesJsIfNecessary(context);
-            renderScript(context, component, null, script.toString());
+            renderScript(context, null, script.toString());
         }
     }
 
@@ -1868,10 +2066,11 @@ public class RenderKitUtils {
         out.append('\'');
     }
 
-    public static void renderScript(FacesContext context, UIComponent component, String clientId, String script) throws IOException {
+    public static void renderScript(FacesContext context, String clientId, String script) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
 
-        writer.startElement("script", component);
+        // Started without the component, so that this generated script does not inherit its pass-through attributes.
+        writer.startElement("script", null);
 
         if (clientId != null) {
             writer.writeAttribute("id", clientId, "id");
@@ -1887,7 +2086,7 @@ public class RenderKitUtils {
             writer.writeAttribute("nonce", nonce, "nonce");
         }
 
-        writer.writeText(script, component, null);
+        writer.writeText(script, null, null);
         writer.endElement("script");
     }
 

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/CommandScriptRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/CommandScriptRenderer.java
@@ -106,6 +106,7 @@ public class CommandScriptRenderer extends HtmlBasicRenderer {
         assert writer != null;
 
         writer.endElement("span");
+        RenderKitUtils.flushPendingBehaviorEventListeners(context, component, null);
     }
 
     @Override

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/HiddenRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/HiddenRenderer.java
@@ -24,6 +24,8 @@ import jakarta.faces.component.UIComponent;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.context.ResponseWriter;
 
+import org.glassfish.mojarra.renderkit.RenderKitUtils;
+
 /**
  * <B>HiddenRenderer</B> is a class that renders the current value of <code>UIInput</code> component as a HTML hidden
  * variable.
@@ -55,6 +57,7 @@ public class HiddenRenderer extends HtmlBasicInputRenderer {
             writer.writeAttribute("value", currentValue, "value");
         }
         writer.endElement("input");
+        RenderKitUtils.flushPendingBehaviorEventListeners(context, component, null);
 
     }
 

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/HtmlBasicRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/HtmlBasicRenderer.java
@@ -605,16 +605,23 @@ public abstract class HtmlBasicRenderer extends Renderer<UIComponent> {
         //
         // - We have a non-auto-generated id, or...
         // - We have client behaviors, or...
-        // - The component is a UICommand (its CSP-style click listener is attached
-        //   via mojarra.ael(clientId, ...) which needs the id on the rendered element).
+        // - The component is a UICommand, or...
+        // - The component carries a behavior event attribute.
         //
+        // The last two are attached via mojarra.ael(clientId, ...) which needs the id on the rendered element.
         // We assume that if client behaviors are present, they
         // may need access to the id (AjaxBehavior certainly does).
 
-        String id;
-        return null != (id = component.getId()) && (!id.startsWith(UIViewRoot.UNIQUE_ID_PREFIX)
+        String id = component.getId();
+
+        if (id == null) {
+            return RenderKitUtils.hasBehaviorEventAttribute(component);
+        }
+
+        return !id.startsWith(UIViewRoot.UNIQUE_ID_PREFIX)
                 || component instanceof UICommand
-                || component instanceof ClientBehaviorHolder && !((ClientBehaviorHolder) component).getClientBehaviors().isEmpty());
+                || component instanceof ClientBehaviorHolder && !((ClientBehaviorHolder) component).getClientBehaviors().isEmpty()
+                || RenderKitUtils.hasBehaviorEventAttribute(component);
     }
 
     protected String writeIdAttributeIfNecessary(FacesContext context, ResponseWriter writer, UIComponent component) {

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/HtmlResponseWriter.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/HtmlResponseWriter.java
@@ -142,6 +142,19 @@ public class HtmlResponseWriter extends ResponseWriter {
     // pending-behavior-event-listeners map. May be null if startElement was called without a component.
     private UIComponent currentComponent;
 
+    // The id attribute written on the element currently being started, if any. A deferred on* pass-through attribute
+    // is wired by mojarra.ael(), which locates its element by the component's client id, so the handler can only be
+    // deferred when the element actually carries that very id.
+    private String currentElementId;
+
+    // Name of the element currently being started, so that the delegation rule is applied to the element the
+    // pass-through attributes are written onto.
+    private String currentElementName;
+
+    // Whether the behavior event bootstrap is already in the response being written. Cleared in startDocument, so
+    // that a response which is reset and rendered anew gets the bootstrap again.
+    private boolean behaviorEventBootstrapWritten;
+
     // Internal buffer for to store the result of String.getChars() for
     // values passed to the writer as String to reduce the overhead
     // of String.charAt(). This buffer will be grown, if necessary, to
@@ -152,6 +165,10 @@ public class HtmlResponseWriter extends ResponseWriter {
 
     private Deque<String> elementNames;
 
+    private static final String SCRIPT_CDATA_START = "\n//<![CDATA[\n";
+    private static final String SCRIPT_CDATA_END = "\n//]]>\n";
+    private static final String STYLE_CDATA_START = "\n<![CDATA[\n";
+    private static final String STYLE_CDATA_END = "\n]]>\n";
     private static final String BREAKCDATA = "]]><![CDATA[";
     private static final char[] ESCAPEDSINGLEBRACKET = ("]" + BREAKCDATA).toCharArray();
     private static final char[] ESCAPEDLT = ("&lt;" + BREAKCDATA).toCharArray();
@@ -318,6 +335,7 @@ public class HtmlResponseWriter extends ResponseWriter {
                     isScriptInAttributeValueEnabled, disableUnicodeEscaping, isPartial);
             responseWriter.dontEscape = dontEscape;
             responseWriter.writingCdata = writingCdata;
+            responseWriter.behaviorEventBootstrapWritten = behaviorEventBootstrapWritten;
             return responseWriter;
 
         } catch (FacesException e) {
@@ -377,7 +395,7 @@ public class HtmlResponseWriter extends ResponseWriter {
             dontEscape = false;
         }
 
-        isXhtml = getContentType().equals(RIConstants.XHTML_CONTENT_TYPE);
+        isXhtml = RIConstants.XHTML_CONTENT_TYPE.equals(getContentType());
 
         if (isScriptOrStyle(kind) && !scriptOrStyleSrc && writer instanceof FastStringWriter) {
             String result = ((FastStringWriter) writer).getBuffer().toString();
@@ -434,15 +452,7 @@ public class HtmlResponseWriter extends ResponseWriter {
                     }
                 }
             }
-            if (isXhtml) {
-                if (!writingCdata) {
-                    if (isScript) {
-                        writer.write("\n//]]>\n");
-                    } else {
-                        writer.write("\n]]>\n");
-                    }
-                }
-            }
+            writeCdataEndIfNecessary();
         }
 
         if (!withinScript || isScript) {
@@ -505,7 +515,7 @@ public class HtmlResponseWriter extends ResponseWriter {
     @Override
     public void startDocument() throws IOException {
 
-        // do nothing;
+        behaviorEventBootstrapWritten = false;
 
     }
 
@@ -552,15 +562,26 @@ public class HtmlResponseWriter extends ResponseWriter {
         }
 
         currentComponent = componentForElement;
+        currentElementId = null;
+        Map<String, Object> passThroughAttrs = null;
+
         if (null != componentForElement) {
-            Map<String, Object> passThroughAttrs = componentForElement.getPassThroughAttributes(false);
+            passThroughAttrs = componentForElement.getPassThroughAttributes(false);
             if (null != passThroughAttrs && !passThroughAttrs.isEmpty()) {
                 considerPassThroughAttributes(passThroughAttrs);
             }
         }
 
-        writer.write('<');
+        // Resolved before anything is written, as the pass-through localName can rename the element and it is the
+        // rendered element which decides whether its handler can outrun the wiring.
         String elementName = pushElementName(name);
+        currentElementName = elementName;
+
+        if (null != passThroughAttrs && !passThroughAttrs.isEmpty()) {
+            writeBehaviorEventBootstrapIfNecessary(elementName, passThroughAttrs);
+        }
+
+        writer.write('<');
         writer.write(elementName);
 
         closeStart = true;
@@ -665,6 +686,10 @@ public class HtmlResponseWriter extends ResponseWriter {
 
         if (name.equalsIgnoreCase("src") && isScriptOrStyle()) {
             scriptOrStyleSrc = true;
+        }
+
+        if (name.equalsIgnoreCase("id")) {
+            currentElementId = value.toString();
         }
 
         Class<?> valueClass = value.getClass();
@@ -993,16 +1018,8 @@ public class HtmlResponseWriter extends ResponseWriter {
             writer.write('>');
             closeStart = false;
             if (isScriptOrStyle() && !scriptOrStyleSrc) {
-                isXhtml = getContentType().equals(RIConstants.XHTML_CONTENT_TYPE);
-                if (isXhtml) {
-                    if (!writingCdata) {
-                        if (isScript) {
-                            writer.write("\n//<![CDATA[\n");
-                        } else {
-                            writer.write("\n<![CDATA[\n");
-                        }
-                    }
-                }
+                isXhtml = RIConstants.XHTML_CONTENT_TYPE.equals(getContentType());
+                writeCdataStartIfNecessary();
                 origWriter = writer;
                 if (scriptBuffer == null) {
                     scriptBuffer = new FastStringWriter(1024);
@@ -1046,6 +1063,20 @@ public class HtmlResponseWriter extends ResponseWriter {
         writePassthroughAttributes(passthroughAttributes);
     }
 
+    /**
+     * Write the given pass-through attributes onto the currently open start tag. A behavior event attribute, whose name
+     * starts with {@code on}, is written without an inline handler where the runtime can still guarantee that its
+     * script runs on the event, in one of two ways. A delegated one is renamed to its
+     * {@value RenderKitUtils#DELEGATED_BEHAVIOR_EVENT_ATTRIBUTE_PREFIX} counterpart and picked up by the bootstrap
+     * which this writer has put ahead of it. Any other is wired afterwards by {@code mojarra.ael()}, which
+     * locates its element by the component's client id and therefore needs the element to carry that very id. An
+     * element which qualifies for neither gets the handler inline, as a handler which is dropped or attached too late
+     * is no handler at all.
+     *
+     * @param attrs the pass-through attributes to write
+     * @throws IOException if an input/output error occurs
+     * @throws IllegalStateException if there is no currently open element
+     */
     public void writePassthroughAttributes(Map<String, Object> attrs) throws IOException {
         if (attrs == null || attrs.isEmpty()) {
             return;
@@ -1054,20 +1085,107 @@ public class HtmlResponseWriter extends ResponseWriter {
             throw new IllegalStateException("Cannot write passthrough attributes when there is no currently open element");
         }
         FacesContext context = FacesContext.getCurrentInstance();
+        Map<String, String> resolved = new LinkedHashMap<>(attrs.size());
+
         for (Map.Entry<String, Object> entry : attrs.entrySet()) {
-            Object valObj = entry.getValue();
-            String val = getAttributeValue(context, valObj);
+            String val = getAttributeValue(context, entry.getValue());
+
             if (val != null) {
-                String key = entry.getKey();
-                if ("styleClass".equals(key)) {
-                    key = "class";
-                }
-                if (currentComponent != null && RenderKitUtils.isBehaviorEventAttribute(key)) {
-                    RenderKitUtils.addEventListener(context, currentComponent, key.substring(2), val);
-                } else {
-                    writeURIAttributeIgnoringPassThroughAttributes(key, val, key, true);
-                }
+                resolved.put(entry.getKey(), val);
             }
+        }
+
+        String elementId = resolved.containsKey("id") ? resolved.get("id") : currentElementId;
+        boolean elementIsAddressable = context != null && currentComponent != null && elementId != null
+                && elementId.equals(currentComponent.getClientId(context));
+        for (Map.Entry<String, String> entry : resolved.entrySet()) {
+            String key = entry.getKey();
+            String val = entry.getValue();
+
+            if ("styleClass".equals(key)) {
+                key = "class";
+            }
+
+            boolean delegated = RenderKitUtils.isDelegatedBehaviorEventAttribute(currentElementName, key);
+
+            if (delegated && behaviorEventBootstrapWritten) {
+                writeURIAttributeIgnoringPassThroughAttributes(RenderKitUtils.getDelegatedBehaviorEventAttributeName(key), val, key, true);
+            }
+            // A delegated attribute without its bootstrap goes inline: mojarra.ael() attaches after the element is
+            // parsed, which is too late for the very events which are delegated.
+            else if (!delegated && elementIsAddressable && RenderKitUtils.isBehaviorEventAttribute(key)) {
+                RenderKitUtils.addEventListener(context, currentComponent, key.substring(2), val);
+            }
+            else {
+                writeURIAttributeIgnoringPassThroughAttributes(key, val, key, true);
+            }
+        }
+    }
+
+    /**
+     * Writes the behavior event bootstrap ahead of the element being started, when that element carries a delegated
+     * behavior event attribute and the bootstrap is not already in the response. It goes out as raw markup, as the
+     * element methods of this writer would touch the bookkeeping of the element being started.
+     */
+    private void writeBehaviorEventBootstrapIfNecessary(String elementName, Map<String, Object> passThroughAttrs) throws IOException {
+        if (behaviorEventBootstrapWritten || !RenderKitUtils.hasDelegatedBehaviorEventAttribute(elementName, passThroughAttrs)) {
+            return;
+        }
+
+        behaviorEventBootstrapWritten = true;
+        FacesContext context = FacesContext.getCurrentInstance();
+        String nonce = context != null ? context.getApplication().getResourceHandler().getCurrentNonce(context) : null;
+        // Both are recomputed at each use, and are set here for the CDATA writers below.
+        boolean wasScript = isScript;
+        boolean wasXhtml = isXhtml;
+        isScript = true;
+        isXhtml = RIConstants.XHTML_CONTENT_TYPE.equals(getContentType());
+
+        writer.write("<script ");
+        writer.write(RenderKitUtils.INDEPENDENT_SCRIPT_ATTRIBUTE);
+
+        if (context != null && !RenderKitUtils.isOutputHtml5Doctype(context)) {
+            writer.write(" type=\"");
+            writer.write(ScriptRenderer.DEFAULT_CONTENT_TYPE);
+            writer.write('"');
+        }
+
+        if (nonce != null) {
+            writer.write(" nonce=\"");
+            ensureTextBufferCapacity(nonce);
+            HtmlUtils.writeAttribute(writer, escapeUnicode, escapeIso, nonce, textBuffer, isScriptInAttributeValueEnabled, isPartial);
+            writer.write('"');
+        }
+
+        writer.write('>');
+
+        // The script is written as-is, so it needs the CDATA section itself, which the buffered path gets from
+        // closeStartIfNecessary and endElement.
+        writeCdataStartIfNecessary();
+        writer.write(RenderKitUtils.getBehaviorEventBootstrap());
+        writeCdataEndIfNecessary();
+        writer.write("</script>");
+        isScript = wasScript;
+        isXhtml = wasXhtml;
+    }
+
+    /**
+     * Writes the start of the CDATA section which wraps the content of a script or style element, if the response is
+     * XML and no section is open yet.
+     */
+    private void writeCdataStartIfNecessary() throws IOException {
+        if (isXhtml && !writingCdata) {
+            writer.write(isScript ? SCRIPT_CDATA_START : STYLE_CDATA_START);
+        }
+    }
+
+    /**
+     * Writes the end of the CDATA section which {@link #writeCdataStartIfNecessary()} started, under the same
+     * condition.
+     */
+    private void writeCdataEndIfNecessary() throws IOException {
+        if (isXhtml && !writingCdata) {
+            writer.write(isScript ? SCRIPT_CDATA_END : STYLE_CDATA_END);
         }
     }
 
@@ -1120,9 +1238,8 @@ public class HtmlResponseWriter extends ResponseWriter {
     }
 
     private String getElementName(String name) {
-        // The passthrough localName applies only to the element itself, never to framework-generated
-        // <script>/<style> elements (e.g. the CSP behavior-listener script written by renderScript()
-        // for a passthrough element that holds a client behavior such as f:ajax).
+        // The passthrough localName applies only to the element itself, never to a framework-generated
+        // <script>/<style> element.
         ElementKind kind = ElementKind.of(name);
         if (kind != ElementKind.SCRIPT && kind != ElementKind.STYLE
                 && containsPassThroughAttribute(Renderer.PASSTHROUGH_RENDERER_LOCALNAME_KEY)) {

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/MessageRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/MessageRenderer.java
@@ -116,6 +116,7 @@ public class MessageRenderer extends HtmlBasicRenderer {
                 writer.startElement("span", component);
                 writeIdAttributeIfNecessary(context, writer, component);
                 writer.endElement("span");
+                RenderKitUtils.flushPendingBehaviorEventListeners(context, component, null);
             } // otherwise, return without rendering
             return;
         }
@@ -228,6 +229,7 @@ public class MessageRenderer extends HtmlBasicRenderer {
 
         if (wroteSpan || wroteTooltip) {
             writer.endElement("span");
+            RenderKitUtils.flushPendingBehaviorEventListeners(context, component, null);
         }
 
     }

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/OutputMessageRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/OutputMessageRenderer.java
@@ -130,6 +130,7 @@ public class OutputMessageRenderer extends HtmlBasicInputRenderer {
         }
         if (wroteSpan) {
             writer.endElement("span");
+            RenderKitUtils.flushPendingBehaviorEventListeners(context, component, null);
         }
 
     }

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/TextRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/TextRenderer.java
@@ -179,6 +179,7 @@ public class TextRenderer extends HtmlBasicInputRenderer {
         if (isOutput && (styleClass != null || style != null || dir != null || lang != null || title != null || hasPassthroughAttributes
                 || shouldWriteIdAttribute)) {
             writer.endElement("span");
+            RenderKitUtils.flushPendingBehaviorEventListeners(context, component, null);
         }
 
     }

--- a/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/WebsocketRenderer.java
+++ b/impl/src/main/java/org/glassfish/mojarra/renderkit/html_basic/WebsocketRenderer.java
@@ -94,7 +94,7 @@ public class WebsocketRenderer extends HtmlBasicRenderer implements ComponentSys
 
             RenderKitUtils.renderFacesJsIfNecessary(context);
 
-            RenderKitUtils.renderScript(context, component, clientId, String.format(SCRIPT_INIT, clientId, url, channel, functions, behaviors, connected));
+            RenderKitUtils.renderScript(context, clientId, String.format(SCRIPT_INIT, clientId, url, channel, functions, behaviors, connected));
         }
     }
 

--- a/impl/src/main/ts/behavior-event-bootstrap.ts
+++ b/impl/src/main/ts/behavior-event-bootstrap.ts
@@ -1,0 +1,79 @@
+/*
+ * Bundle entry for the delegated behavior event attribute bootstrap.
+ *
+ * Rendered inline, ahead of every element which can carry a `data-mojarra-on*` attribute, and therefore deliberately
+ * kept apart from the faces.js bundle: it must run before the first resource element is parsed, which a `<script src>`
+ * anywhere in the document cannot be relied upon to do.
+ *
+ * The `load` and `error` of an element whose fetch of an external resource starts as the element is parsed can be
+ * dispatched before any script following the element runs, so a handler for those cannot be attached to the element
+ * afterwards. It is carried by the attribute instead and run from here. The listeners capture at the window because a
+ * resource load event does not bubble.
+ */
+
+import { executeScriptWithNonce, getHead, getNonce, WindowAsDict } from "./faces/dom";
+
+const ATTRIBUTE_PREFIX = "data-mojarra-on";
+const SLOT_PREFIX = "__mojarraDelegated";
+const INSTALLED_SLOT = SLOT_PREFIX + "Installed";
+
+const nonce = getNonce();
+
+// Distinct per invocation, so that a handler which synchronously dispatches another delegated event does not have its
+// own slots deleted by the nested run before it reads its result back.
+let slotSequence = 0;
+
+/**
+ * Runs the script of the delegated behavior event attribute matching the given event, if its target carries one. The
+ * script is evaluated through a nonce bearing script element rather than through `eval()`, so that it also runs under
+ * a Content Security Policy, and is removed first so that it runs at most once.
+ */
+function run(event: Event): void {
+    const element = event.target as Element;
+    const name = ATTRIBUTE_PREFIX + event.type;
+
+    if (!element || element.nodeType !== Node.ELEMENT_NODE || !element.hasAttribute(name)) {
+        return;
+    }
+
+    const script = element.getAttribute(name);
+    element.removeAttribute(name);
+
+    const w = window as unknown as WindowAsDict;
+    const slot = SLOT_PREFIX + slotSequence++;
+    const thisSlot = slot + "This";
+    const eventSlot = slot + "Event";
+    const resultSlot = slot + "Result";
+    let result: unknown = undefined;
+
+    try {
+        w[thisSlot] = element;
+        w[eventSlot] = event;
+        // The handler body is put on its own line, as a handler ending in a line comment would otherwise comment out
+        // the closing brace of the function it is wrapped in.
+        executeScriptWithNonce(
+            getHead(),
+            "window." + resultSlot + " = (function(event) {\n" + script + "\n}).call(window." + thisSlot + ", window." + eventSlot + ");",
+            nonce);
+        result = w[resultSlot];
+    }
+    finally {
+        delete w[thisSlot];
+        delete w[eventSlot];
+        delete w[resultSlot];
+    }
+
+    if (result === false) {
+        event.preventDefault();
+    }
+}
+
+const global = window as unknown as WindowAsDict;
+
+// An ajax response carrying a delegated attribute brings the bootstrap along again, so the listeners are installed
+// at most once per document however often that happens.
+if (!global[INSTALLED_SLOT]) {
+    global[INSTALLED_SLOT] = true;
+    window.addEventListener("load", run, true);
+    window.addEventListener("error", run, true);
+}

--- a/impl/src/main/ts/faces/ajax.ts
+++ b/impl/src/main/ts/faces/ajax.ts
@@ -205,6 +205,10 @@ export const ajax = (function () {
         // Regex to find type attribute
         const TAG_ATTRIBUTE_TYPE_REGEX = /type="([\S]*?)"/im;
 
+        // Marks a script which depends on nothing around it, so that it runs before the markup it came with goes
+        // live. Must spell the same name as RenderKitUtils.INDEPENDENT_SCRIPT_ATTRIBUTE.
+        const INDEPENDENT_SCRIPT_ATTRIBUTE_REGEX = /\sdata-mojarra-independent(\s|=|$)/im;
+
         /**
          * Get all scripts from supplied string, return them as an array for later processing.
          * @param html a String containing a portion of html
@@ -225,6 +229,41 @@ export const ajax = (function () {
                 scripts.push(scriptStr);
             }
             return scripts;
+        };
+
+        /**
+         * Extract the scripts from the given markup, running those which declare that they must run before that
+         * markup goes live and returning the rest for {@link runScripts}.
+         * @param html a String containing a portion of html
+         * @ignore
+         */
+        const extractScripts = function extractScripts(html: string): RegExpMatchArray[] {
+            const scripts = getScripts(html);
+            runIndependentScripts(scripts);
+            return scripts;
+        };
+
+        /**
+         * Run and remove the scripts which declare themselves independent of the scripts around them.
+         *
+         * {@link runScripts} suspends on every script with a src, resuming in a later task, by which time the markup
+         * is live and any load or error of its resource elements may already have been dispatched. A script which
+         * declares itself independent must observe those, so it runs before the markup goes live.
+         * @param scripts Array of script nodes, from which the independent ones are removed.
+         * @ignore
+         */
+        const runIndependentScripts = function runIndependentScripts(scripts: RegExpMatchArray[]): void {
+            const head = getHead();
+            const nonce = getNonce();
+
+            for (let index = scripts.length - 1; index >= 0; index--) {
+                const scriptStr = scripts[index];
+
+                if (INDEPENDENT_SCRIPT_ATTRIBUTE_REGEX.test(scriptStr[1]) && scriptStr[2]) {
+                    executeScriptWithNonce(head, scriptStr[2], nonce);
+                    scripts.splice(index, 1);
+                }
+            }
         };
 
         /**
@@ -408,7 +447,7 @@ export const ajax = (function () {
 
             // Get scripts from text, then strip them so innerHTML does not see them,
             // then run them after the DOM is in place.
-            const scripts = getScripts(src);
+            const scripts = extractScripts(src);
             src = removeScripts(src);
             temp.innerHTML = src;
             cloneAttributes(temp, element);
@@ -820,7 +859,7 @@ export const ajax = (function () {
                 throw new Error("jakarta.faces.ViewHead not supported - browsers cannot reliably replace the head's contents");
             } else if (id === "jakarta.faces.Resource") {
                 runStylesheets(src);
-                scripts = getScripts(src);
+                scripts = extractScripts(src);
                 runScripts(scripts);
             } else {
                 const element = getElemById(id) as HTMLElement | null;
@@ -854,7 +893,7 @@ export const ajax = (function () {
                         try {
                             runStylesheets(src);
                             // Get scripts from text
-                            scripts = getScripts(src);
+                            scripts = extractScripts(src);
                             // Remove scripts from text
                             const newSrc = removeScripts(src);
                             elementReplace(getBodyElement(newSrc) as HTMLElement, docBody);
@@ -892,7 +931,7 @@ export const ajax = (function () {
 
                     if (isTableInnerElement) {
                         // Get the scripts from the html, then strip and re-run them after insertion.
-                        scripts = getScripts(html);
+                        scripts = extractScripts(html);
                         html = removeScripts(html);
                         // enclose new html inside a table
                         newElementContainer.innerHTML = '<table>' + html + '</table>';
@@ -917,7 +956,7 @@ export const ajax = (function () {
                         deleteNode(newElementContainer);
                     } else if (html.length > 0) {
                         // Get the scripts from the text, then strip and re-run them after insertion.
-                        scripts = getScripts(html);
+                        scripts = extractScripts(html);
                         html = removeScripts(html);
                         newElementContainer.innerHTML = html;
                         const firstChild = newElementContainer.firstChild;
@@ -961,7 +1000,7 @@ export const ajax = (function () {
             const isInTable = tablePattern.test(html);
 
             // Get the scripts from the text, strip them out, then execute them.
-            const scripts = getScripts(html);
+            const scripts = extractScripts(html);
             html = removeScripts(html);
             runScripts(scripts);
             const tempElement = document.createElement('div');

--- a/impl/src/main/ts/package.json
+++ b/impl/src/main/ts/package.json
@@ -4,7 +4,7 @@
         "node": ">=22"
     },
     "scripts": {
-        "build": "rollup --config rollup.config.mjs && terser ../../../target/classes/META-INF/resources/jakarta.faces/faces-uncompressed.js --compress --mangle --ecma 2020 --comments \"/^!/\" -o ../../../target/classes/META-INF/resources/jakarta.faces/faces.js"
+        "build": "rollup --config rollup.config.mjs && terser ../../../target/classes/META-INF/resources/jakarta.faces/faces-uncompressed.js --compress --mangle --ecma 2020 --comments \"/^!/\" -o ../../../target/classes/META-INF/resources/jakarta.faces/faces.js && terser ../../../target/ts/behavior-event-bootstrap-uncompressed.js --compress --mangle --ecma 2020 --comments false -o ../../../target/classes/org/glassfish/mojarra/renderkit/behavior-event-bootstrap.js"
     },
     "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.4",

--- a/impl/src/main/ts/rollup.config.mjs
+++ b/impl/src/main/ts/rollup.config.mjs
@@ -26,20 +26,35 @@ const BANNER = `/*!
  * @description This is the standard implementation of the Faces JavaScript Library.
  */`;
 
-export default {
-    input: "index.ts",
-    output: {
-        file: "../../../target/classes/META-INF/resources/jakarta.faces/faces-uncompressed.js",
-        format: "iife",
-        banner: BANNER,
-        strict: false,
-        generatedCode: { constBindings: true },
+const plugins = () => [
+    typescript({
+        tsconfig: "./tsconfig.json",
+        noEmitOnError: true,
+        compilerOptions: { noEmit: false },
+    }),
+];
+
+export default [
+    {
+        input: "index.ts",
+        output: {
+            file: "../../../target/classes/META-INF/resources/jakarta.faces/faces-uncompressed.js",
+            format: "iife",
+            banner: BANNER,
+            strict: false,
+            generatedCode: { constBindings: true },
+        },
+        plugins: plugins(),
     },
-    plugins: [
-        typescript({
-            tsconfig: "./tsconfig.json",
-            noEmitOnError: true,
-            compilerOptions: { noEmit: false },
-        }),
-    ],
-};
+    {
+        // Rendered inline by the response writer, hence no banner and no place under the served resources.
+        input: "behavior-event-bootstrap.ts",
+        output: {
+            file: "../../../target/ts/behavior-event-bootstrap-uncompressed.js",
+            format: "iife",
+            strict: false,
+            generatedCode: { constBindings: true },
+        },
+        plugins: plugins(),
+    },
+];

--- a/impl/src/main/ts/tsconfig.json
+++ b/impl/src/main/ts/tsconfig.json
@@ -13,5 +13,5 @@
         "noEmit": true,
         "allowSyntheticDefaultImports": true
     },
-    "include": ["index.ts", "faces.ts", "mojarra.ts", "faces/**/*.ts", "types.d.ts"]
+    "include": ["index.ts", "behavior-event-bootstrap.ts", "faces.ts", "mojarra.ts", "faces/**/*.ts", "types.d.ts"]
 }

--- a/impl/src/test/java/org/glassfish/mojarra/renderkit/DelegatedBehaviorEventAttributeTest.java
+++ b/impl/src/test/java/org/glassfish/mojarra/renderkit/DelegatedBehaviorEventAttributeTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.mojarra.renderkit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.StringWriter;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import jakarta.faces.application.Application;
+import jakarta.faces.application.ResourceHandler;
+import jakarta.faces.component.TransientStateHelper;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.render.Renderer;
+
+import org.glassfish.mojarra.renderkit.html_basic.HtmlResponseWriter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The <code>load</code> and <code>error</code> of an element whose fetch of an external resource starts as the element
+ * is parsed can be dispatched before any script following the element runs, so such a handler is carried by a
+ * <code>data-mojarra-on*</code> attribute and run by a bootstrap which the writer puts immediately ahead of that very
+ * element. Any other behavior event attribute is wired afterwards by <code>mojarra.ael()</code>, which locates its
+ * element by the component's client id and therefore needs the element to carry that very id.
+ */
+class DelegatedBehaviorEventAttributeTest {
+
+    private static final String NONCE = "test-nonce";
+
+    private StringWriter output;
+    private HtmlResponseWriter writer;
+
+    @BeforeEach
+    void setUpCurrentFacesContext() throws Exception {
+        writer = newWriter("text/html");
+
+        ResourceHandler resourceHandler = mock(ResourceHandler.class);
+        when(resourceHandler.getCurrentNonce(any(FacesContext.class))).thenReturn(NONCE);
+
+        Application application = mock(Application.class);
+        when(application.getResourceHandler()).thenReturn(resourceHandler);
+
+        FacesContext facesContext = mock(FacesContext.class);
+        when(facesContext.getApplication()).thenReturn(application);
+        when(facesContext.getResponseWriter()).thenReturn(writer);
+        when(facesContext.getAttributes()).thenReturn(new HashMap<>());
+        setCurrentInstance(facesContext);
+        writer.startDocument();
+    }
+
+    @AfterEach
+    void tearDownCurrentFacesContext() throws Exception {
+        setCurrentInstance(null);
+    }
+
+    @Test
+    void theBootstrapPrecedesTheElementWhichCarriesADelegatedAttribute() throws Exception {
+        writeElement("script", attributes("onerror", "fallback()"));
+
+        assertTrue(output.toString().startsWith("<script data-mojarra-independent type=\"text/javascript\" nonce=\"" + NONCE + "\">"), output.toString());
+        assertTrue(output.toString().contains(RenderKitUtils.DELEGATED_BEHAVIOR_EVENT_ATTRIBUTE_PREFIX + "onerror=\"fallback()\""), output.toString());
+        assertFalse(output.toString().contains(" onerror="), output.toString());
+    }
+
+    /**
+     * Under XHTML the response is parsed as XML, where the script body is not character data, so it needs the same
+     * CDATA section that every other script this writer emits gets.
+     */
+    @Test
+    void theBootstrapIsWrappedInCdataForXhtml() throws Exception {
+        writer = newWriter("application/xhtml+xml");
+        writer.startDocument();
+        writeElement("script", attributes("onerror", "fallback()"));
+
+        assertTrue(output.toString().contains("//<![CDATA[\n" + RenderKitUtils.getBehaviorEventBootstrap() + "\n//]]>"), output.toString());
+    }
+
+    /**
+     * The element and attribute names keep the case the page author wrote them in, and the delegation rule is about
+     * the element and event, not about the spelling.
+     */
+    @Test
+    void delegationIgnoresTheCaseOfTheElementAndAttributeName() throws Exception {
+        writeElement("IMG", attributes("onLoad", "init()"));
+
+        assertEquals(1, countBootstraps(), output.toString());
+        assertTrue(output.toString().contains(RenderKitUtils.DELEGATED_BEHAVIOR_EVENT_ATTRIBUTE_PREFIX + "onload=\"init()\""), output.toString());
+    }
+
+    /**
+     * The pass-through localName renames the element, and it is the rendered element which decides whether its
+     * handler can outrun the wiring.
+     */
+    @Test
+    void delegationFollowsTheRenamedElement() throws Exception {
+        writeElement("div", attributes(Renderer.PASSTHROUGH_RENDERER_LOCALNAME_KEY, "img", "onerror", "fallback()"));
+
+        assertEquals(1, countBootstraps(), output.toString());
+        assertTrue(output.toString().contains(RenderKitUtils.DELEGATED_BEHAVIOR_EVENT_ATTRIBUTE_PREFIX + "onerror=\"fallback()\""), output.toString());
+    }
+
+    @Test
+    void delegationIsRefusedForAnElementRenamedOutOfTheDelegatedSet() throws Exception {
+        writeElement("img", attributes(Renderer.PASSTHROUGH_RENDERER_LOCALNAME_KEY, "div", "onerror", "fallback()"));
+
+        assertEquals(0, countBootstraps(), output.toString());
+        assertTrue(output.toString().contains("onerror=\"fallback()\""), output.toString());
+    }
+
+    @Test
+    void theBootstrapIsWrittenOnlyOncePerResponse() throws Exception {
+        writeElement("script", attributes("onerror", "fallback()"));
+        writeElement("link", attributes("onerror", "fallback()"));
+
+        assertEquals(1, countBootstraps(), output.toString());
+    }
+
+    @Test
+    void theBootstrapIsWrittenAgainForAResponseWhichIsRenderedAnew() throws Exception {
+        writeElement("script", attributes("onerror", "fallback()"));
+        writer.startDocument();
+        writeElement("script", attributes("onerror", "fallback()"));
+
+        assertEquals(2, countBootstraps(), output.toString());
+    }
+
+    @Test
+    void anElementWhoseEventCannotOutrunTheWiringIsNotDelegated() throws Exception {
+        writeElement("div", attributes("onerror", "fallback()"));
+
+        assertEquals(0, countBootstraps(), output.toString());
+        assertTrue(output.toString().contains("onerror=\"fallback()\""), output.toString());
+    }
+
+    /**
+     * The <code>load</code> of a body is dispatched at the window rather than at the element, where the bootstrap
+     * would never see it, so it stays inline.
+     */
+    @Test
+    void aBodyIsNotDelegated() throws Exception {
+        writeElement("body", attributes("onload", "init()"));
+
+        assertEquals(0, countBootstraps(), output.toString());
+        assertTrue(output.toString().contains("onload=\"init()\""), output.toString());
+    }
+
+    @Test
+    void anUndelegatedAttributeIsDeferredWhenTheElementCarriesTheComponentClientId() throws Exception {
+        writeElement("button", "form:button", mockComponent("form:button", attributes("onclick", "handle()")));
+
+        assertFalse(output.toString().contains("onclick"), output.toString());
+    }
+
+    @Test
+    void anUndelegatedAttributeIsInlineWhenTheElementIdIsNotTheComponentClientId() throws Exception {
+        writeElement("button", null, mockComponent("form:j_id1", attributes("id", "foo", "onclick", "handle()")));
+
+        assertTrue(output.toString().contains("onclick=\"handle()\""), output.toString());
+    }
+
+    @Test
+    void anUndelegatedAttributeIsInlineAfterAnAddressableElement() throws Exception {
+        writeElement("button", "form:button", mockComponent("form:button", attributes("onclick", "handle()")));
+        writeElement("button", null, mockComponent("form:j_id1", attributes("onclick", "handle()")));
+
+        assertEquals(1, output.toString().split("onclick", -1).length - 1, output.toString());
+    }
+
+    /**
+     * Constructs a writer without a current faces context, as its constructor reads that context, which the mock set
+     * up here does not serve.
+     */
+    private HtmlResponseWriter newWriter(String contentType) throws Exception {
+        FacesContext facesContext = FacesContext.getCurrentInstance();
+        setCurrentInstance(null);
+        output = new StringWriter();
+        HtmlResponseWriter newWriter = new HtmlResponseWriter(output, contentType, "UTF-8");
+        setCurrentInstance(facesContext);
+        return newWriter;
+    }
+
+    private int countBootstraps() {
+        return output.toString().split(Pattern.quote(RenderKitUtils.getBehaviorEventBootstrap()), -1).length - 1;
+    }
+
+    private void writeElement(String elementName, Map<String, Object> passThroughAttributes) throws Exception {
+        writeElement(elementName, null, mockComponent("j_id1", passThroughAttributes));
+    }
+
+    private void writeElement(String elementName, String id, UIComponent component) throws Exception {
+        writer.startElement(elementName, component);
+
+        if (id != null) {
+            writer.writeAttribute("id", id, "id");
+        }
+
+        writer.endElement(elementName);
+        writer.flush();
+    }
+
+    private static Map<String, Object> attributes(String... namesAndValues) {
+        Map<String, Object> attributes = new LinkedHashMap<>();
+
+        for (int i = 0; i < namesAndValues.length; i += 2) {
+            attributes.put(namesAndValues[i], namesAndValues[i + 1]);
+        }
+
+        return attributes;
+    }
+
+    private static UIComponent mockComponent(String clientId, Map<String, Object> passThroughAttributes) {
+        // A deferred handler is parked in the component's transient state, so that has to hold what is put into it.
+        Map<Object, Object> transientState = new HashMap<>();
+        TransientStateHelper transientStateHelper = mock(TransientStateHelper.class);
+        when(transientStateHelper.getTransient(any())).thenAnswer(invocation -> transientState.get(invocation.getArgument(0)));
+        when(transientStateHelper.putTransient(any(), any())).thenAnswer(invocation -> transientState.put(invocation.getArgument(0), invocation.getArgument(1)));
+
+        UIComponent component = mock(UIComponent.class);
+        when(component.getClientId(any(FacesContext.class))).thenReturn(clientId);
+        when(component.getPassThroughAttributes(false)).thenReturn(passThroughAttributes);
+        when(component.getTransientStateHelper()).thenReturn(transientStateHelper);
+        return component;
+    }
+
+    private static void setCurrentInstance(FacesContext facesContext) throws Exception {
+        Method setCurrentInstance = FacesContext.class.getDeclaredMethod("setCurrentInstance", FacesContext.class);
+        setCurrentInstance.setAccessible(true);
+        setCurrentInstance.invoke(null, facesContext);
+    }
+}

--- a/impl/src/test/java/org/glassfish/mojarra/renderkit/html_basic/HtmlBasicRendererIdTest.java
+++ b/impl/src/test/java/org/glassfish/mojarra/renderkit/html_basic/HtmlBasicRendererIdTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.mojarra.renderkit.html_basic;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+
+import jakarta.faces.component.html.HtmlPanelGroup;
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A behavior event attribute is wired by <code>mojarra.ael()</code>, which locates its element by the component's
+ * client id, so a component carrying one gets that id rendered even when the id was auto generated and would
+ * otherwise have been left out.
+ */
+class HtmlBasicRendererIdTest {
+
+    private final GroupRenderer renderer = new GroupRenderer();
+
+    @BeforeEach
+    void setUpCurrentFacesContext() throws Exception {
+        // The supported event names of a component are resolved through the application map.
+        ExternalContext externalContext = mock(ExternalContext.class);
+        when(externalContext.getApplicationMap()).thenReturn(new HashMap<>());
+
+        FacesContext facesContext = mock(FacesContext.class);
+        when(facesContext.getExternalContext()).thenReturn(externalContext);
+        setCurrentInstance(facesContext);
+    }
+
+    @AfterEach
+    void tearDownCurrentFacesContext() throws Exception {
+        setCurrentInstance(null);
+    }
+
+    @Test
+    void anAutoIdIsRenderedForARendererSpecificEventAttribute() {
+        HtmlPanelGroup component = autoIdComponent();
+        component.setOnclick("handle()");
+
+        assertTrue(renderer.shouldWriteIdAttribute(component));
+    }
+
+    @Test
+    void anAutoIdIsRenderedForAPassThroughEventAttribute() {
+        HtmlPanelGroup component = autoIdComponent();
+        component.getPassThroughAttributes(true).put("onerror", "fallback()");
+
+        assertTrue(renderer.shouldWriteIdAttribute(component));
+    }
+
+    /**
+     * A component whose id was never set has none to leave out, so the event attribute is what makes one be generated.
+     */
+    @Test
+    void anAbsentIdIsGeneratedForAnEventAttribute() {
+        HtmlPanelGroup component = new HtmlPanelGroup();
+        component.getPassThroughAttributes(true).put("onerror", "fallback()");
+
+        assertTrue(renderer.shouldWriteIdAttribute(component));
+    }
+
+    /**
+     * A delegated handler travels in its own attribute and needs no id, but the renderer cannot tell which element it
+     * is about to write, so it forces the id for that case too.
+     */
+    @Test
+    void anAutoIdIsRenderedForADelegatedEventAttributeAsWell() {
+        HtmlPanelGroup component = autoIdComponent();
+        component.getPassThroughAttributes(true).put("onload", "init()");
+
+        assertTrue(renderer.shouldWriteIdAttribute(component));
+    }
+
+    @Test
+    void anAutoIdIsNotRenderedForAnAttributeWhichIsNoEventAttribute() {
+        HtmlPanelGroup component = autoIdComponent();
+        component.getPassThroughAttributes(true).put("data-x", "1");
+
+        assertFalse(renderer.shouldWriteIdAttribute(component));
+    }
+
+    @Test
+    void anAbsentIdIsNotGeneratedWithoutAnEventAttribute() {
+        assertFalse(renderer.shouldWriteIdAttribute(new HtmlPanelGroup()));
+    }
+
+    private static void setCurrentInstance(FacesContext facesContext) throws Exception {
+        Method setCurrentInstance = FacesContext.class.getDeclaredMethod("setCurrentInstance", FacesContext.class);
+        setCurrentInstance.setAccessible(true);
+        setCurrentInstance.invoke(null, facesContext);
+    }
+
+    private static HtmlPanelGroup autoIdComponent() {
+        HtmlPanelGroup component = new HtmlPanelGroup();
+        component.setId("j_id1");
+        return component;
+    }
+}

--- a/impl/src/test/ts/spec/behavior-event-bootstrap.test.ts
+++ b/impl/src/test/ts/spec/behavior-event-bootstrap.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the delegated behavior event attribute bootstrap.
+ *
+ * The bootstrap runs the script of a `data-mojarra-on*` attribute when the matching event is dispatched at its element.
+ * It exists for the `load` and `error` of an element whose fetch of an external resource starts as the element is
+ * parsed, which can be dispatched before any script following the element runs, so those handlers cannot be attached
+ * to the element afterwards.
+ *
+ * Only `error` is dispatched here: jsdom does not deliver a `load` dispatched at an element to a window capture
+ * listener, where a browser does, so the `load` half of the contract is covered by an integration test instead.
+ */
+
+import { loadBehaviorEventBootstrap } from "../test-setup";
+
+beforeAll(() => loadBehaviorEventBootstrap());
+
+beforeEach(() => {
+    document.body.innerHTML = "";
+    delete (window as unknown as Record<string, unknown>).probe;
+});
+
+function appendScript(attributes: Record<string, string>): HTMLScriptElement {
+    const script = document.createElement("script");
+
+    for (const [name, value] of Object.entries(attributes)) {
+        script.setAttribute(name, value);
+    }
+
+    document.body.appendChild(script);
+    return script;
+}
+
+function probe(): unknown {
+    return (window as unknown as Record<string, unknown>).probe;
+}
+
+it("runs the handler of the event which was dispatched", () => {
+    const element = appendScript({ "data-mojarra-onerror": "window.probe = 'error'" });
+
+    element.dispatchEvent(new Event("error"));
+
+    expect(probe()).toBe("error");
+});
+
+it("runs the handler with the element as this and the event as event", () => {
+    const element = appendScript({ "data-mojarra-onerror": "window.probe = this.tagName + ':' + event.type" });
+
+    element.dispatchEvent(new Event("error"));
+
+    expect(probe()).toBe("SCRIPT:error");
+});
+
+it("runs the handler at most once", () => {
+    const element = appendScript({ "data-mojarra-onerror": "window.probe = (window.probe || 0) + 1" });
+
+    element.dispatchEvent(new Event("error"));
+    element.dispatchEvent(new Event("error"));
+
+    expect(probe()).toBe(1);
+    expect(element.hasAttribute("data-mojarra-onerror")).toBe(false);
+});
+
+it("leaves an event which the element has no handler for alone", () => {
+    const element = appendScript({ "data-mojarra-onerror": "window.probe = 'error'" });
+
+    element.dispatchEvent(new Event("load"));
+
+    expect(probe()).toBeUndefined();
+    expect(element.hasAttribute("data-mojarra-onerror")).toBe(true);
+});
+
+it("leaves an element without a handler alone", () => {
+    appendScript({ src: "any.js" }).dispatchEvent(new Event("error"));
+
+    expect(probe()).toBeUndefined();
+});
+
+it("prevents the default of an event whose handler returns false", () => {
+    const element = appendScript({ "data-mojarra-onerror": "return false" });
+    const event = new Event("error", { cancelable: true });
+
+    element.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+});
+
+it("does not prevent the default of an event whose handler returns nothing", () => {
+    const element = appendScript({ "data-mojarra-onerror": "window.probe = 'error'" });
+    const event = new Event("error", { cancelable: true });
+
+    element.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+});
+
+it("leaves an event whose target is not an element alone", () => {
+    window.dispatchEvent(new Event("error"));
+    document.dispatchEvent(new Event("error"));
+
+    expect(probe()).toBeUndefined();
+});
+
+it("leaves no window slots behind when the handler throws", () => {
+    // The throw is what this asserts against, and jsdom reports it as an uncaught error, so the report is silenced
+    // to keep it out of the test log where it reads like a failure.
+    const consoleError = jest.spyOn(console, "error").mockImplementation(() => undefined);
+
+    try {
+        const element = appendScript({ "data-mojarra-onerror": "throw new Error('boom')" });
+
+        element.dispatchEvent(new Event("error"));
+
+        // The per-invocation slots must be gone; the install marker is permanent by design.
+        expect(Object.keys(window).filter(key => /^__mojarraDelegated\d/.test(key))).toEqual([]);
+    }
+    finally {
+        consoleError.mockRestore();
+    }
+});
+
+it("runs a handler which ends in a line comment", () => {
+    const element = appendScript({ "data-mojarra-onerror": "window.probe = 'error'; // and no more" });
+
+    element.dispatchEvent(new Event("error"));
+
+    expect(probe()).toBe("error");
+});
+
+it("keeps the result of the outer handler when it dispatches a nested delegated event", () => {
+    const inner = appendScript({ "data-mojarra-onerror": "window.probe = 'inner'" });
+    inner.id = "inner";
+    const outer = appendScript({ "data-mojarra-onerror": "document.getElementById('inner').dispatchEvent(new Event('error')); return false" });
+    const event = new Event("error", { cancelable: true });
+
+    outer.dispatchEvent(event);
+
+    expect(probe()).toBe("inner");
+    expect(event.defaultPrevented).toBe(true);
+});
+
+it("installs its listeners only once however often it is loaded", () => {
+    const addEventListener = jest.spyOn(window, "addEventListener");
+
+    try {
+        loadBehaviorEventBootstrap();
+
+        const events = addEventListener.mock.calls.map(call => call[0]);
+        expect(events).not.toContain("load");
+        expect(events).not.toContain("error");
+    }
+    finally {
+        addEventListener.mockRestore();
+    }
+});

--- a/impl/src/test/ts/spec/faces.ajax.test.ts
+++ b/impl/src/test/ts/spec/faces.ajax.test.ts
@@ -2274,3 +2274,62 @@ describe("faces.ajax.response: malformedXML parser branches", () => {
         expect(errors[0].status).toBe("malformedXML");
     });
 });
+
+// ---- Independent scripts in an update ----
+
+/**
+ * The scripts of an update run in document order, and each one with a `src` suspends the rest until it has loaded,
+ * resuming in a later task. By then the update markup is live and the `load` or `error` of any resource element in it
+ * may already have been dispatched. A script which depends on nothing around it therefore declares itself
+ * independent, and runs before the markup goes live rather than in that order.
+ */
+describe("faces.ajax.response: independent scripts", () => {
+    let form: HTMLFormElement;
+    let button: HTMLButtonElement;
+    let target: HTMLElement;
+
+    /** Records what each script saw of the markup it came with, written from the scripts under test. */
+    const recorder = () => window as unknown as { order: string[] };
+
+    const respondWithUpdate = (markup: string) => lastXHR().respond(200, "", '<?xml version="1.0" encoding="UTF-8"?>'
+        + '<partial-response id="testForm"><changes>'
+        + '<update id="target"><![CDATA[' + markup + ']]></update>'
+        + '</changes></partial-response>');
+
+    beforeEach(() => {
+        installMockXHR();
+        ({ form, button } = createAjaxForm());
+        target = document.createElement("div");
+        target.id = "target";
+        document.body.appendChild(target);
+        recorder().order = [];
+    });
+
+    afterEach(() => {
+        form?.remove();
+        target?.remove();
+        uninstallMockXHR();
+    });
+
+    test("runs an independent script before the markup goes live", () => {
+        ajax().request(button, null, { render: "target" });
+        respondWithUpdate('<div id="target">'
+            + '<script src="/suspends.js"></script>'
+            + '<script data-mojarra-independent>order.push("independent:" + !!document.getElementById("marker"))</script>'
+            + '<span id="marker"></span>'
+            + '</div>');
+
+        expect(recorder().order).toEqual(["independent:false"]);
+    });
+
+    test("runs an ordinary script only once the markup is live", () => {
+        ajax().request(button, null, { render: "target" });
+        respondWithUpdate('<div id="target">'
+            + '<script src="/suspends.js"></script>'
+            + '<script>order.push("ordinary:" + !!document.getElementById("marker"))</script>'
+            + '<span id="marker"></span>'
+            + '</div>');
+
+        expect(recorder().order).toEqual(["ordinary:true"]);
+    });
+});

--- a/impl/src/test/ts/test-setup.ts
+++ b/impl/src/test/ts/test-setup.ts
@@ -12,6 +12,7 @@ declare global {
 
 export const FACES_JS_UNCOMPRESSED = path.resolve(__dirname, "../../../target/classes/META-INF/resources/jakarta.faces/faces-uncompressed.js");
 export const FACES_JS = path.resolve(__dirname, "../../../target/classes/META-INF/resources/jakarta.faces/faces.js");
+export const BEHAVIOR_EVENT_BOOTSTRAP_JS = path.resolve(__dirname, "../../../target/classes/org/glassfish/mojarra/renderkit/behavior-event-bootstrap.js");
 
 /**
  * Parse the @version JSDoc tag from faces-uncompressed.js and derive expected specversion and implversion.
@@ -45,5 +46,15 @@ export function loadFacesJs(): void {
 
     const script = document.createElement("script");
     script.textContent = evaluated;
+    document.head.appendChild(script);
+}
+
+/**
+ * Load the compressed behavior event bootstrap into jsdom, the way the response writer renders it: inline, and ahead of
+ * the elements whose events it handles. Call this in beforeAll().
+ */
+export function loadBehaviorEventBootstrap(): void {
+    const script = document.createElement("script");
+    script.textContent = fs.readFileSync(BEHAVIOR_EVENT_BOOTSTRAP_JS, "utf-8");
     document.head.appendChild(script);
 }

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -43,6 +43,15 @@
         <test.selenium>true</test.selenium>
         <failsafe.rerunFailingTestsCount>0</failsafe.rerunFailingTestsCount>
         <chromedriver.version>139</chromedriver.version>
+
+        <!-- The TCK util declares its test tooling optional so that it is not packaged into every war, so every
+             consumer of it declares that tooling itself. Keep these in step with faces/tck/pom.xml. -->
+        <arquillian.version>1.10.0.Final</arquillian.version>
+        <arquillian-suite-extension.version>1.2.2</arquillian-suite-extension.version>
+        <junit.version>5.13.4</junit.version>
+        <junit-platform.version>1.14.4</junit-platform.version>
+        <selenium.version>4.35.0</selenium.version>
+        <shrinkwrap-resolver.version>3.3.4</shrinkwrap-resolver.version>
         <arquillian.browser>chrome</arquillian.browser>
         <faces-api.version>5.0.0-SNAPSHOT</faces-api.version>
         <mojarra.version>${project.version}</mojarra.version>
@@ -78,6 +87,60 @@
             <groupId>org.eclipse.ee4j.tck.faces.test</groupId>
             <artifactId>util</artifactId>
             <version>${tck.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>${junit-platform.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
+            <version>${arquillian.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>${selenium.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-chrome-driver</artifactId>
+            <version>${selenium.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-devtools-v${chromedriver.version}</artifactId>
+            <version>${selenium.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <version>${shrinkwrap-resolver.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven-archive</artifactId>
+            <version>${shrinkwrap-resolver.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eu.ingwar.tools</groupId>
+            <artifactId>arquillian-suite-extension</artifactId>
+            <version>${arquillian-suite-extension.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Closes #5976

## Problem

A pass-through `on*` attribute was unconditionally deferred to `mojarra.ael()`, which locates its element by the component's client id. A resource element renders no id, and `ScriptStyleBaseRenderer` never flushes the parked listeners, so the handler was dropped without a trace. This is a regression against 4.x, introduced on the 5.0 branch by 61cd2fb567.

Deferring cannot work at all for the `load` and `error` of an element whose fetch of an external resource starts as the element is parsed. A parser-inserted classic `<script src>` blocks the parser; when the fetch settles, "execute the script element" fires `error` at the element synchronously and only then does the parser resume and create the following nodes. Any `ael` call is by construction emitted after the element, so it runs strictly after the event has already been dispatched.

## Solution

`load` and `error` on `script`, `link`, `img` and `iframe` are renamed to `data-mojarra-on*` and run by a small bootstrap which the response writer puts immediately ahead of the element, capture-listening at the window because a resource load event does not bubble. The bootstrap evaluates the handler through a nonce-bearing script element, so it also works under a Content Security Policy, and installs at most once per document.

Every other `on*` is deferred to `mojarra.ael()` only when the rendered id is the component's client id, and is written inline otherwise. `shouldWriteIdAttribute` now forces the client id when the component carries a behavior event attribute, generalizing the rule that already existed for `UICommand`, and the flush which emits the parked listener was missing from `TextRenderer`, `MessageRenderer`, `OutputMessageRenderer`, `HiddenRenderer` and `CommandScriptRenderer`.

The bootstrap source lives in `behavior-event-bootstrap.ts` and is bundled by a second rollup entry, minified by terser into a classpath resource which is inlined at render time — it cannot be served as a resource, because it must run before the first element which can carry such an attribute is parsed. It is marked `data-mojarra-independent` so that `faces.ajax` runs it before the update markup goes live, since `runScripts` suspends on every script with a `src` and resumes only in a later task.

`renderScript` no longer starts its script element with the component, so a generated script does not inherit that component's pass-through attributes.

## Spec

The permission to wire an `on*` attribute at runtime is a MAY conditional on the observable behavior being preserved, which the previous implementation did not preserve. The clarification of what preserving it requires is in jakartaee/faces#1507; the submodule is bumped to pick it up.

## Testing

- `DelegatedBehaviorEventAttributeTest` and `HtmlBasicRendererIdTest`, plus jest coverage of the bootstrap and of the ajax script ordering
- 1360 Java unit tests, 410 jest tests, integration tests, all green
- Full TCK green, including a new `Spec1507IT` in the `faces50/csp` module which asserts the handlers fire under a real nonce policy, on the initial render and after an ajax update
- Verified against OmniFaces' `CombinedResourceHandler` CDN fallback, which is where this was found: its integration tests are green on both Mojarra 4 and this build

🤖 Generated with Claude Opus 5
