### PR TITLE
Do not compare components a render left standing on a row (#5984)

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategy.java
+++ b/impl/src/main/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategy.java
@@ -50,7 +50,10 @@ import com.sun.faces.util.Util;
 
 import jakarta.faces.FacesException;
 import jakarta.faces.application.ProjectStage;
+import jakarta.faces.component.NamingContainer;
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIData;
+import jakarta.faces.component.UIForm;
 import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.component.visit.VisitContext;
 import jakarta.faces.component.visit.VisitHint;
@@ -465,6 +468,44 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
     }
 
     /**
+     * Whether the given component holds the same client id on the two builds, which is what the comparison identifies
+     * it by.
+     *
+     * <p>
+     * A {@link NamingContainer} standing on a row hands its children a client id extending its own with that row, and
+     * it stands on none while the tree is visited with {@link VisitHint#SKIP_ITERATION}, so a container found handing
+     * out an extension of its own client id anyway was left standing on a row by a render which iterated it. Its
+     * children then hold a client id no other request reproduces, which is the render's own to fix and none of the
+     * report's business. A container which hands out anything else stands on no row: {@link UIForm} which prepends no
+     * id hands out the client id of the container above it, or none at all when there is none.
+     * </p>
+     *
+     * <p>
+     * A container which carries the row in its own client id as well, which is what {@link UIData} does, hands its
+     * children an extension of nothing and is compared as usual. Its render resets the row it stands on, so this does
+     * not have to hold it apart.
+     * </p>
+     *
+     * @param context the Faces context.
+     * @param component the component.
+     * @return true when no naming container above the given component was left standing on a row.
+     */
+    static boolean holdsStableClientId(FacesContext context, UIComponent component) {
+        for (UIComponent parent = component.getParent(); parent != null; parent = parent.getParent()) {
+            if (parent instanceof NamingContainer) {
+                String clientId = parent.getClientId(context);
+                String containerClientId = parent.getContainerClientId(context);
+
+                if (containerClientId != null && containerClientId.length() > clientId.length() && containerClientId.startsWith(clientId)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * The client ids the rendered view held which the rebuilt one does not, so that the state saved for them is
      * restored into nothing and a value submitted for them is decoded by nothing.
      *
@@ -526,7 +567,7 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
                 return VisitResult.REJECT;
             }
             String tag = tagOf(target);
-            if (tag != null) {
+            if (tag != null && holdsStableClientId(context1.getFacesContext(), target)) {
                 rebuiltTags.put(target.getClientId(context1.getFacesContext()), tag);
             }
             return ACCEPT;
@@ -665,7 +706,7 @@ public class FaceletPartialStateManagementStrategy extends StateManagementStrate
                 String tag = renderedTags != null ? tagOf(target) : null;
                 if (tag != null || stateObj != null) {
                     String clientId = target.getClientId(context1.getFacesContext());
-                    if (tag != null) {
+                    if (tag != null && holdsStableClientId(context1.getFacesContext(), target)) {
                         renderedTags.put(clientId, tag);
                     }
                     if (stateObj != null) {

--- a/impl/src/test/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategyTest.java
+++ b/impl/src/test/java/com/sun/faces/application/view/FaceletPartialStateManagementStrategyTest.java
@@ -22,6 +22,7 @@ import static com.sun.faces.application.view.FaceletPartialStateManagementStrate
 import static com.sun.faces.application.view.FaceletPartialStateManagementStrategy.REBUILT_FROM_ANOTHER_TAG_REPORT;
 import static com.sun.faces.application.view.FaceletPartialStateManagementStrategy.clientIdsNotRebuilt;
 import static com.sun.faces.application.view.FaceletPartialStateManagementStrategy.clientIdsRebuiltFromAnotherTag;
+import static com.sun.faces.application.view.FaceletPartialStateManagementStrategy.holdsStableClientId;
 import static com.sun.faces.application.view.FaceletPartialStateManagementStrategy.isViewRootOnlyState;
 import static com.sun.faces.application.view.FaceletPartialStateManagementStrategy.tagOf;
 import static com.sun.faces.application.view.FaceletPartialStateManagementStrategy.truncated;
@@ -44,8 +45,11 @@ import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 
+import jakarta.faces.component.NamingContainer;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.UIOutput;
+import jakarta.faces.component.UIPanel;
+import jakarta.faces.context.FacesContext;
 
 /**
  * A postback rebuilds its view from the markup rather than from the response it was submitted from, so a build time
@@ -160,6 +164,80 @@ class FaceletPartialStateManagementStrategyTest {
         assertNull(tagOf(new UIOutput()));
     }
 
+    /**
+     * A naming container positioned on no row hands its children the client id they hold on every other request too.
+     */
+    @Test
+    void aComponentUnderANamingContainerPositionedOnNoRowIsCompared() {
+        UIComponent component = new UIOutput();
+        container("form:rows", "form:rows").getChildren().add(component);
+
+        assertTrue(holdsStableClientId(null, component));
+    }
+
+    /**
+     * A container left positioned on a row by a render which iterated it hands its children a client id no request
+     * which does not iterate it reproduces, the rebuild of the postback included.
+     */
+    @Test
+    void aComponentUnderANamingContainerPositionedOnARowIsNotCompared() {
+        UIComponent component = new UIOutput();
+        container("form:rows", "form:rows:1").getChildren().add(component);
+
+        assertFalse(holdsStableClientId(null, component));
+    }
+
+    /**
+     * A container nested in a positioned one is itself positioned on no row, yet holds the row of the one above it in
+     * its own client id, so the whole chain decides.
+     */
+    @Test
+    void aComponentUnderANamingContainerNestedInAPositionedOneIsNotCompared() {
+        UIComponent component = new UIOutput();
+        UIComponent nested = container("form:rows:1:group", "form:rows:1:group");
+        container("form:rows", "form:rows:1").getChildren().add(nested);
+        nested.getChildren().add(component);
+
+        assertFalse(holdsStableClientId(null, component));
+    }
+
+    /**
+     * A component which is held by nothing that can stand on a row holds the client id it holds on every request.
+     */
+    @Test
+    void aComponentHeldByNoNamingContainerIsCompared() {
+        assertTrue(holdsStableClientId(null, new UIOutput()));
+    }
+
+    /**
+     * A plain component between the two decides nothing: the container above it is the one standing on a row.
+     */
+    @Test
+    void aComponentUnderAPlainComponentUnderAPositionedNamingContainerIsNotCompared() {
+        UIComponent component = new UIOutput();
+        UIComponent plain = new UIPanel();
+        container("form:rows", "form:rows:1").getChildren().add(plain);
+        plain.getChildren().add(component);
+
+        assertFalse(holdsStableClientId(null, component));
+    }
+
+    /**
+     * A form which prepends no id hands its children the client id of the container above it rather than one
+     * extending its own, and none at all when no container holds it, so it stands on no row either way.
+     */
+    @Test
+    void aComponentUnderAFormWhichPrependsNoIdIsCompared() {
+        UIComponent underNestedForm = new UIOutput();
+        container("outer:form", "outer").getChildren().add(underNestedForm);
+
+        UIComponent underRootForm = new UIOutput();
+        container("form", null).getChildren().add(underRootForm);
+
+        assertTrue(holdsStableClientId(null, underNestedForm));
+        assertTrue(holdsStableClientId(null, underRootForm));
+    }
+
     @Test
     void stateHoldingNoComponentDeltaAtAllNeedsOnlyTheViewRootRestored() {
         assertTrue(isViewRootOnlyState("root", state()));
@@ -223,6 +301,34 @@ class FaceletPartialStateManagementStrategyTest {
 
         assertTrue(NOT_REBUILT_REPORT.contains(parameterName), NOT_REBUILT_REPORT);
         assertTrue(REBUILT_FROM_ANOTHER_TAG_REPORT.contains(parameterName), REBUILT_FROM_ANOTHER_TAG_REPORT);
+    }
+
+    private static UIComponent container(String clientId, String containerClientId) {
+        return new Container(clientId, containerClientId);
+    }
+
+    /**
+     * A naming container which is asked for its client ids alone, so that neither has to be built from a context.
+     */
+    private static class Container extends UIPanel implements NamingContainer {
+
+        private final String clientId;
+        private final String containerClientId;
+
+        private Container(String clientId, String containerClientId) {
+            this.clientId = clientId;
+            this.containerClientId = containerClientId;
+        }
+
+        @Override
+        public String getClientId(FacesContext context) {
+            return clientId;
+        }
+
+        @Override
+        public String getContainerClientId(FacesContext context) {
+            return containerClientId;
+        }
     }
 
     private static List<String> clientIds(int count) {

--- a/test/issue5970/src/main/java/org/eclipse/mojarra/test/issue5970/IteratingContainer.java
+++ b/test/issue5970/src/main/java/org/eclipse/mojarra/test/issue5970/IteratingContainer.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.eclipse.mojarra.test.issue5970;
+
+import java.io.IOException;
+
+import jakarta.faces.component.FacesComponent;
+import jakarta.faces.component.NamingContainer;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIComponentBase;
+import jakarta.faces.component.UIData;
+import jakarta.faces.component.UINamingContainer;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * A naming container which renders its children once per row, handing them a client id carrying the row it is
+ * positioned on, and which is left positioned on the last row it rendered. Its children therefore hold another client
+ * id while the response is rendered than they do on any request which does not iterate it.
+ */
+@FacesComponent(createTag = true, namespace = "eclipse.mojarra.test", tagName = "iterating")
+public class IteratingContainer extends UIComponentBase implements NamingContainer {
+
+    private static final String FAMILY = "org.eclipse.mojarra.test.issue5970.IteratingContainer";
+
+    private static final int ROWS = 2;
+
+    private Integer row;
+
+    @Override
+    public String getFamily() {
+        return FAMILY;
+    }
+
+    @Override
+    public boolean getRendersChildren() {
+        return true;
+    }
+
+    @Override
+    public String getContainerClientId(FacesContext context) {
+        String containerClientId = super.getContainerClientId(context);
+        return row == null ? containerClientId : containerClientId + UINamingContainer.getSeparatorChar(context) + row;
+    }
+
+    @Override
+    public void encodeChildren(FacesContext context) throws IOException {
+        for (int i = 0; i < ROWS; i++) {
+            position(i);
+
+            for (UIComponent child : getChildren()) {
+                child.encodeAll(context);
+            }
+        }
+    }
+
+    /**
+     * Position on the given row, dropping the client id each child cached while standing on the previous one, which
+     * is what {@link UIData#setRowIndex(int)} does with {@code setId} as well.
+     *
+     * @param row the row to position on.
+     */
+    private void position(int row) {
+        this.row = row;
+
+        for (UIComponent child : getChildren()) {
+            child.setId(child.getId());
+        }
+    }
+}

--- a/test/issue5970/src/main/webapp/iterating.xhtml
+++ b/test/issue5970/src/main/webapp/iterating.xhtml
@@ -1,0 +1,36 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:f="jakarta.faces.core"
+      xmlns:h="jakarta.faces.html"
+      xmlns:t="eclipse.mojarra.test">
+    <h:head><title>iterating</title></h:head>
+    <h:body>
+        <h:form id="form">
+            <t:iterating id="rows">
+                <h:inputText id="input" value="#{issue5970Bean.value}" />
+            </t:iterating>
+            <h:commandButton id="submit" value="submit" />
+            <h:commandButton id="ajaxSubmit" value="ajax submit">
+                <f:ajax execute="@form" render="@form" />
+            </h:commandButton>
+            <h:outputText id="reports" value="#{requestScope.issue5970Reports}" />
+        </h:form>
+    </h:body>
+</html>

--- a/test/issue5970/src/main/webapp/unprependedform.xhtml
+++ b/test/issue5970/src/main/webapp/unprependedform.xhtml
@@ -1,0 +1,37 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:f="jakarta.faces.core"
+      xmlns:h="jakarta.faces.html"
+      xmlns:c="jakarta.tags.core">
+    <h:head><title>unprepended form</title></h:head>
+    <h:body>
+        <h:form id="form" prependId="false">
+            <h:commandButton id="show" value="show" action="#{issue5970Bean.show}" />
+            <c:if test="#{issue5970Bean.shown}">
+                <h:inputText id="input" value="#{issue5970Bean.value}" />
+            </c:if>
+            <h:commandButton id="submit" value="submit" />
+            <h:commandButton id="ajaxSubmit" value="ajax submit">
+                <f:ajax execute="@form" render="@form" />
+            </h:commandButton>
+            <h:outputText id="reports" value="#{requestScope.issue5970Reports}" />
+        </h:form>
+    </h:body>
+</html>

--- a/test/issue5970/src/test/java/org/eclipse/mojarra/test/issue5970/Issue5970IT.java
+++ b/test/issue5970/src/test/java/org/eclipse/mojarra/test/issue5970/Issue5970IT.java
@@ -48,6 +48,18 @@ class Issue5970IT extends BaseIT {
     @FindBy(id = "form:reports")
     private WebElement reports;
 
+    @FindBy(id = "show")
+    private WebElement plainShow;
+
+    @FindBy(id = "input")
+    private WebElement plainInput;
+
+    @FindBy(id = "submit")
+    private WebElement plainSubmit;
+
+    @FindBy(id = "reports")
+    private WebElement plainReports;
+
     /**
      * The input a <code>c:if</code> held while the response was rendered, and no longer holds while the postback is
      * restored, is named by the report.
@@ -60,6 +72,37 @@ class Issue5970IT extends BaseIT {
         input.sendKeys("test");
         guardHttp(submit::click);
         assertTrue(reports.getText().contains("form:input"), reports.getText());
+    }
+
+    /**
+     * A form which prepends no id hands its children the client id of the container above it rather than one
+     * extending its own, so it stands on no row and the input a <code>c:if</code> drops is reported as it is
+     * anywhere else.
+     */
+    @Test
+    void testComponentDroppedByABuildTimeConditionInAFormWhichPrependsNoId() {
+        open("unprependedform.xhtml");
+        guardHttp(plainShow::click);
+        assertEquals("[]", plainReports.getText(), "the rebuild reproduces the view the response was rendered from");
+        plainInput.sendKeys("test");
+        guardHttp(plainSubmit::click);
+        assertTrue(plainReports.getText().contains("input"), plainReports.getText());
+    }
+
+    /**
+     * A component the render left holding the row of an iterating naming container is reported on by neither
+     * postback: it holds another client id on every request which does not iterate that container, so comparing it
+     * would report it as vanished on every postback.
+     *
+     * @see <a href="https://github.com/eclipse-ee4j/mojarra/issues/5984">GitHub issue #5984</a>
+     */
+    @Test
+    void testComponentUnderAContainerLeftPositionedOnARow() {
+        open("iterating.xhtml");
+        guardHttp(submit::click);
+        assertEquals("[]", reports.getText(), reports.getText());
+        guardAjax(ajaxSubmit::click);
+        assertEquals("[]", reports.getText(), reports.getText());
     }
 
     /**


### PR DESCRIPTION
The Development stage report on the view rebuilt for a postback compares components by client id. A naming container which is left standing on a row hands its children a client id carrying that row. The postback rebuilds the view standing on no row, so every one of those components was reported as restored into nothing, on every postback, while nothing was wrong with the view.

A container standing on a row hands out a client id which extends its own. A component below such a container is no longer compared, on the save side and on the compare side alike. A container which hands out anything else stands on no row: UIForm which prepends no id hands out the client id of the container above it, or none at all.

The report stays what it was for everything else. A `c:if` which drops an input still names it, also inside a form which prepends no id.

Reported for a `p:tree`, which leaves itself standing on its last node after rendering. That is a PrimeFaces bug of its own, reported at primefaces/primefaces#15161, and it costs more than this warning: the iteration variable leaks past the tree, and the state Mojarra saves for the components inside the tree is dropped on every postback. This change makes Mojarra stop reporting it either way, since any component with the same defect produces the same false positive.

Test module issue5970 gains two views. `iterating.xhtml` holds a naming container which renders its children per row and stays standing on the last one, which is the false positive. `unprependedform.xhtml` holds a form which prepends no id, whose container client id differs from its client id for a reason which is not a row, and where the report must still fire.

Verified: impl unit tests 1376 green, issue5970 IT 4 green, restoreBuildTimeDecisions IT 17 green.

Closes #5984

🤖 Generated with Claude Opus 5
