### PR TITLE
Preserve whitespace between text and an inline child (#5989)

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/compiler/TextUnit.java
+++ b/impl/src/main/java/com/sun/faces/facelets/compiler/TextUnit.java
@@ -284,7 +284,7 @@ final class TextUnit extends CompilationUnit {
             if (Character.isWhitespace(s.charAt(i))) {
                 i--;
             } else {
-                return s.substring(0,i+1);
+                return s;
             }
         }
         return "";

--- a/test/issue5989/pom.xml
+++ b/test/issue5989/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.mojarra.test</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.1.16-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>issue5989</artifactId>
+    <packaging>war</packaging>
+
+    <name>Mojarra ${project.version} - INTEGRATION TESTS - ${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.mojarra.test</groupId>
+            <artifactId>base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/test/issue5989/src/main/webapp/WEB-INF/beans.xml
+++ b/test/issue5989/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/test/issue5989/src/main/webapp/WEB-INF/fragment.xhtml
+++ b/test/issue5989/src/main/webapp/WEB-INF/fragment.xhtml
@@ -1,0 +1,18 @@
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<ui:composition xmlns:ui="jakarta.faces.facelets">component</ui:composition>

--- a/test/issue5989/src/main/webapp/WEB-INF/web.xml
+++ b/test/issue5989/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+    version="5.0"
+>
+    <servlet>
+        <servlet-name>facesServlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>facesServlet</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/test/issue5989/src/main/webapp/issue5989.xhtml
+++ b/test/issue5989/src/main/webapp/issue5989.xhtml
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<html lang="en"
+    xmlns:h="jakarta.faces.html"
+    xmlns:ui="jakarta.faces.facelets"
+>
+    <h:head>
+        <title>issue5989</title>
+    </h:head>
+    <h:body>
+        <div id="literalTextBeforeComponent">before <h:outputText value="component" /> after</div>
+        <div id="dynamicTextBeforeComponent">#{'before'} <h:outputText value="component" /> after</div>
+        <div id="literalTextBeforeTagHandler">before <ui:include src="/WEB-INF/fragment.xhtml" /> after</div>
+        <div id="tabBeforeComponent">before&#9;<h:outputText value="component" /> after</div>
+        <div id="whitespaceOnlyBetweenComponents"><h:outputText value="before" /> <h:outputText value="after" /></div>
+        <h:panelGroup id="trailingTextAtEndOfComponentBody" layout="block">before <h:outputText value="component" /> after&#9;</h:panelGroup>
+        <div id="trailingTextWithoutChild">before&#9;</div>
+    </h:body>
+</html>

--- a/test/issue5989/src/test/java/org/eclipse/mojarra/test/issue5989/Issue5989IT.java
+++ b/test/issue5989/src/test/java/org/eclipse/mojarra/test/issue5989/Issue5989IT.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.eclipse.mojarra.test.issue5989;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.mojarra.test.base.BaseIT;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The Facelets compiler collects consecutive markup into a single text unit and flushes it whenever a child of that
+ * unit starts, and once more when the unit itself ends. Both flushes drop the collected text when it consists solely of
+ * whitespace, and both must otherwise emit it verbatim, because whitespace next to an inline child is content.
+ *
+ * The view exercises every shape that reaches those two flushes: literal text, text carrying an expression, text in
+ * front of a tag handler rather than a component, whitespace which is not a plain space, whitespace-only text, text at
+ * the end of a component body, and text which never gets a child at all.
+ *
+ * https://github.com/eclipse-ee4j/mojarra/issues/5989
+ */
+class Issue5989IT extends BaseIT {
+
+    /**
+     * The whitespace between text and a child which follows it is content and must be rendered verbatim, no matter
+     * whether the text is literal, carries an expression, or precedes a tag handler instead of a component, and no
+     * matter which whitespace character it is.
+     */
+    @Test
+    void testWhitespaceBeforeChildIsPreserved() {
+        String body = getResponseBody("issue5989.xhtml");
+
+        assertEquals("before component after", getElementContent(body, "literalTextBeforeComponent"), body);
+        assertEquals("before component after", getElementContent(body, "dynamicTextBeforeComponent"), body);
+        assertEquals("before component after", getElementContent(body, "literalTextBeforeTagHandler"), body);
+        assertEquals("before\tcomponent after", getElementContent(body, "tabBeforeComponent"), body);
+    }
+
+    /**
+     * Text which consists solely of whitespace carries no content of its own, so the flush drops it and two children
+     * separated by nothing else end up adjacent.
+     */
+    @Test
+    void testWhitespaceOnlyTextBeforeChildIsDropped() {
+        String body = getResponseBody("issue5989.xhtml");
+
+        assertEquals("beforeafter", getElementContent(body, "whitespaceOnlyBetweenComponents"), body);
+    }
+
+    /**
+     * The text unit is flushed a second time when it ends, which is the case for text trailing the last child of a
+     * component body. That flush must leave the whitespace alone as well.
+     */
+    @Test
+    void testTrailingWhitespaceAtEndOfComponentBodyIsPreserved() {
+        String body = getResponseBody("issue5989.xhtml");
+
+        assertEquals("before component after\t", getElementContent(body, "trailingTextAtEndOfComponentBody"), body);
+    }
+
+    /**
+     * Markup which never gets a child is flushed at the surrounding element boundaries, which is a flush that never
+     * drops anything, so its trailing whitespace survives too.
+     */
+    @Test
+    void testTrailingWhitespaceWithoutChildIsPreserved() {
+        String body = getResponseBody("issue5989.xhtml");
+
+        assertEquals("before\t", getElementContent(body, "trailingTextWithoutChild"), body);
+    }
+
+    /**
+     * Returns the content between the opening and the closing tag of the element with the given id.
+     */
+    private static String getElementContent(String body, String id) {
+        int idIndex = body.indexOf("id=\"" + id + "\"");
+        if (idIndex == -1) {
+            throw new IllegalStateException("No element with id " + id + " in response:\n" + body);
+        }
+
+        int contentStart = body.indexOf('>', idIndex) + 1;
+        return body.substring(contentStart, body.indexOf('<', contentStart));
+    }
+}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -64,6 +64,7 @@
         <module>issue5918</module>
         <module>issue5920</module>
         <module>issue5970</module>
+        <module>issue5989</module>
         <module>perf</module>
     </modules>
 


### PR DESCRIPTION
Whitespace between text and an inline child is dropped, so `<div>Die <h:outputText value="#{bean.organisation}"/> stellt das Tool bereit.</div>` renders as `DieDB Fernverkehr AG stellt das Tool bereit.`

`TextUnit` collects consecutive markup and flushes it when a child of that unit starts (`addChild`), and once more when the unit itself ends (`createFaceletHandler`). Both flushes run the collected text through `trimRight`, which since 7841b6b77b (#5246) returns `s.substring(0, i + 1)` and so eats the significant space in front of the child. This restores what the method was written to do, and what 4.0 and MyFaces still have: return `""` when the string is entirely whitespace, return it unchanged otherwise.

Affects 4.1 and 5.0 only. 7841b6b77b landed on 4.1 and shipped in 4.1.0-M1, so every 4.1 carries it and no 4.0 ever did. This also covers #5706, the same bug, misdiagnosed at the time as WildFly specific: WildFly 36 and newer ship Mojarra 4.1, while the norepro back then was on 4.0.

## Test

New `test/issue5989`, asserting on the raw response body rather than the browser DOM, since Selenium's `getText()` collapses whitespace and hides the defect.

| case | expected | without the fix |
| --- | --- | --- |
| literal text before a component | `before component after` | `beforecomponent after` |
| expression-carrying text before a component | `before component after` | `beforecomponent after` |
| literal text before a tag handler | `before component after` | `beforecomponent after` |
| tab before a component | `before\tcomponent after` | `beforecomponent after` |
| trailing text at the end of a component body | `before component after\t` | `beforecomponent after` |
| whitespace-only text between two components | `beforeafter` | `beforeafter` |
| trailing text which never gets a child | `before\t` | `before\t` |

The last two rows pass either way on purpose: they pin the behavior that must not change, so the trim does not get removed outright later.

Verified on Tomcat in both directions: 4/4 green with the fix, 2 failures with the trim put back.

🤖 Generated with Claude Opus 5
