### PR TITLE
Clean up the children a binding carries into a rebuild (#6001)

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/ComponentTagHandlerDelegateImpl.java
@@ -114,12 +114,16 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
      * {@link com.sun.faces.facelets.tag.MetaTagHandlerImpl#setAttributes(FaceletContext, Object)}</li>
      * <li>Set the UIComponent's id</li>
      * <li>Set the RendererType of this instance</li>
+     * <li>A UIComponent which a <code>binding</code> supplies from an earlier build, recognized by the mark id it already
+     * carries, has its children
+     * {@link com.sun.faces.facelets.tag.faces.ComponentSupport#markForDeletion(jakarta.faces.component.UIComponent) marked}
+     * for deletion as well.</li>
      * </ol>
      * </li>
      * <li>Now apply the nextHandler, passing the UIComponent we've created/found.</li>
      * <li>Now add the UIComponent to the passed parent</li>
-     * <li>Lastly, if the UIComponent already existed (found), then {@link ComponentSupport#finalizeForDeletion(UIComponent)
-     * finalize} for deletion.</li>
+     * <li>Lastly, if the UIComponent already existed (found or supplied by a <code>binding</code>), then
+     * {@link ComponentSupport#finalizeForDeletion(UIComponent) finalize} for deletion.</li>
      * </ol>
      *
      * @throws TagException if the UIComponent parent is null
@@ -153,6 +157,7 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
         }
 
         boolean componentFound = false;
+        boolean componentReused = false;
         boolean parentModified = false;
         if (c != null) {
             componentFound = true;
@@ -164,6 +169,12 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
             c = owner.createComponent(ctx);
             if (c == null) {
                 c = createComponent(ctx);
+            }
+
+            // A component carrying a mark id here predates this build and arrives through its binding, with that build's children attached.
+            componentReused = c.getAttributes().containsKey(ComponentSupport.MARK_CREATED);
+            if (componentReused) {
+                ComponentSupport.markForDeletion(c);
             }
 
             doNewComponentActions(ctx, id, c);
@@ -221,6 +232,8 @@ public class ComponentTagHandlerDelegateImpl extends TagHandlerDelegate {
         if (componentFound) {
             parentModified = isParentChildrenModified(parent);
             doOrphanedChildCleanup(ctx, parent, c, parentModified);
+        } else if (componentReused) {
+            ComponentSupport.finalizeForDeletion(c);
         }
 
         privateOnComponentPopulated(ctx, c);

--- a/test/issue6001/pom.xml
+++ b/test/issue6001/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.mojarra.test</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.0.26-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>issue6001</artifactId>
+    <packaging>war</packaging>
+
+    <name>Mojarra ${project.version} - INTEGRATION TESTS - ${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.mojarra.test</groupId>
+            <artifactId>base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test/issue6001/src/main/java/org/eclipse/mojarra/test/issue6001/Issue6001Bean.java
+++ b/test/issue6001/src/main/java/org/eclipse/mojarra/test/issue6001/Issue6001Bean.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.eclipse.mojarra.test.issue6001;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+/**
+ * A view scoped bean holding the type of each slot, so that the restore of a postback sees the types the response was
+ * rendered from and the render of that same postback sees the types the action left behind.
+ */
+@Named
+@ViewScoped
+public class Issue6001Bean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<String> types = new ArrayList<>(List.of("text", "table"));
+
+    public void toggle() {
+        types.set(0, "text".equals(types.get(0)) ? "table" : "text");
+    }
+
+    public List<String> getTypes() {
+        return types;
+    }
+}

--- a/test/issue6001/src/main/java/org/eclipse/mojarra/test/issue6001/Issue6001Holder.java
+++ b/test/issue6001/src/main/java/org/eclipse/mojarra/test/issue6001/Issue6001Holder.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.eclipse.mojarra.test.issue6001;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.faces.component.UIComponent;
+import jakarta.inject.Named;
+
+/**
+ * The target of the {@code binding} of the component the fragment holds, keyed by slot. Request scoped, as a
+ * {@link UIComponent} is not thread safe and must not outlive the request, so both builds of a postback read back
+ * the very component the build before them put here.
+ */
+@Named
+@RequestScoped
+public class Issue6001Holder {
+
+    private final Map<String, UIComponent> components = new HashMap<>();
+
+    public Map<String, UIComponent> getComponents() {
+        return components;
+    }
+}

--- a/test/issue6001/src/main/webapp/WEB-INF/beans.xml
+++ b/test/issue6001/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/test/issue6001/src/main/webapp/WEB-INF/compositefragment.xhtml
+++ b/test/issue6001/src/main/webapp/WEB-INF/compositefragment.xhtml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<ui:composition xmlns:h="jakarta.faces.html"
+                xmlns:ui="jakarta.faces.facelets"
+                xmlns:my="jakarta.faces.composite/components">
+    <h:panelGroup>
+        <my:child id="child_#{key}" binding="#{issue6001Holder.components[key]}" value="#{key}" />
+    </h:panelGroup>
+</ui:composition>

--- a/test/issue6001/src/main/webapp/WEB-INF/fragment.xhtml
+++ b/test/issue6001/src/main/webapp/WEB-INF/fragment.xhtml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<ui:composition xmlns:h="jakarta.faces.html"
+                xmlns:ui="jakarta.faces.facelets">
+    <h:panelGroup>
+        <h:panelGroup binding="#{issue6001Holder.components[key]}">
+            <h:outputText id="child_#{key}" value="#{key}" />
+        </h:panelGroup>
+    </h:panelGroup>
+</ui:composition>

--- a/test/issue6001/src/main/webapp/WEB-INF/web.xml
+++ b/test/issue6001/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+    version="6.0"
+>
+    <context-param>
+        <param-name>jakarta.faces.PROJECT_STAGE</param-name>
+        <param-value>Development</param-value>
+    </context-param>
+
+    <servlet>
+        <servlet-name>facesServlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>facesServlet</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+    </servlet-mapping>
+
+    <session-config>
+        <tracking-mode>COOKIE</tracking-mode>
+    </session-config>
+</web-app>

--- a/test/issue6001/src/main/webapp/composite.xhtml
+++ b/test/issue6001/src/main/webapp/composite.xhtml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:c="jakarta.tags.core">
+    <h:head><title>composite</title></h:head>
+    <h:body>
+        <h:form id="form">
+            <h:commandButton id="toggle" value="toggle" action="#{issue6001Bean.toggle}" />
+
+            <c:forEach var="i" begin="0" end="1">
+                <h:panelGroup id="slot#{i}">
+                    <c:if test="#{issue6001Bean.types[i] eq 'table'}">
+                        <ui:include src="/WEB-INF/compositefragment.xhtml">
+                            <ui:param name="key" value="slot#{i}" />
+                        </ui:include>
+                    </c:if>
+                </h:panelGroup>
+            </c:forEach>
+        </h:form>
+    </h:body>
+</html>

--- a/test/issue6001/src/main/webapp/index.xhtml
+++ b/test/issue6001/src/main/webapp/index.xhtml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:c="jakarta.tags.core">
+    <h:head><title>index</title></h:head>
+    <h:body>
+        <h:form id="form">
+            <h:commandButton id="toggle" value="toggle" action="#{issue6001Bean.toggle}" />
+
+            <c:forEach var="i" begin="0" end="1">
+                <h:panelGroup id="slot#{i}">
+                    <c:if test="#{issue6001Bean.types[i] eq 'table'}">
+                        <ui:include src="/WEB-INF/fragment.xhtml">
+                            <ui:param name="key" value="slot#{i}" />
+                        </ui:include>
+                    </c:if>
+                </h:panelGroup>
+            </c:forEach>
+        </h:form>
+    </h:body>
+</html>

--- a/test/issue6001/src/main/webapp/resources/components/child.xhtml
+++ b/test/issue6001/src/main/webapp/resources/components/child.xhtml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<ui:component
+    xmlns:h="jakarta.faces.html"
+    xmlns:ui="jakarta.faces.facelets"
+    xmlns:cc="jakarta.faces.composite"
+>
+    <cc:interface>
+        <cc:attribute name="value" required="true" />
+    </cc:interface>
+    <cc:implementation>
+        <h:outputText id="text" value="#{cc.attrs.value}" />
+    </cc:implementation>
+</ui:component>

--- a/test/issue6001/src/test/java/org/eclipse/mojarra/test/issue6001/Issue6001IT.java
+++ b/test/issue6001/src/test/java/org/eclipse/mojarra/test/issue6001/Issue6001IT.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.eclipse.mojarra.test.issue6001;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.mojarra.test.base.BaseIT;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * A tag generates its mark id from the number of times it has been applied so far in the current build, so a fragment
+ * applied more often than it was during the build before it shifts the mark id of every tag it holds and none of them
+ * finds back the component it built. Where a {@code binding} then hands such a tag the component of that earlier
+ * build, the component arrives with the children of that build attached and must have them cleaned up like a
+ * component found back under its parent, or its tags build a second set beside the first.
+ */
+class Issue6001IT extends BaseIT {
+
+    @FindBy(id = "form:toggle")
+    private WebElement toggle;
+
+    /**
+     * Toggling slot 0 from text to table applies the fragment twice where the build before it applied it once, so the
+     * tags of slot 1 all shift and the bound component of slot 1 arrives through its binding. Each slot must hold
+     * exactly one child.
+     */
+    @Test
+    void testFragmentAppliedMoreOftenThanBefore() {
+        open("index.xhtml");
+        assertEquals(0, getComponentCount("form:child_slot0"));
+        assertEquals(1, getComponentCount("form:child_slot1"));
+
+        guardHttp(toggle::click);
+        assertEquals(1, getComponentCount("form:child_slot0"), getPageSource());
+        assertEquals(1, getComponentCount("form:child_slot1"), getPageSource());
+    }
+
+    /**
+     * Toggling back applies the fragment once where the build before it applied it twice, which every tag still
+     * matches, and toggling once more applies it twice again with the binding of slot 1 filled by a build which
+     * itself reused it.
+     */
+    @Test
+    void testFragmentAppliedRepeatedly() {
+        open("index.xhtml");
+        guardHttp(toggle::click);
+        guardHttp(toggle::click);
+        assertEquals(0, getComponentCount("form:child_slot0"), getPageSource());
+        assertEquals(1, getComponentCount("form:child_slot1"), getPageSource());
+
+        guardHttp(toggle::click);
+        assertEquals(1, getComponentCount("form:child_slot0"), getPageSource());
+        assertEquals(1, getComponentCount("form:child_slot1"), getPageSource());
+    }
+
+    /**
+     * A composite component reached through a binding arrives holding the implementation its earlier build applied,
+     * which lives in a facet of its own, and must be cleaned up as the children of any other component are.
+     */
+    @Test
+    void testCompositeComponentFragmentAppliedMoreOftenThanBefore() {
+        open("composite.xhtml");
+        assertEquals(0, getComponentCount("form:child_slot0:text"));
+        assertEquals(1, getComponentCount("form:child_slot1:text"));
+
+        guardHttp(toggle::click);
+        assertEquals(1, getComponentCount("form:child_slot0:text"), getPageSource());
+        assertEquals(1, getComponentCount("form:child_slot1:text"), getPageSource());
+    }
+
+    private int getComponentCount(String clientId) {
+        return browser.findElements(By.id(clientId)).size();
+    }
+}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -64,6 +64,7 @@
         <module>issue5918</module>
         <module>issue5920</module>
         <module>issue5970</module>
+        <module>issue6001</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Closes #6001

A tag generates its mark id from the number of times it has been applied so far in the current build. A fragment applied more often than the build before it applied it therefore shifts the mark id of every tag it holds, and none of them finds back the component it built. Facelets normally heals that: the tag which does find its component back marks that component's children for deletion, the tags which match them clear the mark, and what is left over is pruned.

A component supplied by a `binding` escapes that bracket. It is handed to the tag by `Application.createComponent`, holding the children of the build which created it, and is parented under a component of the current build, while the tags below it build their own children beside the old ones. The result is two components with one id under one parent: an `IllegalStateException` naming the duplicate id under `ProjectStage.Development`, and a silently corrupt tree under `Production`, where the surviving stale component posts back under a client id the live tree no longer holds.

A component which already carries a mark id when `createComponent` returns it predates this build, because a component created for the tag is stamped only afterwards, so only a `binding` can produce that state. Its children are now marked for deletion before the nested handlers run and pruned after, exactly as for a component the tag finds back under its parent. The component itself still gets its attributes, its new mark id and a unique id from this build, as any created component does.

Test module `issue6001` holds two slots, each its own container, and a fragment which one of them only starts holding on a postback: once with a plain panel group behind the binding, once with a composite component, whose implementation the same cleanup reaches through its facet. Both fail on 4.0 without this change and pass with it.

The defect is not a regression: the reproducer fails identically on 2.2.14, 2.2.20, 2.3.21, 4.0.0 and 4.1.15, and #4495 reports it against 2.1.28. MyFaces 4.0.3 renders the same view correctly. #4244 is the same family — a mark id shift whose stale children escaped the bracket, there through a composite component's facet — and was fixed in 2.2.x by widening what the bracket reaches, which is what this change does for `binding`.

🤖 Generated with Claude Opus 5
