### PR TITLE
Keep the order of imported constant fields (#4574)

### DIFF
--- a/impl/src/main/java/com/sun/faces/application/view/ViewMetadataImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/view/ViewMetadataImpl.java
@@ -196,7 +196,7 @@ public class ViewMetadataImpl extends ViewMetadata {
                         constants.putIfAbsent(field.getName(), field.get(null));
                     } catch (Exception e) {
                         throw new IllegalArgumentException(
-                                String.format("UIImportConstants cannot access constant field '%s' of type '%s'.", type, field.getName()), e);
+                                String.format("UIImportConstants cannot access constant field '%s' of type '%s'.", field.getName(), type), e);
                     }
                 }
             }

--- a/impl/src/main/java/com/sun/faces/application/view/ViewMetadataImpl.java
+++ b/impl/src/main/java/com/sun/faces/application/view/ViewMetadataImpl.java
@@ -29,7 +29,10 @@ import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.sun.faces.RIConstants;
 import com.sun.faces.application.ApplicationAssociate;
@@ -173,28 +176,67 @@ public class ViewMetadataImpl extends ViewMetadata {
     }
 
     /**
-     * Collect constants of the given type. That are, all public static final fields of the given type.
+     * Collect constants of the given type. That are, all public static final fields of the given type and of all its
+     * super classes and interfaces. They are collected in declaration order, starting with those of the given type
+     * itself. When the same constant field name is declared more than once in the hierarchy, then the one declared by
+     * the most specific type wins.
      *
      * @param type The fully qualified name of the type to collect constants for.
-     * @return Constants of the given type.
+     * @return Constants of the given type, in declaration order.
      */
-    private static Map<String, Object> collectConstants(String type) {
+    static Map<String, Object> collectConstants(String type) {
         Map<String, Object> constants = new LinkedHashMap<>();
 
-        for (Field field : toClass(type).getFields()) {
-            int modifiers = field.getModifiers();
+        for (Class<?> declaredType : getDeclaredTypes(toClass(type))) {
+            for (Field field : declaredType.getDeclaredFields()) {
+                int modifiers = field.getModifiers();
 
-            if (isPublic(modifiers) && isStatic(modifiers) && isFinal(modifiers)) {
-                try {
-                    constants.put(field.getName(), field.get(null));
-                } catch (Exception e) {
-                    throw new IllegalArgumentException(
-                            String.format("UIImportConstants cannot access constant field '%s' of type '%s'.", type, field.getName()), e);
+                if (isPublic(modifiers) && isStatic(modifiers) && isFinal(modifiers)) {
+                    try {
+                        constants.putIfAbsent(field.getName(), field.get(null));
+                    } catch (Exception e) {
+                        throw new IllegalArgumentException(
+                                String.format("UIImportConstants cannot access constant field '%s' of type '%s'.", type, field.getName()), e);
+                    }
                 }
             }
         }
 
         return unmodifiableMap(new ConstantsMap(constants, type));
+    }
+
+    /**
+     * Collect the given type and all its super classes and interfaces, except {@link Object}, in the order in which
+     * their constant fields must be collected. That is, the given type first, then its super classes from the most
+     * specific one on, and then their interfaces.
+     *
+     * @param type The type to collect the declared types for.
+     * @return The given type and all its super classes and interfaces, except {@link Object}.
+     */
+    private static Set<Class<?>> getDeclaredTypes(Class<?> type) {
+        Set<Class<?>> declaredTypes = new LinkedHashSet<>();
+        declaredTypes.add(type);
+        fillAllSuperClasses(type, declaredTypes);
+
+        for (Class<?> declaredType : List.copyOf(declaredTypes)) {
+            fillAllInterfaces(declaredType, declaredTypes);
+        }
+
+        return declaredTypes;
+    }
+
+    private static void fillAllSuperClasses(Class<?> type, Set<Class<?>> declaredTypes) {
+        for (Class<?> superClass = type.getSuperclass(); superClass != null && superClass != Object.class; superClass = superClass.getSuperclass()) {
+            declaredTypes.add(superClass);
+        }
+    }
+
+    private static void fillAllInterfaces(Class<?> type, Set<Class<?>> declaredTypes) {
+        for (Class<?> interfaceType : type.getInterfaces()) {
+            if (declaredTypes.add(interfaceType)) {
+                fillAllInterfaces(interfaceType, declaredTypes);
+            }
+        }
     }
 
     /**
@@ -231,7 +273,7 @@ public class ViewMetadataImpl extends ViewMetadata {
      * @author Bauke Scholtz
      * @since 2.3
      */
-    private static class ConstantsMap extends HashMap<String, Object> {
+    private static class ConstantsMap extends LinkedHashMap<String, Object> {
 
         private static final long serialVersionUID = 7036447585721834948L;
         private String type;

--- a/impl/src/test/java/com/sun/faces/application/view/ViewMetadataImplTest.java
+++ b/impl/src/test/java/com/sun/faces/application/view/ViewMetadataImplTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.application.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+public class ViewMetadataImplTest {
+
+    public interface Labeled {
+        String LABEL = "labeled";
+        String SHARED = "labeled";
+    }
+
+    public enum Weekday {
+        MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY;
+    }
+
+    public enum LabeledWeekday implements Labeled {
+        MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY;
+    }
+
+    public static class Parent {
+        public static final String SHARED = "parent";
+        public static final String PARENT_ONLY = "parent";
+    }
+
+    public static class Child extends Parent implements Labeled {
+        public static final String SHARED = "child";
+        public static final String CHILD_ONLY = "child";
+    }
+
+    /**
+     * Enum constants are exposed in the order in which they are declared, so that <code>#{Weekday.values()}</code>
+     * feeds <code>f:selectItems</code> the same order as <code>Weekday.values()</code> does.
+     */
+    @Test
+    public void collectConstantsKeepsDeclarationOrderOfEnumConstants() {
+        Map<String, Object> constants = ViewMetadataImpl.collectConstants(Weekday.class.getName());
+
+        assertEquals(List.of("MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY"), List.copyOf(constants.keySet()));
+    }
+
+    /**
+     * The constants of the type itself come before the ones it inherits, so that the constants an enum inherits from
+     * an interface trail its own members instead of being mixed in between them.
+     */
+    @Test
+    public void collectConstantsKeepsDeclarationOrderOfEnumConstantsBeforeInheritedOnes() {
+        Map<String, Object> constants = ViewMetadataImpl.collectConstants(LabeledWeekday.class.getName());
+
+        assertEquals(List.of("MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY", "LABEL", "SHARED"),
+                List.copyOf(constants.keySet()));
+    }
+
+    /**
+     * Constants inherited from super classes and from interfaces are collected as well, the super classes first.
+     */
+    @Test
+    public void collectConstantsIncludesInheritedClassAndInterfaceConstants() {
+        Map<String, Object> constants = ViewMetadataImpl.collectConstants(Child.class.getName());
+
+        assertEquals(List.of("SHARED", "CHILD_ONLY", "PARENT_ONLY", "LABEL"), List.copyOf(constants.keySet()));
+    }
+
+    /**
+     * When a constant field name is declared more than once in the hierarchy, then the declaration of the most
+     * specific type is the one exposed.
+     */
+    @Test
+    public void collectConstantsPrefersMostSpecificDeclarationOfSharedConstant() {
+        assertEquals("child", ViewMetadataImpl.collectConstants(Child.class.getName()).get("SHARED"));
+        assertEquals("parent", ViewMetadataImpl.collectConstants(Parent.class.getName()).get("SHARED"));
+        assertEquals("labeled", ViewMetadataImpl.collectConstants(Labeled.class.getName()).get("SHARED"));
+    }
+
+    /**
+     * A constant which does not exist at all is a typo in the view, which must not silently evaluate to empty.
+     */
+    @Test
+    public void collectConstantsThrowsIllegalArgumentExceptionOnUnknownConstant() {
+        Map<String, Object> constants = ViewMetadataImpl.collectConstants(Weekday.class.getName());
+
+        assertThrows(IllegalArgumentException.class, () -> constants.get("CANEDAY"));
+    }
+
+}


### PR DESCRIPTION
Fixes #4574.

The constants of a type reach the view as a map. The order in which that map iterates is the order in which `f:selectItems` renders them. `Class.getFields()` returns fields in no defined order, and the map they were collected into was copied into a hash ordered one on the way out, so the members of an enum arrived in whichever order their names happened to hash to.

`ViewMetadataImpl` now walks the hierarchy itself: the type, then its super classes up to but not including `Object`, then their interfaces. Each contributes the constant fields it declares, and the map keeps the order in which they arrive. A type's own constants come first, in declaration order, and the ones it inherits trail them. This is the same approach as `o:importConstants` in OmniFaces.

The walk also fixes a second defect. A constant field name declared more than once in the hierarchy now resolves to the declaration of the most specific type. Collecting the fields of the whole hierarchy in one go let the inherited declaration overwrite the one hiding it, so `#{Child.NAME}` yielded the value declared by its super class.

A separate commit swaps two arguments in the error message for an inaccessible constant field, which named the type where the field belongs and the other way round.

Note that the spec says nothing about either order or hiding, and the TCK asserts membership only (`Spec1424IT` checks the size and the entries of the map, never the sequence), so this is a quality of implementation change, not a compliance fix.

`ViewMetadataImplTest` covers the order of an enum, of an enum inheriting constants from an interface, and of a class inheriting from both a super class and an interface, plus the constant a subclass hides. Four of its five tests fail on the code before this change.

This supersedes #6004 by @bvfalcon, which correctly identified `ConstantsMap extends HashMap` as the cause but targeted main instead of 4.0, where the defect also lives.

🤖 Generated with Claude Opus 5
