### PR TITLE
Give a fabricated Facelet an id mapper of its own (#6006)

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFacelet.java
+++ b/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFacelet.java
@@ -84,20 +84,41 @@ final class DefaultFacelet extends Facelet implements XMLFrontMatterSaver {
 
     private final URL src;
 
-    private IdMapper mapper;
+    private final IdMapper mapper;
+
+    /** Whether {@link #mapper} belongs to this Facelet alone, rather than to every Facelet sharing its alias. */
+    private final boolean ownIdMapper;
 
     private Doctype savedDoctype;
 
     private String savedXMLDecl;
 
     public DefaultFacelet(DefaultFaceletFactory factory, ExpressionFactory el, URL src, String alias, FaceletHandler root) {
+        this(factory, el, src, alias, root, null);
+    }
+
+    /**
+     * @param ownIdMapper the {@link IdMapper} this Facelet installs for its own build, or null to alias through the
+     * application scoped mapper for this alias, and through any mapper an ongoing build already installed. Pass one
+     * only for a Facelet that is not cached, whose alias would otherwise be a key the application scoped cache never
+     * sees again.
+     */
+    public DefaultFacelet(DefaultFaceletFactory factory, ExpressionFactory el, URL src, String alias, FaceletHandler root, IdMapper ownIdMapper) {
 
         this.factory = factory;
         elFactory = el;
         this.src = src;
         this.root = root;
         this.alias = alias;
-        this.mapper = factory.idMappers != null ? factory.idMappers.get(alias) : null;
+
+        if (ownIdMapper != null) {
+            mapper = ownIdMapper;
+            this.ownIdMapper = true;
+        } else {
+            mapper = factory.idMappers != null ? factory.idMappers.get(alias) : null;
+            this.ownIdMapper = false;
+        }
+
         createTime = System.currentTimeMillis();
         refreshPeriodInMillis = this.factory.getRefreshPeriodInMillis();
 
@@ -129,9 +150,9 @@ final class DefaultFacelet extends Facelet implements XMLFrontMatterSaver {
     @Override
     public void apply(FacesContext facesContext, UIComponent parent) throws IOException {
 
-        IdMapper idMapper = IdMapper.getMapper(facesContext);
+        IdMapper outerIdMapper = IdMapper.getMapper(facesContext);
         boolean mapperSet = false;
-        if (idMapper == null && this.mapper != null) {
+        if (mapper != null && (ownIdMapper || outerIdMapper == null)) {
             IdMapper.setMapper(facesContext, mapper);
             mapperSet = true;
         }
@@ -144,7 +165,7 @@ final class DefaultFacelet extends Facelet implements XMLFrontMatterSaver {
         markApplied(parent);
 
         if (mapperSet) {
-            IdMapper.setMapper(facesContext, null);
+            IdMapper.setMapper(facesContext, outerIdMapper);
         }
 
     }

--- a/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFaceletFactory.java
+++ b/impl/src/main/java/com/sun/faces/facelets/impl/DefaultFaceletFactory.java
@@ -41,9 +41,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 
 import jakarta.el.ELException;
 import jakarta.faces.FacesException;
@@ -96,6 +96,8 @@ public class DefaultFaceletFactory {
     private ConcurrentMap<String, FaceletCache<DefaultFacelet>> cachePerContract;
 
     Cache<String, IdMapper> idMappers;
+
+    private final AtomicLong fabricatedFaceletCount = new AtomicLong();
 
     // ------------------------------------------------------------ Constructors
 
@@ -363,7 +365,7 @@ public class DefaultFaceletFactory {
             }
 
             URL fabricatedFaceletPage = tempFile.toURI().toURL();
-            Facelet fabricatedFacelet = createFacelet(fabricatedFaceletPage);
+            Facelet fabricatedFacelet = createFabricatedFacelet(fabricatedFaceletPage);
             UIComponent tmp = app.createComponent("jakarta.faces.NamingContainer");
             tmp.setId(context.getViewRoot().createUniqueId());
             fabricatedFacelet.apply(context, tmp);
@@ -479,27 +481,47 @@ public class DefaultFaceletFactory {
      * @throws ELException
      */
     private DefaultFacelet createFacelet(URL url) throws IOException {
-        String escapedBaseURL = Pattern.quote(this.baseUrl.getFile());
-        String alias = '/' + url.getFile().replaceFirst(escapedBaseURL, "");
-        return createFacelet(url, alias);
+        return createFacelet(url, null);
     }
 
-    private DefaultFacelet createFacelet(URL url, String alias) throws IOException {
+    /**
+     * Creates the Facelet for the one-shot page {@link #_createComponent} fabricates. Every such page lives in its own
+     * temporary file, so its alias is a key the application scoped {@link #idMappers} cache would never see again: it
+     * gets its own mapper instead.
+     */
+    private DefaultFacelet createFabricatedFacelet(URL url) throws IOException {
+        return createFacelet(url, createFabricatedIdMapper());
+    }
+
+    /**
+     * Returns the {@link IdMapper} a fabricated Facelet installs for its own build, numbered so that its ids stay
+     * apart from those of every other mapper, or null when this application does not alias ids at all.
+     */
+    IdMapper createFabricatedIdMapper() {
+        return idMappers == null ? null : IdMapper.numbered(fabricatedFaceletCount.incrementAndGet());
+    }
+
+    private DefaultFacelet createFacelet(URL url, IdMapper ownIdMapper) throws IOException {
         if (log.isLoggable(Level.FINE)) {
             log.fine("Creating Facelet for: " + url);
         }
+        String alias = getAlias(url);
         try {
             FaceletHandler h = compiler.compile(url, alias);
-            return new DefaultFacelet(this, compiler.createExpressionFactory(), url, alias, h);
+            return new DefaultFacelet(this, compiler.createExpressionFactory(), url, alias, h, ownIdMapper);
         } catch (FileNotFoundException fnfe) {
             throw new FileNotFoundException("Facelet " + alias + " not found at: " + url.toExternalForm());
         }
     }
 
+    private String getAlias(URL url) {
+        return '/' + url.getFile().replaceFirst(quote(baseUrl.getFile()), "");
+    }
+
     private DefaultFacelet createMetadataFacelet(URL url) throws IOException {
         log.fine(() -> "Creating Metadata Facelet for: " + url);
 
-        String alias = '/' + url.getFile().replaceFirst(quote(baseUrl.getFile()), "");
+        String alias = getAlias(url);
         try {
             return new DefaultFacelet(this,
                 compiler.createExpressionFactory(),

--- a/impl/src/main/java/com/sun/faces/facelets/impl/IdMapper.java
+++ b/impl/src/main/java/com/sun/faces/facelets/impl/IdMapper.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import com.sun.faces.util.Cache;
 import com.sun.faces.util.Util;
 
+import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.context.FacesContext;
 
 /**
@@ -30,11 +31,31 @@ public class IdMapper {
 
     private static final String KEY = IdMapper.class.getName();
 
-    private Cache<String, String> idCache = new Cache<>(new IdGen());
+    private static final String DEFAULT_PREFIX = "t";
+
+    private final Cache<String, String> idCache;
 
     // ------------------------------------------------------------ Constructors
 
     IdMapper() {
+        this(DEFAULT_PREFIX);
+    }
+
+    private IdMapper(String prefix) {
+        idCache = new Cache<>(new IdGen(prefix));
+    }
+
+    /**
+     * Returns a mapper whose ids collide neither with those of the default mapper, nor with those of any other
+     * distinctly numbered one. The ids a mapper generates are seeds for
+     * {@link UIViewRoot#createUniqueId(FacesContext, String)}, which returns them verbatim behind its own prefix, so
+     * every mapper whose ids can land in one view needs a prefix of its own.
+     *
+     * @param number what distinguishes this mapper from every other numbered one
+     * @return a mapper generating ids of its own
+     */
+    static IdMapper numbered(long number) {
+        return new IdMapper(DEFAULT_PREFIX + number + '_');
     }
 
     // ---------------------------------------------------------- Public Methods
@@ -82,14 +103,21 @@ public class IdMapper {
 
     private static final class IdGen implements Cache.Factory<String, String> {
 
-        private AtomicInteger counter = new AtomicInteger(0);
+        private final String prefix;
+        private final AtomicInteger counter = new AtomicInteger(0);
+
+        // -------------------------------------------------------- Constructors
+
+        private IdGen(String prefix) {
+            this.prefix = prefix;
+        }
 
         // ------------------------------------------ Methods from Cache.Factory
 
         @Override
         public String newInstance(String arg) throws InterruptedException {
 
-            return 't' + Integer.toString(counter.incrementAndGet());
+            return prefix + counter.incrementAndGet();
 
         }
 

--- a/impl/src/test/java/com/sun/faces/facelets/impl/DefaultFaceletIdMapperTest.java
+++ b/impl/src/test/java/com/sun/faces/facelets/impl/DefaultFaceletIdMapperTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.facelets.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.el.ELContext;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.view.facelets.FaceletHandler;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.faces.util.Cache;
+
+/**
+ * A Facelet the {@link DefaultFaceletFactory} does not cache is applied under an alias that never recurs, so it may not
+ * take its {@link IdMapper} from the application scoped cache keyed by that alias, and it must install its own mapper
+ * for its build instead of aliasing through the one an ongoing build put in place. Every other Facelet keeps sharing
+ * the mapper of its alias, and the ids of a build stay unique across mappers.
+ */
+class DefaultFaceletIdMapperTest {
+
+    private final FacesContext faces = mock(FacesContext.class);
+    private final DefaultFaceletFactory factory = new DefaultFaceletFactory();
+    private final AtomicInteger mappersCreated = new AtomicInteger();
+
+    DefaultFaceletIdMapperTest() {
+        when(faces.getAttributes()).thenReturn(new HashMap<>());
+        when(faces.getELContext()).thenReturn(mock(ELContext.class));
+        factory.idMappers = new Cache<>(alias -> {
+            mappersCreated.incrementAndGet();
+            return new IdMapper();
+        });
+    }
+
+    @Test
+    void aFaceletWithItsOwnMapperLeavesTheApplicationScopedCacheUntouched() throws Exception {
+        for (int i = 0; i < 1000; i++) {
+            facelet("/mojarra" + i + ".tmp", IdMapper.numbered(i), null);
+        }
+
+        assertEquals(0, mappersCreated.get());
+    }
+
+    @Test
+    void aFaceletWithoutItsOwnMapperTakesOneFromTheApplicationScopedCache() throws Exception {
+        facelet("/page.xhtml", null, null);
+        facelet("/page.xhtml", null, null);
+        facelet("/other.xhtml", null, null);
+
+        assertEquals(2, mappersCreated.get(), "one mapper per alias, shared by every Facelet under it");
+    }
+
+    @Test
+    void aFaceletWithItsOwnMapperInstallsItForItsBuildAndRestoresTheOuterOne() throws Exception {
+        IdMapper outer = new IdMapper();
+        IdMapper own = IdMapper.numbered(1);
+        IdMapper.setMapper(faces, outer);
+        AtomicReference<IdMapper> duringBuild = new AtomicReference<>();
+
+        facelet("/mojarra1.tmp", own, duringBuild).apply(faces, parent());
+
+        assertSame(own, duringBuild.get());
+        assertSame(outer, IdMapper.getMapper(faces));
+    }
+
+    @Test
+    void aFaceletWithoutItsOwnMapperAliasesThroughTheOuterOne() throws Exception {
+        IdMapper outer = new IdMapper();
+        IdMapper.setMapper(faces, outer);
+        AtomicReference<IdMapper> duringBuild = new AtomicReference<>();
+
+        facelet("/page.xhtml", null, duringBuild).apply(faces, parent());
+
+        assertSame(outer, duringBuild.get());
+        assertSame(outer, IdMapper.getMapper(faces));
+    }
+
+    @Test
+    void aFaceletStartingABuildInstallsItsOwnMapperAndLeavesNoneBehind() throws Exception {
+        AtomicReference<IdMapper> duringBuild = new AtomicReference<>();
+
+        facelet("/page.xhtml", null, duringBuild).apply(faces, parent());
+
+        assertTrue(duringBuild.get() != null, "the outermost Facelet installs the mapper of its alias");
+        assertNull(IdMapper.getMapper(faces));
+    }
+
+    @Test
+    void everyFabricatedFaceletGetsAMapperWithAPrefixOfItsOwn() {
+        Set<String> ids = new HashSet<>();
+
+        for (int i = 0; i < 1000; i++) {
+            ids.add(factory.createFabricatedIdMapper().getAliasedId("tag1"));
+        }
+
+        assertEquals(1000, ids.size());
+        assertEquals(0, mappersCreated.get(), "a fabricated Facelet's mapper never enters the application scoped cache");
+    }
+
+    @Test
+    void anApplicationThatDoesNotAliasIdsGetsNoFabricatedMapperEither() {
+        factory.idMappers = null;
+
+        assertNull(factory.createFabricatedIdMapper());
+    }
+
+    @Test
+    void mappersWithDistinctPrefixesGenerateDistinctIds() {
+        Set<String> ids = new HashSet<>();
+
+        for (int i = 0; i < 100; i++) {
+            IdMapper mapper = i == 0 ? new IdMapper() : IdMapper.numbered(i);
+
+            for (int tag = 0; tag < 100; tag++) {
+                ids.add(mapper.getAliasedId("tag" + tag));
+            }
+        }
+
+        assertEquals(100 * 100, ids.size());
+    }
+
+    private DefaultFacelet facelet(String alias, IdMapper ownIdMapper, AtomicReference<IdMapper> duringBuild) throws IOException {
+        FaceletHandler root = (ctx, parent) -> {
+            if (duringBuild != null) {
+                duringBuild.set(IdMapper.getMapper(ctx.getFacesContext()));
+            }
+        };
+
+        return new DefaultFacelet(factory, null, new URL("file:" + alias), alias, root, ownIdMapper);
+    }
+
+    private static UIComponent parent() {
+        UIComponent parent = mock(UIComponent.class);
+        when(parent.getAttributes()).thenReturn(new HashMap<>());
+        return parent;
+    }
+}


### PR DESCRIPTION
Fixes #6006.

`ViewDeclarationLanguage.createComponent(FacesContext, String taglibURI, String tagName, Map)` writes the requested tag to a temporary file and builds a Facelet from that file. The Facelet is never cached, and its alias names a file that lives for the duration of one call, yet its `IdMapper` came from the application scoped `DefaultFaceletFactory.idMappers` cache keyed by alias. That cache never evicts, so every call added an entry no lookup would hit again. An application that builds its screens through this API — OmniFaces `Components.includeCompositeComponent()` is the common route — grew one alias, one mapper and one id cache per inclusion until the heap ran out.

There is a second growth vector. `DefaultFacelet.apply()` installed its own mapper only when none was in effect, so a fabricated Facelet applied inside an ongoing build pushed its never-recurring tag ids into the id cache of the *outer* Facelet, one the cache does hold for the lifetime of the application.

Both date back to 2.2.0 (JAVASERVERFACES_SPEC_PUBLIC-599, `769d85a092` in the old svn history) and are unchanged on every branch since.

## The fix

A fabricated Facelet now carries a mapper of its own, which never enters that cache and is collected along with the Facelet. It installs that mapper for its own build even when a build is already under way, and restores the outer one afterwards.

The ids a mapper generates are seeds for `UIViewRoot.createUniqueId(FacesContext, String)`, which returns them verbatim behind its own prefix and uniquifies them no further, so two mappers whose ids can reach the same view need distinct prefixes. Each fabricated mapper takes one from a counter the factory holds, via `IdMapper.numbered(long)`. An application that turned off id aliasing through `com.sun.faces.useFaceletsID` gets no mapper here either, as it gets none anywhere else.

## Verification

Constructing 10,000 fabricated Facelets left 10,000 permanent entries in `idMappers` before the fix and 0 after. `DefaultFaceletIdMapperTest` covers the cache a fabricated Facelet leaves untouched, the mapper it installs and restores around a build already in progress, the prefixes that keep a thousand of them apart, the `useFaceletsID` case, and the mapper every other Facelet keeps sharing with its alias. Both leak assertions were confirmed red against the old behavior before being committed.

Full impl unit suite green (1391 tests). The full TCK was run green against the equivalent change ported to 5.0.

## Note for reviewers

Generated ids for dynamically included subtrees change shape: `j_idt3_1` where it used to be `j_idt7`. Auto-generated ids are unstable by contract, but it is the one visible behavior change.

🤖 Generated with Claude Opus 5
