### PR TITLE
Confine what a tag file invocation inherits and leaves behind (#3263)

### DIFF
--- a/impl/src/main/java/com/sun/faces/facelets/el/UserTagParameterVariableMapper.java
+++ b/impl/src/main/java/com/sun/faces/facelets/el/UserTagParameterVariableMapper.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.facelets.el;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+
+import com.sun.faces.util.FacesLogger;
+
+import jakarta.el.ValueExpression;
+import jakarta.el.VariableMapper;
+
+/**
+ * The parameter namespace of a single tag file invocation.
+ * <p>
+ * A name the invocation received as an attribute resolves to the expression it was given. A name an enclosing
+ * invocation received, and this one did not, resolves to nothing rather than to the enclosing value. Every other name
+ * resolves against the scope the invocation was made from, so a tag file still sees the variables in scope where it is
+ * used.
+ */
+public final class UserTagParameterVariableMapper extends VariableMapper {
+
+    private static final Logger LOGGER = FacesLogger.FACELETS_EL.getLogger();
+
+    private static final Set<String> REPORTED = ConcurrentHashMap.newKeySet();
+
+    private final VariableMapper target;
+
+    private final Map<String, ValueExpression> parameters;
+
+    private final String invocation;
+
+    private UserTagParameterVariableMapper(VariableMapper target, Map<String, ValueExpression> parameters, String invocation) {
+        this.target = target;
+        this.parameters = parameters;
+        this.invocation = invocation;
+    }
+
+    /**
+     * Returns the variable mapper a tag file invocation resolves its names against: the given attributes, plus every
+     * parameter name already in scope bound to nothing, over the scope the invocation was made from. The enclosing
+     * scope is returned unchanged when the invocation supplies no attributes and inherits no parameter names, which is
+     * every tag file used outside another one.
+     *
+     * @param enclosing the variable mapper in effect where the tag file is invoked
+     * @param attributes the attributes supplied at the invocation
+     * @param invocation describes the invocation for the benefit of a diagnostic, or {@code null} to raise none
+     * @return the variable mapper the tag file resolves its names against
+     */
+    public static VariableMapper forInvocation(VariableMapper enclosing, Map<String, ValueExpression> attributes, String invocation) {
+        Set<String> inherited = parameterNamesInScope(enclosing);
+
+        if (attributes.isEmpty() && inherited.isEmpty()) {
+            return enclosing;
+        }
+
+        Map<String, ValueExpression> parameters = new HashMap<>(inherited.size() + attributes.size());
+
+        for (String name : inherited) {
+            parameters.put(name, null);
+        }
+
+        parameters.putAll(attributes);
+
+        return new UserTagParameterVariableMapper(enclosing, parameters, invocation);
+    }
+
+    private static Set<String> parameterNamesInScope(VariableMapper mapper) {
+        while (mapper instanceof VariableMapperWrapper) {
+            mapper = ((VariableMapperWrapper) mapper).getTarget();
+        }
+
+        return mapper instanceof UserTagParameterVariableMapper ? ((UserTagParameterVariableMapper) mapper).parameters.keySet() : Set.of();
+    }
+
+    @Override
+    public ValueExpression resolveVariable(String variable) {
+        if (parameters.containsKey(variable)) {
+            ValueExpression parameter = parameters.get(variable);
+
+            if (parameter == null && invocation != null) {
+                reportInherited(variable);
+            }
+
+            return parameter;
+        }
+
+        return target.resolveVariable(variable);
+    }
+
+    /**
+     * Reports a name which an enclosing invocation supplied and this one did not, but only where the enclosing scope
+     * holds it, which is where a page written against an implementation that let it through resolves it differently
+     * here. Reported once per invocation and name.
+     */
+    private void reportInherited(String variable) {
+        if (target.resolveVariable(variable) != null && REPORTED.add(invocation + ' ' + variable)) {
+            LOGGER.warning(() -> "The tag file behind " + invocation + " resolves #{" + variable
+                + "} to nothing: the name is an attribute of an enclosing tag file and is not inherited."
+                + " Supply it as an attribute of this tag where the tag file needs it.");
+        }
+    }
+
+    /**
+     * @throws UnsupportedOperationException always, because the parameters of a tag file invocation are fixed at the
+     * invocation, and whatever the tag file itself sets belongs to the mapper wrapping this one
+     */
+    @Override
+    public ValueExpression setVariable(String variable, ValueExpression expression) {
+        throw new UnsupportedOperationException("The parameters of a tag file invocation cannot be changed");
+    }
+}

--- a/impl/src/main/java/com/sun/faces/facelets/el/VariableMapperWrapper.java
+++ b/impl/src/main/java/com/sun/faces/facelets/el/VariableMapperWrapper.java
@@ -63,6 +63,13 @@ public class VariableMapperWrapper extends VariableMapper {
     }
 
     /**
+     * @return the variable mapper this one resolves against when it does not hold the name itself
+     */
+    VariableMapper getTarget() {
+        return target;
+    }
+
+    /**
      * Set the ValueExpression on the inner Map instance.
      *
      * @see jakarta.el.VariableMapper#setVariable(java.lang.String, jakarta.el.ValueExpression)

--- a/impl/src/main/java/com/sun/faces/facelets/tag/UserTagHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/UserTagHandler.java
@@ -25,11 +25,15 @@ import java.util.Map;
 
 import com.sun.faces.facelets.FaceletContextImplBase;
 import com.sun.faces.facelets.TemplateClient;
+import com.sun.faces.facelets.el.UserTagParameterVariableMapper;
 import com.sun.faces.facelets.el.VariableMapperWrapper;
 import com.sun.faces.facelets.tag.ui.DefineHandler;
 
+import jakarta.el.ValueExpression;
 import jakarta.el.VariableMapper;
+import jakarta.faces.application.ProjectStage;
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
 import jakarta.faces.view.facelets.FaceletContext;
 import jakarta.faces.view.facelets.TagAttribute;
 import jakarta.faces.view.facelets.TagConfig;
@@ -50,6 +54,8 @@ final class UserTagHandler extends TagHandlerImpl implements TemplateClient {
 
     protected final Map handlers;
 
+    private final String invocation;
+
     /**
      * @param config
      */
@@ -69,14 +75,31 @@ final class UserTagHandler extends TagHandlerImpl implements TemplateClient {
         } else {
             handlers = null;
         }
+
+        invocation = describeInvocation();
     }
 
     /**
-     * Iterate over all TagAttributes and set them on the FaceletContext's VariableMapper, then include the target Facelet.
-     * Finally, replace the old VariableMapper.
+     * Describes this invocation for a diagnostic, or returns {@code null} outside {@code Development}, where no
+     * diagnostic is raised and nothing should be spent describing one.
+     */
+    private String describeInvocation() {
+        FacesContext context = FacesContext.getCurrentInstance();
+
+        if (context == null || !context.isProjectStage(ProjectStage.Development)) {
+            return null;
+        }
+
+        return tag.getQName() + " at " + tag.getLocation();
+    }
+
+    /**
+     * Binds the attributes supplied at this invocation as the parameters of the target Facelet file, includes it, and
+     * restores the variable mapper afterwards, so that neither the parameters nor anything the file sets itself
+     * outlives the invocation.
      *
      * @see TagAttribute#getValueExpression(FaceletContext, Class)
-     * @see VariableMapper
+     * @see UserTagParameterVariableMapper
      * @see jakarta.faces.view.facelets.FaceletHandler#apply(jakarta.faces.view.facelets.FaceletContext,
      * jakarta.faces.component.UIComponent)
      */
@@ -85,14 +108,7 @@ final class UserTagHandler extends TagHandlerImpl implements TemplateClient {
         FaceletContextImplBase ctx = (FaceletContextImplBase) ctxObj;
         VariableMapper orig = ctx.getVariableMapper();
 
-        // setup a variable map
-        if (vars.length > 0) {
-            VariableMapper varMapper = new VariableMapperWrapper(orig);
-            for (int i = 0; i < vars.length; i++) {
-                varMapper.setVariable(vars[i].getLocalName(), vars[i].getValueExpression(ctx, Object.class));
-            }
-            ctx.setVariableMapper(varMapper);
-        }
+        ctx.setVariableMapper(new VariableMapperWrapper(UserTagParameterVariableMapper.forInvocation(orig, attributes(ctx), invocation)));
 
         // eval include
         try {
@@ -106,6 +122,20 @@ final class UserTagHandler extends TagHandlerImpl implements TemplateClient {
             ctx.popClient(this);
             ctx.setVariableMapper(orig);
         }
+    }
+
+    private Map<String, ValueExpression> attributes(FaceletContext ctx) {
+        if (vars.length == 0) {
+            return Map.of();
+        }
+
+        Map<String, ValueExpression> attributes = new HashMap<>(vars.length);
+
+        for (TagAttribute var : vars) {
+            attributes.put(var.getLocalName(), var.getValueExpression(ctx, Object.class));
+        }
+
+        return attributes;
     }
 
     @Override

--- a/impl/src/main/java/com/sun/faces/facelets/tag/faces/CompositeComponentTagHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/faces/CompositeComponentTagHandler.java
@@ -138,8 +138,16 @@ public class CompositeComponentTagHandler extends ComponentHandler implements Cr
         setAttributes(ctx, c);
 
         // Allow any nested elements that reside inside the markup element
-        // for this tag to get applied
-        super.applyNextHandler(ctx, c);
+        // for this tag to get applied, bounded so that what they set does not
+        // outlive the composite component nor reach its implementation
+        VariableMapper orig = ctx.getVariableMapper();
+        ctx.setVariableMapper(new VariableMapperWrapper(orig));
+
+        try {
+            super.applyNextHandler(ctx, c);
+        } finally {
+            ctx.setVariableMapper(orig);
+        }
 
         // Apply the facelet for this composite component
         applyCompositeComponent(ctx, c);

--- a/impl/src/test/java/com/sun/faces/facelets/el/UserTagParameterVariableMapperTest.java
+++ b/impl/src/test/java/com/sun/faces/facelets/el/UserTagParameterVariableMapperTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.faces.facelets.el;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.el.ValueExpression;
+import jakarta.el.VariableMapper;
+
+class UserTagParameterVariableMapperTest {
+
+    private final ValueExpression ambient = mock(ValueExpression.class);
+    private final ValueExpression outerAttribute = mock(ValueExpression.class);
+    private final ValueExpression innerAttribute = mock(ValueExpression.class);
+
+    private final VariableMapper page = new MapVariableMapper(singletonMap("ambient", ambient));
+
+    @Test
+    void anAttributeOfTheInvocationResolvesToTheExpressionItWasGiven() {
+        VariableMapper mapper = UserTagParameterVariableMapper.forInvocation(page, singletonMap("attribute", innerAttribute), null);
+
+        assertSame(innerAttribute, mapper.resolveVariable("attribute"));
+    }
+
+    @Test
+    void aNameInScopeAtTheInvocationResolvesThroughIt() {
+        VariableMapper mapper = UserTagParameterVariableMapper.forInvocation(page, singletonMap("attribute", innerAttribute), null);
+
+        assertSame(ambient, mapper.resolveVariable("ambient"));
+    }
+
+    @Test
+    void anAttributeOfAnEnclosingInvocationResolvesToNothing() {
+        VariableMapper outer = UserTagParameterVariableMapper.forInvocation(page, singletonMap("attribute", outerAttribute), null);
+        VariableMapper inner = UserTagParameterVariableMapper.forInvocation(new VariableMapperWrapper(outer), emptyMap(), null);
+
+        assertNull(inner.resolveVariable("attribute"));
+        assertSame(ambient, inner.resolveVariable("ambient"));
+    }
+
+    @Test
+    void theEnclosingScopeIsReturnedUnchangedWhenNoParameterIsInPlay() {
+        assertSame(page, UserTagParameterVariableMapper.forInvocation(page, emptyMap(), null));
+    }
+
+    @Test
+    void theParametersOfAnInvocationCannotBeChanged() {
+        VariableMapper mapper = UserTagParameterVariableMapper.forInvocation(page, singletonMap("attribute", innerAttribute), null);
+
+        assertThrows(UnsupportedOperationException.class, () -> mapper.setVariable("attribute", ambient));
+    }
+
+    private static class MapVariableMapper extends VariableMapper {
+
+        private final Map<String, ValueExpression> variables;
+
+        MapVariableMapper(Map<String, ValueExpression> variables) {
+            this.variables = new HashMap<>(variables);
+        }
+
+        @Override
+        public ValueExpression resolveVariable(String variable) {
+            return variables.get(variable);
+        }
+
+        @Override
+        public ValueExpression setVariable(String variable, ValueExpression expression) {
+            return variables.put(variable, expression);
+        }
+    }
+}

--- a/test/issue3263/pom.xml
+++ b/test/issue3263/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.mojarra.test</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.0.26-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>issue3263</artifactId>
+    <packaging>war</packaging>
+
+    <name>Mojarra ${project.version} - INTEGRATION TESTS - ${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.mojarra.test</groupId>
+            <artifactId>base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test/issue3263/src/main/webapp/WEB-INF/issue3263.taglib.xml
+++ b/test/issue3263/src/main/webapp/WEB-INF/issue3263.taglib.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<facelet-taglib
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facelettaglibrary_4_0.xsd"
+    version="4.0"
+>
+    <namespace>issue3263</namespace>
+
+    <tag>
+        <tag-name>parameterized</tag-name>
+        <source>tags/parameterized.xhtml</source>
+        <attribute>
+            <name>attribute</name>
+        </attribute>
+    </tag>
+    <tag>
+        <tag-name>setter</tag-name>
+        <source>tags/setter.xhtml</source>
+    </tag>
+    <tag>
+        <tag-name>inserting</tag-name>
+        <source>tags/inserting.xhtml</source>
+    </tag>
+    <tag>
+        <tag-name>scoped</tag-name>
+        <source>tags/scoped.xhtml</source>
+    </tag>
+</facelet-taglib>

--- a/test/issue3263/src/main/webapp/WEB-INF/tags/inserting.xhtml
+++ b/test/issue3263/src/main/webapp/WEB-INF/tags/inserting.xhtml
@@ -1,0 +1,1 @@
+<ui:composition xmlns:ui="jakarta.faces.facelets">IN(<ui:insert/>)</ui:composition>

--- a/test/issue3263/src/main/webapp/WEB-INF/tags/parameterized.xhtml
+++ b/test/issue3263/src/main/webapp/WEB-INF/tags/parameterized.xhtml
@@ -1,0 +1,1 @@
+<ui:composition xmlns:ui="jakarta.faces.facelets">(#{attribute}:<ui:insert/>)</ui:composition>

--- a/test/issue3263/src/main/webapp/WEB-INF/tags/scoped.xhtml
+++ b/test/issue3263/src/main/webapp/WEB-INF/tags/scoped.xhtml
@@ -1,0 +1,1 @@
+<ui:composition xmlns:ui="jakarta.faces.facelets">[#{applicationVariable}|#{sessionVariable}|#{viewVariable}|#{requestVariable}]</ui:composition>

--- a/test/issue3263/src/main/webapp/WEB-INF/tags/setter.xhtml
+++ b/test/issue3263/src/main/webapp/WEB-INF/tags/setter.xhtml
@@ -1,0 +1,1 @@
+<ui:composition xmlns:ui="jakarta.faces.facelets" xmlns:c="jakarta.tags.core"><c:set var="setInsideTagFile" value="X"/>SET</ui:composition>

--- a/test/issue3263/src/main/webapp/WEB-INF/web.xml
+++ b/test/issue3263/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+    version="6.0"
+>
+    <context-param>
+        <param-name>jakarta.faces.FACELETS_LIBRARIES</param-name>
+        <param-value>/WEB-INF/issue3263.taglib.xml</param-value>
+    </context-param>
+
+    <servlet>
+        <servlet-name>facesServlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>facesServlet</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+    </servlet-mapping>
+
+    <session-config>
+        <tracking-mode>COOKIE</tracking-mode>
+    </session-config>
+</web-app>

--- a/test/issue3263/src/main/webapp/issue3263.xhtml
+++ b/test/issue3263/src/main/webapp/issue3263.xhtml
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:c="jakarta.tags.core"
+      xmlns:h="jakarta.faces.html"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:t="issue3263"
+      xmlns:my="jakarta.faces.composite/issue3263">
+    <h:head>
+        <title>issue3263</title>
+    </h:head>
+    <h:body>
+        <h:panelGroup id="nestedInvocation"><t:parameterized attribute="A"><t:parameterized/></t:parameterized></h:panelGroup>
+        <h:panelGroup id="variableEscape"><t:setter/>[#{setInsideTagFile}]</h:panelGroup>
+        <h:panelGroup id="parameterEscape"><t:inserting><ui:param name="parameterInsideInvocation" value="P"/></t:inserting>[#{parameterInsideInvocation}]</h:panelGroup>
+
+        <h:panelGroup id="compositeParameterEscape"><my:probe attribute="A"><ui:param name="parameterInsideComposite" value="P"/>[body]</my:probe>[#{parameterInsideComposite}]</h:panelGroup>
+
+        <c:set var="applicationVariable" value="APP" scope="application"/>
+        <c:set var="sessionVariable" value="SES" scope="session"/>
+        <c:set var="viewVariable" value="VIEW" scope="view"/>
+        <c:set var="requestVariable" value="REQ" scope="request"/>
+        <h:panelGroup id="scopedVariables"><t:scoped/></h:panelGroup>
+    </h:body>
+</html>

--- a/test/issue3263/src/main/webapp/resources/issue3263/probe.xhtml
+++ b/test/issue3263/src/main/webapp/resources/issue3263/probe.xhtml
@@ -1,0 +1,6 @@
+<ui:composition xmlns:ui="jakarta.faces.facelets" xmlns:cc="jakarta.faces.composite">
+    <cc:interface>
+        <cc:attribute name="attribute"/>
+    </cc:interface>
+    <cc:implementation>(#{cc.attrs.attribute}:#{parameterInsideComposite}:<cc:insertChildren/>)</cc:implementation>
+</ui:composition>

--- a/test/issue3263/src/test/java/org/eclipse/mojarra/test/issue3263/Issue3263IT.java
+++ b/test/issue3263/src/test/java/org/eclipse/mojarra/test/issue3263/Issue3263IT.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package org.eclipse.mojarra.test.issue3263;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.mojarra.test.base.BaseIT;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * The variable scope of a tag file: what the attributes of an invocation reach, and what a tag file may leave behind.
+ * <p>
+ * These assertions hold on any implementation which isolates the parameter namespace of a tag file, so they are
+ * portable rather than specific to this implementation, though the one about a parameter written inside an invocation
+ * states a rule rather than established practice, the other implementation being inconsistent about it. What variables
+ * in scope at the invocation site reach inside a tag file is deliberately not asserted, because implementations
+ * disagree about it.
+ *
+ * @see <a href="https://github.com/eclipse-ee4j/mojarra/issues/3263">issue 3263</a>
+ */
+class Issue3263IT extends BaseIT {
+
+    @FindBy(id = "nestedInvocation")
+    private WebElement nestedInvocation;
+
+    @FindBy(id = "variableEscape")
+    private WebElement variableEscape;
+
+    @FindBy(id = "parameterEscape")
+    private WebElement parameterEscape;
+
+    @FindBy(id = "compositeParameterEscape")
+    private WebElement compositeParameterEscape;
+
+    @FindBy(id = "scopedVariables")
+    private WebElement scopedVariables;
+
+    @Test
+    void testNestedInvocationDoesNotInheritTheAttributesOfTheEnclosingOne() {
+        open("issue3263.xhtml");
+        assertEquals("(A:(:))", nestedInvocation.getText(), "The nested invocation supplies no attribute, so its own #{attribute} must resolve to nothing rather than to the value the enclosing invocation was given");
+    }
+
+    @Test
+    void testVariableSetInsideATagFileDoesNotOutliveTheInvocation() {
+        open("issue3263.xhtml");
+        assertEquals("SET[]", variableEscape.getText(), "A variable the tag file sets with c:set must not be visible to the page after the invocation, the same way it is not after a ui:include");
+    }
+
+    @Test
+    void testParameterWrittenInsideAnInvocationDoesNotOutliveIt() {
+        open("issue3263.xhtml");
+        assertEquals("IN()[]", parameterEscape.getText(), "A ui:param written as a child of the invocation must not be visible to the page after it, the same way it is not on a ui:include or a ui:decorate");
+    }
+
+    @Test
+    void testParameterWrittenInsideACompositeComponentReachesNeitherItsImplementationNorThePage() {
+        open("issue3263.xhtml");
+        assertEquals("(A::[body])[]", compositeParameterEscape.getText(), "A composite component takes its parameters from its declared attributes, so a ui:param written inside its usage must reach neither the implementation nor the page after it, while the children it is written among still see it");
+    }
+
+    @Test
+    void testScopedVariablesRemainVisibleInsideATagFile() {
+        open("issue3263.xhtml");
+        assertEquals("[APP|SES|VIEW|REQ]", scopedVariables.getText(), "A c:set carrying an explicit scope writes to that scope, which the scoped attribute EL resolver reaches from anywhere, so isolating the parameters of an invocation must not hide it");
+    }
+}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -40,6 +40,7 @@
         <module>uiIncludeRceJar</module>
         <module>uiIncludeRce</module>
         <module>issue5741</module>
+        <module>issue3263</module>
         <module>issue5059</module>
         <module>issue5460</module>
         <module>issue5464</module>


### PR DESCRIPTION
Fixes the three ways a tag file invocation leaked variables, and the same leak in a composite component usage. Measurements across both implementations, and against JSP tag files, are in #3263. The behavior is specified by jakartaee/faces#2247, merged as jakartaee/faces#2249.

| case | before | after |
| --- | --- | --- |
| outer invocation's `attr` read in a nested attribute-less invocation | `(A:(A:))` | `(A:(:))` |
| scopeless `c:set` inside a tag file, read after the invocation | `SET[w=W]` | `SET[w=]` |
| `<ui:param>` in the body of an invocation, read after it | `IN()[p=P]` | `IN()[p=]` |
| `<ui:param>` in a composite usage, read after it and in its implementation | reaches both | reaches neither |

Nothing else moves. A `c:set`, a `ui:param` on an enclosing `ui:include`, the `c:forEach` and `ui:repeat` row variables, `#{cc.attrs}` and the request, view, session and application maps all still reach inside a tag file exactly as before. Whether the first three should is a genuinely contested question which the specification deliberately leaves undefined, tracked in jakartaee/faces#2248, and this pull request is independent of it.

There is no context parameter to revert to legacy behavior. These are leaks rather than a scoping model, and an application depending on one depends on a construct behaving like nothing else in either implementation. What an upgrade gets instead is a `Development` warning naming the tag, the page and the position wherever a name now resolves differently, reported once per invocation and name:

```
The tag file behind t:parameterized at /issue3263.xhtml @12,94 resolves #{attribute}
to nothing: the name is an attribute of an enclosing tag file and is not inherited.
Supply it as an attribute of this tag where the tag file needs it.
```

Nothing is spent on it in any other project stage: the handler describes the invocation only under `Development`, and the mapper skips the check when it has no description.

`test/issue3263` asserts all four rows plus the controls, against markup which uses nothing outside the specification. Four of its five assertions pass on MyFaces unmodified; the two `ui:param` ones state the rule jakartaee/faces#2249 introduces, which MyFaces does not meet yet.

🤖 Generated with Claude Opus 5
