### PR TITLE
Enforce the required attributes a tag file declares

### DIFF
--- a/impl/src/main/java/com/sun/faces/config/processor/FaceletTaglibConfigProcessor.java
+++ b/impl/src/main/java/com/sun/faces/config/processor/FaceletTaglibConfigProcessor.java
@@ -23,6 +23,8 @@ import static java.util.logging.Level.WARNING;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -123,6 +125,27 @@ public class FaceletTaglibConfigProcessor extends AbstractConfigProcessor {
      * </p>
      */
     private static final String SOURCE = "source";
+
+    /**
+     * <p>
+     * /facelet-taglib/tag/attribute
+     * </p>
+     */
+    private static final String ATTRIBUTE = "attribute";
+
+    /**
+     * <p>
+     * /facelet-taglib/tag/attribute/name
+     * </p>
+     */
+    private static final String ATTRIBUTE_NAME = "name";
+
+    /**
+     * <p>
+     * /facelet-taglib/tag/attribute/required
+     * </p>
+     */
+    private static final String REQUIRED = "required";
 
     /**
      * <p>
@@ -293,6 +316,7 @@ public class FaceletTaglibConfigProcessor extends AbstractConfigProcessor {
                 NodeList behavior = null;
                 Node source = null;
                 Node handlerClass = null;
+                Set<String> requiredAttributes = new LinkedHashSet<>();
 
                 for (int j = 0, jlen = children.getLength(); j < jlen; j++) {
                     Node n = children.item(j);
@@ -318,6 +342,9 @@ public class FaceletTaglibConfigProcessor extends AbstractConfigProcessor {
                         case SOURCE:
                             source = n;
                             break;
+                        case ATTRIBUTE:
+                            collectRequiredAttribute(n, requiredAttributes);
+                            break;
                         case HANDLER_CLASS:
                             handlerClass = n;
                             break;
@@ -334,7 +361,7 @@ public class FaceletTaglibConfigProcessor extends AbstractConfigProcessor {
                 } else if (behavior != null) {
                     processBehavior(servletContext, facesContext, behavior, taglibrary, tagName);
                 } else if (source != null) {
-                    processSource(documentElement, source, taglibrary, tagName);
+                    processSource(documentElement, source, taglibrary, tagName, requiredAttributes);
                 } else if (handlerClass != null) {
                     processHandlerClass(servletContext, facesContext, handlerClass, taglibrary, tagName);
                 }
@@ -404,13 +431,38 @@ public class FaceletTaglibConfigProcessor extends AbstractConfigProcessor {
 
     }
 
-    private void processSource(Element documentElement, Node source, TagLibraryImpl taglibrary, String name) {
+    /**
+     * Collects the name of an attribute the tag declares as required, which a tag file then enforces where it is used.
+     */
+    private void collectRequiredAttribute(Node attribute, Set<String> requiredAttributes) {
+
+        String name = null;
+        boolean required = false;
+
+        NodeList children = attribute.getChildNodes();
+
+        for (int i = 0, len = children.getLength(); i < len; i++) {
+            Node child = children.item(i);
+
+            if (ATTRIBUTE_NAME.equals(child.getLocalName())) {
+                name = getNodeText(child);
+            } else if (REQUIRED.equals(child.getLocalName())) {
+                required = Boolean.parseBoolean(getNodeText(child));
+            }
+        }
+
+        if (required && name != null) {
+            requiredAttributes.add(name);
+        }
+    }
+
+    private void processSource(Element documentElement, Node source, TagLibraryImpl taglibrary, String name, Set<String> requiredAttributes) {
 
         String docURI = documentElement.getOwnerDocument().getDocumentURI();
         String s = getNodeText(source);
         try {
             URL url = new URL(new URL(docURI), s);
-            taglibrary.putUserTag(name, url);
+            taglibrary.putUserTag(name, url, requiredAttributes);
         } catch (MalformedURLException e) {
             throw new FacesException(e);
         }

--- a/impl/src/main/java/com/sun/faces/facelets/tag/AbstractTagLibrary.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/AbstractTagLibrary.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import com.sun.faces.facelets.tag.faces.CompositeComponentTagHandler;
 
@@ -247,13 +248,16 @@ public abstract class AbstractTagLibrary implements TagLibrary {
     private static class UserTagFactory implements TagHandlerFactory {
         protected final URL location;
 
-        public UserTagFactory(URL location) {
+        protected final Set<String> requiredAttributes;
+
+        public UserTagFactory(URL location, Set<String> requiredAttributes) {
             this.location = location;
+            this.requiredAttributes = requiredAttributes;
         }
 
         @Override
         public TagHandler createHandler(TagConfig cfg) throws FacesException, ELException {
-            return new UserTagHandler(cfg, location);
+            return new UserTagHandler(cfg, location, requiredAttributes);
         }
     }
 
@@ -602,8 +606,8 @@ public abstract class AbstractTagLibrary implements TagLibrary {
      * @param name name to use, "foo" would be {@code <my:foo />}
      * @param source source where the Facelet (Tag) source is
      */
-    protected final void addUserTag(String name, URL source) {
-        factories.put(name, new UserTagFactory(source));
+    protected final void addUserTag(String name, URL source, Set<String> requiredAttributes) {
+        factories.put(name, new UserTagFactory(source, requiredAttributes));
     }
 
     /**

--- a/impl/src/main/java/com/sun/faces/facelets/tag/TagLibraryImpl.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/TagLibraryImpl.java
@@ -18,6 +18,7 @@ package com.sun.faces.facelets.tag;
 
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.util.Set;
 
 import com.sun.faces.util.Util;
 
@@ -86,10 +87,10 @@ public class TagLibraryImpl extends AbstractTagLibrary {
         this.addComponent(name, componentType, rendererType, handlerClass);
     }
 
-    public void putUserTag(String name, URL source) {
+    public void putUserTag(String name, URL source, Set<String> requiredAttributes) {
         Util.notNull("name", name);
         Util.notNull("source", source);
-        addUserTag(name, source);
+        addUserTag(name, source, requiredAttributes);
     }
 
     public void putCompositeComponentTag(String name, String resourceId) {

--- a/impl/src/main/java/com/sun/faces/facelets/tag/UserTagHandler.java
+++ b/impl/src/main/java/com/sun/faces/facelets/tag/UserTagHandler.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 import com.sun.faces.facelets.FaceletContextImplBase;
 import com.sun.faces.facelets.TemplateClient;
@@ -59,7 +60,7 @@ final class UserTagHandler extends TagHandlerImpl implements TemplateClient {
     /**
      * @param config
      */
-    public UserTagHandler(TagConfig config, URL location) {
+    public UserTagHandler(TagConfig config, URL location, Set<String> requiredAttributes) {
         super(config);
         vars = tag.getAttributes().getAll();
         this.location = location;
@@ -76,21 +77,23 @@ final class UserTagHandler extends TagHandlerImpl implements TemplateClient {
             handlers = null;
         }
 
-        invocation = describeInvocation();
+        if (isDevelopment()) {
+            invocation = tag.getQName() + " at " + tag.getLocation();
+            requiredAttributes.forEach(this::getRequiredAttribute);
+        }
+        else {
+            invocation = null;
+        }
     }
 
     /**
-     * Describes this invocation for a diagnostic, or returns {@code null} outside {@code Development}, where no
-     * diagnostic is raised and nothing should be spent describing one.
+     * Whether this application asks to be told about what it declares but does not do, which is where the required
+     * attributes of this tag are enforced and where a name resolving differently than it once did is reported.
      */
-    private String describeInvocation() {
+    private static boolean isDevelopment() {
         FacesContext context = FacesContext.getCurrentInstance();
 
-        if (context == null || !context.isProjectStage(ProjectStage.Development)) {
-            return null;
-        }
-
-        return tag.getQName() + " at " + tag.getLocation();
+        return context != null && context.isProjectStage(ProjectStage.Development);
     }
 
     /**

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -37,6 +37,7 @@
         <module>example_jar_with_metadata_complete_true</module>
         <module>csp</module>
         <module>restoreBuildTimeDecisions</module>
+        <module>spec1904</module>
         <module>uiIncludeRceJar</module>
         <module>uiIncludeRce</module>
         <module>issue5741</module>

--- a/test/spec1904/pom.xml
+++ b/test/spec1904/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.mojarra.test</groupId>
+        <artifactId>pom</artifactId>
+        <version>4.0.26-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>spec1904</artifactId>
+    <packaging>war</packaging>
+
+    <name>Mojarra ${project.version} - INTEGRATION TESTS - ${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.mojarra.test</groupId>
+            <artifactId>base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test/spec1904/src/main/webapp/WEB-INF/spec1904.taglib.xml
+++ b/test/spec1904/src/main/webapp/WEB-INF/spec1904.taglib.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<facelet-taglib
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facelettaglibrary_4_0.xsd"
+    version="4.0"
+>
+    <namespace>spec1904</namespace>
+
+    <tag>
+        <tag-name>tagFile</tag-name>
+        <source>tags/tagFile.xhtml</source>
+        <attribute>
+            <name>requiredAttribute</name>
+            <required>true</required>
+        </attribute>
+        <attribute>
+            <name>optionalAttribute</name>
+        </attribute>
+    </tag>
+</facelet-taglib>

--- a/test/spec1904/src/main/webapp/WEB-INF/tags/tagFile.xhtml
+++ b/test/spec1904/src/main/webapp/WEB-INF/tags/tagFile.xhtml
@@ -1,0 +1,1 @@
+<ui:composition xmlns:ui="jakarta.faces.facelets">[#{requiredAttribute}|#{optionalAttribute}]</ui:composition>

--- a/test/spec1904/src/main/webapp/WEB-INF/web.xml
+++ b/test/spec1904/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<web-app
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+    version="6.0"
+>
+    <context-param>
+        <param-name>jakarta.faces.FACELETS_LIBRARIES</param-name>
+        <param-value>/WEB-INF/spec1904.taglib.xml</param-value>
+    </context-param>
+    <context-param>
+        <param-name>jakarta.faces.PROJECT_STAGE</param-name>
+        <param-value>Development</param-value>
+    </context-param>
+
+    <servlet>
+        <servlet-name>facesServlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>facesServlet</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+    </servlet-mapping>
+
+    <session-config>
+        <tracking-mode>COOKIE</tracking-mode>
+    </session-config>
+</web-app>

--- a/test/spec1904/src/main/webapp/compositeOmitted.xhtml
+++ b/test/spec1904/src/main/webapp/compositeOmitted.xhtml
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:cc="jakarta.faces.composite/spec1904">
+    <h:head>
+        <title>compositeOmitted</title>
+    </h:head>
+    <h:body>
+        <h:panelGroup id="compositeOmitted"><cc:compositeComponent optionalAttribute="O"/></h:panelGroup>
+    </h:body>
+</html>

--- a/test/spec1904/src/main/webapp/compositeSupplied.xhtml
+++ b/test/spec1904/src/main/webapp/compositeSupplied.xhtml
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:cc="jakarta.faces.composite/spec1904">
+    <h:head>
+        <title>compositeSupplied</title>
+    </h:head>
+    <h:body>
+        <h:panelGroup id="compositeSupplied"><cc:compositeComponent requiredAttribute="R" optionalAttribute="O"/></h:panelGroup>
+    </h:body>
+</html>

--- a/test/spec1904/src/main/webapp/omitted.xhtml
+++ b/test/spec1904/src/main/webapp/omitted.xhtml
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:t="spec1904">
+    <h:head>
+        <title>omitted</title>
+    </h:head>
+    <h:body>
+        <h:panelGroup id="omitted"><t:tagFile optionalAttribute="O"/></h:panelGroup>
+    </h:body>
+</html>

--- a/test/spec1904/src/main/webapp/resources/spec1904/compositeComponent.xhtml
+++ b/test/spec1904/src/main/webapp/resources/spec1904/compositeComponent.xhtml
@@ -1,0 +1,7 @@
+<ui:composition xmlns:ui="jakarta.faces.facelets" xmlns:cc="jakarta.faces.composite">
+    <cc:interface>
+        <cc:attribute name="requiredAttribute" required="true"/>
+        <cc:attribute name="optionalAttribute"/>
+    </cc:interface>
+    <cc:implementation>[#{cc.attrs.requiredAttribute}|#{cc.attrs.optionalAttribute}]</cc:implementation>
+</ui:composition>

--- a/test/spec1904/src/main/webapp/supplied.xhtml
+++ b/test/spec1904/src/main/webapp/supplied.xhtml
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:t="spec1904">
+    <h:head>
+        <title>supplied</title>
+    </h:head>
+    <h:body>
+        <h:panelGroup id="supplied"><t:tagFile requiredAttribute="R" optionalAttribute="O"/></h:panelGroup>
+    </h:body>
+</html>

--- a/test/spec1904/src/test/java/org/eclipse/mojarra/test/spec1904/Spec1904IT.java
+++ b/test/spec1904/src/test/java/org/eclipse/mojarra/test/spec1904/Spec1904IT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GPL-2.0 with Classpath-exception-2.0 which
+ * is available at https://openjdk.java.net/legal/gplv2+ce.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 or Apache-2.0
+ */
+package org.eclipse.mojarra.test.spec1904;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.mojarra.test.base.BaseIT;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * An attribute declared as required must be supplied where the tag is used, whether it is declared on a tag file in a
+ * tag library descriptor or on a composite component, which this application asks to be told about by running in the
+ * Development project stage.
+ *
+ * @see <a href="https://github.com/jakartaee/faces/issues/1904">faces issue 1904</a>
+ */
+class Spec1904IT extends BaseIT {
+
+    @FindBy(id = "supplied")
+    private WebElement supplied;
+
+    @FindBy(id = "compositeSupplied")
+    private WebElement compositeSupplied;
+
+    @Test
+    void testTagFileRendersWhenTheRequiredAttributeIsSupplied() {
+        open("supplied.xhtml");
+        assertEquals("[R|O]", supplied.getText(), "Both attributes reach the tag file under the names they were declared with");
+    }
+
+    @Test
+    void testUsingTheTagWithoutTheRequiredAttributeFails() {
+        String body = getResponseBody("omitted.xhtml");
+        assertTrue(!body.contains("[|O]") && body.contains("t:tagFile") && body.contains("requiredAttribute"), "Omitting an attribute the tag library declares as required must fail the page and identify both the tag and the attribute, instead of rendering it unset: " + body);
+    }
+
+    @Test
+    void testCompositeComponentRendersWhenTheRequiredAttributeIsSupplied() {
+        open("compositeSupplied.xhtml");
+        assertEquals("[R|O]", compositeSupplied.getText(), "Both attributes reach the composite component under the names they were declared with");
+    }
+
+    @Test
+    void testUsingTheCompositeComponentWithoutTheRequiredAttributeFails() {
+        String body = getResponseBody("compositeOmitted.xhtml");
+        assertTrue(!body.contains("[|O]") && body.contains("cc:compositeComponent") && body.contains("requiredAttribute"), "Omitting an attribute a composite component declares as required must fail the page and identify both the tag and the attribute, instead of rendering it unset: " + body);
+    }
+}


### PR DESCRIPTION
An attribute a tag library declares with `<required>true</required>` now has to be supplied where the tag is used, or building the view fails naming the tag and the attribute.

The declaration reached nothing before. `FaceletTaglibConfigProcessor` read every other child of a `<tag>` element and dropped `<attribute>` on the floor, so `required` described a duty nobody checked, and the documented workaround of a `<handler-class>` calling `getRequiredAttribute` cannot be applied to a tag file at all, `handler-class` and `source` being alternatives in the same `xsd:choice`.

| omitted where the tag is used | before | after |
| --- | --- | --- |
| `<required>true</required>` on a tag file | renders with the name unset | fails, naming the tag and the attribute |
| `cc:attribute required="true"` | fails | unchanged |

The declared names travel from the descriptor to the tag handler, which asks for each of them in its constructor via the existing `TagHandler.getRequiredAttribute`. That runs once per compiled Facelet rather than once per view build, and a Facelet which fails to compile is not cached, so the failure repeats until the page is fixed.

**Under `Development` only.** jakartaee/faces#2250 asks for every project stage, and a composite component attribute is the same kind of declaration, but both are behavior changes for applications which render today. This stays with the stage which already carries the composite check, and 5.0 can drop the guard once that lands.

`test/spec1904` asserts both declarations, so whichever way the specification goes there is something to flip: each renders when the attribute is supplied, and each fails identifying the tag and the attribute when it is omitted. The assertions avoid implementation wording, checking only what jakartaee/faces#1904 requires the exception to identify.

Measurements across both implementations, and against JSP tag files which reject the same omission at translation time, are in jakartaee/faces#1904.

🤖 Generated with Claude Opus 5
